### PR TITLE
Fix managed AppServer startup recovery

### DIFF
--- a/desktop/src/main/HubClient.ts
+++ b/desktop/src/main/HubClient.ts
@@ -68,12 +68,80 @@ export interface HubEvent {
   data?: unknown
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function stringValue(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function numberValue(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function previewValue(value: unknown, maxLength = 1200): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength)}…` : trimmed
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  if (value !== null && typeof value === 'object') {
+    try {
+      const json = JSON.stringify(value)
+      return json.length > maxLength ? `${json.slice(0, maxLength)}…` : json
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+function summarizeHubErrorDetails(details: unknown): string | null {
+  const direct = previewValue(details)
+  const record = asRecord(details)
+  if (!record) return direct
+
+  const parts: string[] = []
+  const append = (label: string, value: unknown): void => {
+    const preview = previewValue(value)
+    if (preview && !parts.includes(`${label}: ${preview}`)) {
+      parts.push(`${label}: ${preview}`)
+    }
+  }
+
+  append('error', record.error)
+  append('reason', record.reason)
+  append('lastError', record.lastError)
+  append('recentStderr', record.recentStderr)
+  append('workspacePath', stringValue(record, 'workspacePath'))
+  append('craftPath', stringValue(record, 'craftPath'))
+  append('lockPath', stringValue(record, 'lockPath'))
+  append('pid', numberValue(record, 'pid'))
+  append('expectedPid', numberValue(record, 'expectedPid'))
+
+  return parts.length > 0 ? `Details: ${parts.join('; ')}` : direct
+}
+
+function formatHubErrorMessage(message: string, details?: unknown): string {
+  const summary = summarizeHubErrorDetails(details)
+  return summary ? `${message}\n${summary}` : message
+}
+
 export class HubClientError extends Error {
   constructor(
     readonly code: string,
-    message: string
+    message: string,
+    readonly details?: unknown
   ) {
-    super(message)
+    super(formatHubErrorMessage(message, details))
     this.name = 'HubClientError'
   }
 }
@@ -243,16 +311,12 @@ export class HubClient {
   private async ensureHub(): Promise<HubLockInfo> {
     const live = await this.tryGetLiveHub()
     if (live) {
-      if (this.options.restartMismatchedHub) {
-        const expectedBinaryPath = this.resolveExpectedBinaryPath()
+      const expectedBinaryPath = this.resolveExpectedBinaryPath()
+      if (this.shouldRestartMismatchedHub(live, expectedBinaryPath)) {
         if (!expectedBinaryPath) {
           throw new HubClientError('binary-not-found', this.missingBinaryMessage())
         }
-        if (!this.hubMatchesExpectedBinary(live, expectedBinaryPath)) {
-          await this.shutdownMismatchedHub(live)
-        } else {
-          return live
-        }
+        await this.shutdownMismatchedHub(live)
       } else {
         return live
       }
@@ -309,8 +373,23 @@ export class HubClient {
     return typeof hub.binaryPath === 'string' && pathsEqual(hub.binaryPath, expectedBinaryPath)
   }
 
+  private shouldRestartMismatchedHub(hub: HubLockInfo, expectedBinaryPath: string | null): boolean {
+    if (this.options.restartMismatchedHub === false) return false
+    if (!expectedBinaryPath) return this.options.restartMismatchedHub === true
+    if (this.options.restartMismatchedHub === true) return !this.hubMatchesExpectedBinary(hub, expectedBinaryPath)
+    return typeof hub.binaryPath === 'string' && !this.hubMatchesExpectedBinary(hub, expectedBinaryPath)
+  }
+
   private async shutdownMismatchedHub(hub: HubLockInfo): Promise<void> {
-    await this.requestJson<{ ok: boolean }>(hub, '/v1/shutdown', { method: 'POST' })
+    try {
+      await this.requestJson<{ ok: boolean }>(hub, '/v1/shutdown', { method: 'POST' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new HubClientError(
+        'hubMismatchShutdownFailed',
+        `DotCraft Hub is running from a different binary and could not be stopped automatically. Exit DotCraft Hub from the system tray, then restart DotCraft. ${message}`
+      )
+    }
 
     const started = Date.now()
     while (Date.now() - started < SHUTDOWN_TIMEOUT_MS) {
@@ -322,7 +401,7 @@ export class HubClient {
 
     throw new HubClientError(
       'hubMismatchShutdownTimeout',
-      'DotCraft Hub is running from a different binary and did not stop after shutdown. Close DotCraft and tray, then retry Desktop dev.'
+      'DotCraft Hub is running from a different binary and did not stop after shutdown. Exit DotCraft Hub from the system tray, then restart DotCraft.'
     )
   }
 
@@ -381,11 +460,14 @@ export class HubClient {
 
   private async toError(response: Response): Promise<HubClientError> {
     try {
-      const body = await response.json() as { error?: { code?: string; message?: string } }
+      const body = await response.json() as {
+        error?: { code?: string; message?: string; details?: unknown }
+      }
       if (body.error?.code || body.error?.message) {
         return new HubClientError(
           body.error.code ?? 'hubRequestFailed',
-          body.error.message ?? `Hub request failed with HTTP ${response.status}.`
+          body.error.message ?? `Hub request failed with HTTP ${response.status}.`,
+          body.error.details
         )
       }
     } catch {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -965,7 +965,7 @@ function createHubClient(settings: AppSettings): HubClient {
     binaryPath: settings.appServerBinaryPath,
     preferDevBuild: import.meta.env.DEV,
     requireDevBuild: import.meta.env.DEV,
-    restartMismatchedHub: import.meta.env.DEV
+    ...(import.meta.env.DEV ? { restartMismatchedHub: true } : {})
   })
 }
 

--- a/desktop/src/main/tests/hubClient.test.ts
+++ b/desktop/src/main/tests/hubClient.test.ts
@@ -101,6 +101,35 @@ describe('HubClient AppServer management', () => {
     })
   })
 
+  it('includes Hub error details in thrown errors', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({
+          error: {
+            code: 'appServerStartFailed',
+            message: 'Managed AppServer failed during startup.',
+            details: {
+              workspacePath: 'E:/repo',
+              error: 'Access denied while binding WebSocket.',
+              recentStderr: 'System.Net.Sockets.SocketException: forbidden'
+            }
+          }
+        })
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(new HubClient().ensureAppServer('E:/repo')).rejects.toMatchObject({
+      code: 'appServerStartFailed',
+      details: expect.objectContaining({
+        error: 'Access denied while binding WebSocket.'
+      }),
+      message: expect.stringContaining('Access denied while binding WebSocket.')
+    })
+  })
+
   it('restarts a live Hub when dev mode expects a different binary', async () => {
     const expectedBinary = 'C:/repo/build/release/dotcraft.exe'
     let hubPid = 1234
@@ -161,6 +190,75 @@ describe('HubClient AppServer management', () => {
       binarySource: 'custom',
       binaryPath: expectedBinary,
       restartMismatchedHub: true
+    }).ensureAppServer('E:/repo')
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      expectedBinary,
+      ['hub'],
+      expect.objectContaining({ detached: true })
+    )
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/v1/shutdown'))).toBe(true)
+  })
+
+  it('restarts a live Hub by default when it reports a different binary', async () => {
+    const expectedBinary = 'C:/Users/test/AppData/Local/Programs/DotCraft/resources/bin/dotcraft.exe'
+    let hubPid = 1234
+    let hubBinary = 'C:/Users/test/AppData/Local/Programs/DotCraft-old/resources/bin/dotcraft.exe'
+    let shutdownRequested = false
+
+    fsMocks.readFileSync.mockImplementation(() => JSON.stringify({
+      pid: hubPid,
+      apiBaseUrl: 'http://127.0.0.1:8123',
+      token: 'hub-token',
+      startedAt: '',
+      version: '',
+      binaryPath: hubBinary
+    }))
+    vi.spyOn(process, 'kill').mockImplementation((pid) => {
+      if (pid === 1234 && shutdownRequested) {
+        const error = new Error('missing') as NodeJS.ErrnoException
+        error.code = 'ESRCH'
+        throw error
+      }
+      return true
+    })
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/v1/status')) {
+        return {
+          ok: true,
+          json: async () => ({ binaryPath: hubBinary })
+        } as Response
+      }
+      if (url.endsWith('/v1/shutdown')) {
+        shutdownRequested = true
+        hubPid = 5678
+        hubBinary = expectedBinary
+        return {
+          ok: true,
+          json: async () => ({ ok: true })
+        } as Response
+      }
+      if (url.endsWith('/v1/appservers/ensure')) {
+        return {
+          ok: true,
+          json: async () => ({
+            workspacePath: 'E:/repo',
+            canonicalWorkspacePath: 'E:/repo',
+            state: 'running',
+            endpoints: { appServerWebSocket: 'ws://127.0.0.1:9000/ws' },
+            serviceStatus: {},
+            startedByHub: true
+          })
+        } as Response
+      }
+      throw new Error(`unexpected fetch: ${url} ${String(init?.method)}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await new HubClient({
+      binarySource: 'custom',
+      binaryPath: expectedBinary
     }).ensureAppServer('E:/repo')
 
     expect(childProcessMocks.spawn).toHaveBeenCalledWith(

--- a/desktop/src/main/tests/trayManager.test.ts
+++ b/desktop/src/main/tests/trayManager.test.ts
@@ -523,10 +523,16 @@ describe('trayManager process launches', () => {
   })
 
   it('does not launch a macOS tray process when menu bar visibility is disabled', async () => {
-    const { ensureTrayProcess } = await import('../trayManager')
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    try {
+      const { ensureTrayProcess } = await import('../trayManager')
 
-    ensureTrayProcess({ showInMenuBar: false })
+      ensureTrayProcess({ showInMenuBar: false })
 
-    expect(childProcessMocks.spawn).not.toHaveBeenCalled()
+      expect(childProcessMocks.spawn).not.toHaveBeenCalled()
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform })
+    }
   })
 })

--- a/desktop/src/main/trayManager.ts
+++ b/desktop/src/main/trayManager.ts
@@ -256,7 +256,7 @@ function buildAppServerMenu(
         label: L('tray.restartAppServer'),
         enabled: Boolean(workspacePath),
         click: async () => {
-          await hubClient.restartAppServer(workspacePath, undefined, resolveDotCraftRuntimeTools())
+          await hubClient.restartAppServer(workspacePath, resolveDotCraftRuntimeTools())
           refresh()
         }
       },
@@ -447,7 +447,7 @@ export async function runTrayProcess(): Promise<void> {
     binaryPath: settings.appServerBinaryPath,
     preferDevBuild: import.meta.env.DEV,
     requireDevBuild: import.meta.env.DEV,
-    restartMismatchedHub: import.meta.env.DEV
+    ...(import.meta.env.DEV ? { restartMismatchedHub: true } : {})
   })
   let eventAbortController: AbortController | null = null
   let refreshTimer: ReturnType<typeof setInterval> | null = null

--- a/src/DotCraft.App/Hub/ManagedAppServerRegistry.cs
+++ b/src/DotCraft.App/Hub/ManagedAppServerRegistry.cs
@@ -32,6 +32,12 @@ public sealed class ManagedAppServerRegistry : IAsyncDisposable
     internal Func<AppServerLockInfo, CancellationToken, Task<string?>> ExistingAppServerProbeAsync { get; set; } =
         ProbeExistingAppServerAsync;
 
+    internal Func<string?, string, IReadOnlyDictionary<string, string?>, CancellationToken, Task<IManagedAppServerProcess>> StartAppServerProcessAsync { get; set; } =
+        StartManagedAppServerProcessAsync;
+
+    internal Func<string, string, CancellationToken, Task> ManagedWebSocketProbeAsync { get; set; } =
+        ProbeWebSocketAsync;
+
     public ManagedAppServerRegistry(
         HubEventBus events,
         string hubApiBaseUrl,
@@ -114,21 +120,22 @@ public sealed class ManagedAppServerRegistry : IAsyncDisposable
             Persist(entry);
             _events.Publish("appserver.starting", canonical, new { endpoints = plan.ResponseEndpoints });
 
+            IManagedAppServerProcess? startedProcess = null;
             try
             {
-                var process = await AppServerProcess.StartAsync(
-                    dotcraftBin: _dotcraftBin,
-                    workspacePath: canonical,
-                    environmentVariables: plan.Environment,
-                    createNoWindow: true,
-                    attachWindowsJob: true,
-                    ct: cancellationToken);
+                var process = await StartAppServerProcessAsync(
+                    _dotcraftBin,
+                    canonical,
+                    plan.Environment,
+                    cancellationToken);
+                startedProcess = process;
 
-                await ProbeWebSocketAsync(plan.WebSocketProbeUrl, plan.WebSocketToken, cancellationToken);
+                await ManagedWebSocketProbeAsync(plan.WebSocketProbeUrl, plan.WebSocketToken, cancellationToken);
                 VerifyManagedLock(craftPath, process.ProcessId, canonical);
 
                 process.OnCrashed += () => OnProcessCrashed(entry);
                 entry.Process = process;
+                startedProcess = null;
                 entry.State = HubAppServerStates.Running;
                 entry.Pid = process.ProcessId;
                 entry.ServerVersion = process.ServerVersion;
@@ -146,18 +153,31 @@ public sealed class ManagedAppServerRegistry : IAsyncDisposable
                 _events.Publish("appserver.running", canonical, new { pid = process.ProcessId, endpoints = plan.ResponseEndpoints });
                 return entry.ToResponse();
             }
-            catch (Exception ex) when (ex is not HubProtocolException)
+            catch (Exception ex)
             {
+                if (startedProcess is not null)
+                    await DisposeStartedProcessAfterFailureAsync(entry, startedProcess, craftPath);
+
                 entry.State = HubAppServerStates.Exited;
                 entry.LastError = ex.Message;
                 entry.LastExitedAt = DateTimeOffset.UtcNow;
                 Persist(entry);
-                _events.Publish("appserver.exited", canonical, new { error = ex.Message });
+                _events.Publish("appserver.exited", canonical, new
+                {
+                    error = ex.Message,
+                    pid = entry.Pid,
+                    exitCode = entry.ExitCode,
+                    stderr = entry.RecentStderr
+                });
+
+                if (ex is HubProtocolException)
+                    throw;
+
                 throw new HubProtocolException(
                     "appServerStartFailed",
                     "Managed AppServer failed during startup.",
                     StatusCodes.Status500InternalServerError,
-                    new { workspacePath = canonical, error = ex.Message });
+                    new { workspacePath = canonical, error = ex.Message, recentStderr = entry.RecentStderr });
             }
         }
         finally
@@ -647,6 +667,37 @@ public sealed class ManagedAppServerRegistry : IAsyncDisposable
                 Reason: reason));
     }
 
+    private static async Task<IManagedAppServerProcess> StartManagedAppServerProcessAsync(
+        string? dotcraftBin,
+        string workspacePath,
+        IReadOnlyDictionary<string, string?> environmentVariables,
+        CancellationToken cancellationToken)
+        => new AppServerProcessAdapter(await AppServerProcess.StartAsync(
+            dotcraftBin: dotcraftBin,
+            workspacePath: workspacePath,
+            environmentVariables: environmentVariables,
+            createNoWindow: true,
+            attachWindowsJob: true,
+            ct: cancellationToken));
+
+    private static async Task DisposeStartedProcessAfterFailureAsync(
+        ManagedEntry entry,
+        IManagedAppServerProcess process,
+        string craftPath)
+    {
+        try
+        {
+            await process.DisposeAsync();
+        }
+        finally
+        {
+            entry.RecentStderr = process.RecentStderr;
+            entry.ExitCode = process.ExitCode;
+            entry.Pid = process.ProcessId;
+            CleanupWorkspaceLock(craftPath);
+        }
+    }
+
     private static async Task StopManagedProcessesAsync(ManagedEntry entry, string craftPath)
     {
         if (entry.Process is { } process)
@@ -966,7 +1017,7 @@ public sealed class ManagedAppServerRegistry : IAsyncDisposable
 
         public string State { get; set; } = HubAppServerStates.Stopped;
 
-        public AppServerProcess? Process { get; set; }
+        public IManagedAppServerProcess? Process { get; set; }
 
         public bool AdoptedExternalLock { get; set; }
 
@@ -1036,4 +1087,40 @@ public sealed class ManagedAppServerRegistry : IAsyncDisposable
             LastError,
             RecentStderr);
     }
+}
+
+internal interface IManagedAppServerProcess : IAsyncDisposable
+{
+    bool IsRunning { get; }
+
+    int? ExitCode { get; }
+
+    string RecentStderr { get; }
+
+    int ProcessId { get; }
+
+    string? ServerVersion { get; }
+
+    event Action? OnCrashed;
+}
+
+internal sealed class AppServerProcessAdapter(AppServerProcess process) : IManagedAppServerProcess
+{
+    public bool IsRunning => process.IsRunning;
+
+    public int? ExitCode => process.ExitCode;
+
+    public string RecentStderr => process.RecentStderr;
+
+    public int ProcessId => process.ProcessId;
+
+    public string? ServerVersion => process.ServerVersion;
+
+    public event Action? OnCrashed
+    {
+        add => process.OnCrashed += value;
+        remove => process.OnCrashed -= value;
+    }
+
+    public ValueTask DisposeAsync() => process.DisposeAsync();
 }

--- a/tests/DotCraft.App.Tests/Hub/ManagedAppServerRegistryTests.cs
+++ b/tests/DotCraft.App.Tests/Hub/ManagedAppServerRegistryTests.cs
@@ -183,6 +183,43 @@ public sealed class ManagedAppServerRegistryTests : IDisposable
     }
 
     [Fact]
+    public async Task Ensure_DisposesStartedProcessWhenStartupProbeFails()
+    {
+        var registryPath = Path.Combine(_tempDir, "hub", "appservers.json");
+        var workspace = CreateWorkspace("probe-failure-workspace");
+        var process = new FakeManagedAppServerProcess(
+            processId: 12345,
+            exitCode: 42,
+            recentStderr: "probe stderr");
+
+        await using var registry = new ManagedAppServerRegistry(
+            new HubEventBus(),
+            "http://127.0.0.1:43000",
+            "hub-token",
+            registryPath: registryPath)
+        {
+            StartAppServerProcessAsync = (_, _, _, _) => Task.FromResult<IManagedAppServerProcess>(process),
+            ManagedWebSocketProbeAsync = (_, _, _) => Task.FromException(new InvalidOperationException("probe failed"))
+        };
+
+        var ex = await Assert.ThrowsAsync<HubProtocolException>(() => registry.EnsureAsync(new EnsureAppServerRequest
+        {
+            WorkspacePath = workspace,
+            StartIfMissing = true
+        }, CancellationToken.None));
+
+        Assert.Equal("appServerStartFailed", ex.Code);
+        Assert.True(process.Disposed);
+
+        var inspected = registry.GetByWorkspace(workspace);
+        Assert.Equal(HubAppServerStates.Exited, inspected.State);
+        Assert.Equal("probe failed", inspected.LastError);
+        Assert.Equal(12345, inspected.Pid);
+        Assert.Equal(42, inspected.ExitCode);
+        Assert.Equal("probe stderr", inspected.RecentStderr);
+    }
+
+    [Fact]
     public async Task Dispose_DoesNotMarkAdoptedExternalWorkspaceStopped()
     {
         var registryPath = Path.Combine(_tempDir, "hub", "appservers.json");
@@ -288,6 +325,34 @@ public sealed class ManagedAppServerRegistryTests : IDisposable
         ExitCode: null,
         LastError: null,
         RecentStderr: null);
+
+    private sealed class FakeManagedAppServerProcess(
+        int processId,
+        int? exitCode,
+        string recentStderr) : IManagedAppServerProcess
+    {
+        public bool IsRunning => !Disposed;
+
+        public int? ExitCode => exitCode;
+
+        public string RecentStderr => recentStderr;
+
+        public int ProcessId => processId;
+
+        public string? ServerVersion => "test-version";
+
+        public bool Disposed { get; private set; }
+
+        public event Action? OnCrashed;
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+
+        public void RaiseCrashed() => OnCrashed?.Invoke();
+    }
 
     public void Dispose()
     {


### PR DESCRIPTION
Refs #61.

Restart mismatched Hub binaries in production, surface Hub error details, clean up partially started managed AppServer processes on startup probe failures, and pass runtime tools through tray restarts.