### PR TITLE
Optimize desktop tray mode and trace store persistence

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -232,6 +232,11 @@ let initialUpdateCheckStarted = false
 const isTrayMode = process.argv.includes('--tray')
 const CHROME_SETTINGS_DEEP_LINK_PORT = Number.parseInt(process.env.DOTCRAFT_DESKTOP_DEEPLINK_PORT || '32178', 10)
 
+if (isTrayMode) {
+  app.disableHardwareAcceleration()
+  app.commandLine.appendSwitch('disable-gpu')
+}
+
 configureAppIdentity()
 
 let devProcessGuardsInstalled = false

--- a/src/DotCraft.Core/Protocol/ThreadStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadStore.cs
@@ -32,7 +32,6 @@ public sealed class ThreadStore
         _metadataStore = new ThreadMetadataStore(runtime);
         _rolloutStore = new ThreadRolloutStore(botPath);
         _attachmentStore = new ThreadAttachmentStore(runtime, botPath);
-        RebuildAttachmentReferences();
     }
 
     /// <summary>
@@ -422,18 +421,6 @@ public sealed class ThreadStore
         var json = JsonSerializer.SerializeToUtf8Bytes(thread, SessionJsonOptions.Default);
         return JsonSerializer.Deserialize<SessionThread>(json, SessionJsonOptions.Default)
             ?? throw new InvalidOperationException($"Failed to clone thread snapshot for {thread.Id}.");
-    }
-
-    private void RebuildAttachmentReferences()
-    {
-        try
-        {
-            _attachmentStore.RebuildFromThreads(_rolloutStore.LoadAllThreads());
-        }
-        catch
-        {
-            // Attachment indexing is best-effort; missing thumbnails should not block startup.
-        }
     }
 
     private async Task<AgentSession> RebuildSessionFromRolloutAsync(

--- a/src/DotCraft.Core/State/StateRuntime.cs
+++ b/src/DotCraft.Core/State/StateRuntime.cs
@@ -6,6 +6,7 @@ public sealed class StateRuntime
 {
     private const double DefaultCompactFreelistRatio = 0.25;
     private const int DefaultCompactMinFreelistPages = 32;
+    private const string TraceSessionSummaryMetadataBackfillKey = "trace_sessions.summary_metadata_backfill_v1";
 
     private readonly string _connectionString;
     private readonly bool _readOnly;
@@ -331,7 +332,15 @@ public sealed class StateRuntime
                     max_turn_duration_ms INTEGER NOT NULL DEFAULT 0,
                     last_finish_reason TEXT,
                     final_system_prompt TEXT,
-                    tool_names_json TEXT
+                    tool_names_json TEXT,
+                    first_user_request TEXT,
+                    system_prompt_hash TEXT,
+                    tool_schema_hash TEXT,
+                    prompt_drift_count INTEGER NOT NULL DEFAULT 0,
+                    session_metadata_captured_at TEXT,
+                    last_prompt_cache_change_at TEXT,
+                    last_prompt_cache_change_kind TEXT,
+                    last_prompt_cache_changed_fields_json TEXT
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_trace_sessions_last_activity
@@ -443,6 +452,14 @@ public sealed class StateRuntime
             EnsureColumn(connection, "trace_sessions", "maintenance_fork_request_count", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "trace_sessions", "maintenance_fork_response_count", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "trace_sessions", "max_turn_duration_ms", "INTEGER NOT NULL DEFAULT 0");
+            EnsureColumn(connection, "trace_sessions", "first_user_request", "TEXT");
+            EnsureColumn(connection, "trace_sessions", "system_prompt_hash", "TEXT");
+            EnsureColumn(connection, "trace_sessions", "tool_schema_hash", "TEXT");
+            EnsureColumn(connection, "trace_sessions", "prompt_drift_count", "INTEGER NOT NULL DEFAULT 0");
+            EnsureColumn(connection, "trace_sessions", "session_metadata_captured_at", "TEXT");
+            EnsureColumn(connection, "trace_sessions", "last_prompt_cache_change_at", "TEXT");
+            EnsureColumn(connection, "trace_sessions", "last_prompt_cache_change_kind", "TEXT");
+            EnsureColumn(connection, "trace_sessions", "last_prompt_cache_changed_fields_json", "TEXT");
             EnsureColumn(connection, "trace_events", "reasoning_effort", "TEXT");
             EnsureColumn(connection, "token_usage_records", "cache_write_input_tokens", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "dashboard_usage_records", "cached_input_tokens", "INTEGER NOT NULL DEFAULT 0");
@@ -458,8 +475,147 @@ public sealed class StateRuntime
             EnsureColumn(connection, "thread_context_usage", "anchor_boundary", "TEXT");
             EnsureColumn(connection, "thread_context_usage", "usage_source", "TEXT");
             EnsureColumn(connection, "thread_context_usage", "usage_is_estimate", "INTEGER NOT NULL DEFAULT 0");
+            BackfillTraceSessionSummaryMetadata(connection);
 
             _initialized = true;
+        }
+    }
+
+    private static void BackfillTraceSessionSummaryMetadata(SqliteConnection connection)
+    {
+        try
+        {
+            using (var marker = connection.CreateCommand())
+            {
+                marker.CommandText = "SELECT value FROM state_info WHERE key = $key LIMIT 1";
+                marker.Parameters.AddWithValue("$key", TraceSessionSummaryMetadataBackfillKey);
+                if (string.Equals(marker.ExecuteScalar() as string, "1", StringComparison.Ordinal))
+                    return;
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = """
+                    UPDATE trace_sessions
+                    SET first_user_request = COALESCE(
+                        NULLIF(first_user_request, ''),
+                        (
+                            SELECT NULLIF(TRIM(json_extract(e.event_json, '$.Content')), '')
+                            FROM trace_events e
+                            WHERE e.session_key = trace_sessions.session_key
+                              AND e.type = 'Request'
+                              AND json_valid(e.event_json)
+                              AND NULLIF(TRIM(json_extract(e.event_json, '$.Content')), '') IS NOT NULL
+                            ORDER BY e.timestamp ASC, e.id ASC
+                            LIMIT 1
+                        )
+                    );
+
+                    UPDATE trace_sessions
+                    SET
+                        system_prompt_hash = COALESCE(
+                            NULLIF(system_prompt_hash, ''),
+                            (
+                                SELECT NULLIF(TRIM(json_extract(e.event_json, '$.SystemPromptHash')), '')
+                                FROM trace_events e
+                                WHERE e.session_key = trace_sessions.session_key
+                                  AND e.type = 'SessionMetadata'
+                                  AND json_valid(e.event_json)
+                                  AND NULLIF(TRIM(json_extract(e.event_json, '$.SystemPromptHash')), '') IS NOT NULL
+                                ORDER BY e.timestamp DESC, e.id DESC
+                                LIMIT 1
+                            )
+                        ),
+                        tool_schema_hash = COALESCE(
+                            NULLIF(tool_schema_hash, ''),
+                            (
+                                SELECT NULLIF(TRIM(json_extract(e.event_json, '$.ToolSchemaHash')), '')
+                                FROM trace_events e
+                                WHERE e.session_key = trace_sessions.session_key
+                                  AND e.type = 'SessionMetadata'
+                                  AND json_valid(e.event_json)
+                                  AND NULLIF(TRIM(json_extract(e.event_json, '$.ToolSchemaHash')), '') IS NOT NULL
+                                ORDER BY e.timestamp DESC, e.id DESC
+                                LIMIT 1
+                            )
+                        ),
+                        session_metadata_captured_at = COALESCE(
+                            NULLIF(session_metadata_captured_at, ''),
+                            (
+                                SELECT e.timestamp
+                                FROM trace_events e
+                                WHERE e.session_key = trace_sessions.session_key
+                                  AND e.type = 'SessionMetadata'
+                                  AND json_valid(e.event_json)
+                                ORDER BY e.timestamp DESC, e.id DESC
+                                LIMIT 1
+                            )
+                        );
+
+                    UPDATE trace_sessions
+                    SET prompt_drift_count = (
+                        SELECT COUNT(*)
+                        FROM trace_events e
+                        WHERE e.session_key = trace_sessions.session_key
+                          AND e.type IN ('SessionMetadata', 'ToolInjection')
+                          AND json_valid(e.event_json)
+                          AND json_extract(e.event_json, '$.PromptCacheEventKind') = 'drift'
+                    )
+                    WHERE prompt_drift_count = 0;
+
+                    UPDATE trace_sessions
+                    SET
+                        last_prompt_cache_change_at = COALESCE(
+                            NULLIF(last_prompt_cache_change_at, ''),
+                            (
+                                SELECT e.timestamp
+                                FROM trace_events e
+                                WHERE e.session_key = trace_sessions.session_key
+                                  AND e.type IN ('SessionMetadata', 'ToolInjection')
+                                  AND json_valid(e.event_json)
+                                  AND json_extract(e.event_json, '$.PromptCacheEventKind') IN ('drift', 'toolExtension')
+                                ORDER BY e.timestamp DESC, e.id DESC
+                                LIMIT 1
+                            )
+                        ),
+                        last_prompt_cache_change_kind = COALESCE(
+                            NULLIF(last_prompt_cache_change_kind, ''),
+                            (
+                                SELECT json_extract(e.event_json, '$.PromptCacheEventKind')
+                                FROM trace_events e
+                                WHERE e.session_key = trace_sessions.session_key
+                                  AND e.type IN ('SessionMetadata', 'ToolInjection')
+                                  AND json_valid(e.event_json)
+                                  AND json_extract(e.event_json, '$.PromptCacheEventKind') IN ('drift', 'toolExtension')
+                                ORDER BY e.timestamp DESC, e.id DESC
+                                LIMIT 1
+                            )
+                        ),
+                        last_prompt_cache_changed_fields_json = COALESCE(
+                            NULLIF(last_prompt_cache_changed_fields_json, ''),
+                            (
+                                SELECT COALESCE(json_extract(e.event_json, '$.PromptCacheChangedFields'), '[]')
+                                FROM trace_events e
+                                WHERE e.session_key = trace_sessions.session_key
+                                  AND e.type IN ('SessionMetadata', 'ToolInjection')
+                                  AND json_valid(e.event_json)
+                                  AND json_extract(e.event_json, '$.PromptCacheEventKind') IN ('drift', 'toolExtension')
+                                ORDER BY e.timestamp DESC, e.id DESC
+                                LIMIT 1
+                            )
+                        );
+
+                    INSERT INTO state_info(key, value)
+                    VALUES ($key, '1')
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+                    """;
+                command.Parameters.AddWithValue("$key", TraceSessionSummaryMetadataBackfillKey);
+                command.ExecuteNonQuery();
+            }
+        }
+        catch
+        {
+            // Best-effort migration; newly recorded sessions persist these fields directly.
         }
     }
 

--- a/src/DotCraft.Core/Tracing/TraceStore.cs
+++ b/src/DotCraft.Core/Tracing/TraceStore.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Globalization;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -110,6 +112,27 @@ public sealed class TraceStore
             SessionKey = key
         });
 
+        ApplySessionMetadata(
+            session,
+            finalSystemPrompt,
+            toolNames,
+            systemPromptHash,
+            toolSchemaHash,
+            capturedAt,
+            promptCacheEventKind,
+            promptCacheChangedFields);
+    }
+
+    private static void ApplySessionMetadata(
+        TraceSession session,
+        string? finalSystemPrompt,
+        IEnumerable<string>? toolNames,
+        string? systemPromptHash = null,
+        string? toolSchemaHash = null,
+        DateTimeOffset? capturedAt = null,
+        string? promptCacheEventKind = null,
+        IEnumerable<string>? promptCacheChangedFields = null)
+    {
         var effectivePromptCacheEventKind = promptCacheEventKind;
         var effectivePromptCacheChangedFields = promptCacheChangedFields?.ToArray();
         if (string.IsNullOrWhiteSpace(effectivePromptCacheEventKind))
@@ -169,6 +192,9 @@ public sealed class TraceStore
 
     public IReadOnlyList<TraceSession> GetSessions()
     {
+        if (_stateRuntime != null)
+            return GetSessionsFromDb();
+
         return _sessions.Values
             .OrderByDescending(s => s.LastActivityAt)
             .ToList();
@@ -176,11 +202,17 @@ public sealed class TraceStore
 
     public TraceSession? GetSession(string sessionKey)
     {
+        if (_stateRuntime != null)
+            return GetSessionFromDb(sessionKey) ?? _sessions.GetValueOrDefault(sessionKey);
+
         return _sessions.GetValueOrDefault(sessionKey);
     }
 
     public IReadOnlyList<TraceEvent> GetEvents(string sessionKey)
     {
+        if (_stateRuntime != null)
+            return GetEventsFromDb(sessionKey);
+
         if (!_sessions.TryGetValue(sessionKey, out var session))
             return [];
         return session.Events.OrderBy(e => e.Timestamp).ToList();
@@ -196,7 +228,10 @@ public sealed class TraceStore
         var types = ResolveEventPageFilter(filter);
 
         if (_stateRuntime != null)
+        {
+            WaitForPendingPersistence();
             return GetEventPageFromDb(sessionKey, normalizedLimit, beforeCursor, types);
+        }
 
         return GetEventPageFromMemory(sessionKey, normalizedLimit, beforeCursor, types);
     }
@@ -344,6 +379,9 @@ public sealed class TraceStore
 
     public TraceSummary GetSummary()
     {
+        if (_stateRuntime != null)
+            return GetSummaryFromDb();
+
         long totalInput = 0, totalOutput = 0, totalCachedInput = 0, totalCacheWriteInput = 0, totalReasoningOutput = 0;
         int totalRequests = 0, totalMaintenanceForkRequests = 0, totalResponses = 0, totalMaintenanceForkResponses = 0;
         int totalToolCalls = 0, totalErrors = 0, totalContextCompactions = 0;
@@ -403,6 +441,9 @@ public sealed class TraceStore
     /// <param name="tzOffsetMinutes">Minutes to add to UTC to obtain the client's local time.</param>
     public IReadOnlyList<DailyUsageBucket> GetDailyUsage(DateOnly? from, DateOnly? to, int tzOffsetMinutes)
     {
+        if (_stateRuntime != null)
+            return GetDailyUsageFromDb(from, to, tzOffsetMinutes);
+
         var offset = TimeSpan.FromMinutes(tzOffsetMinutes);
         var buckets = new Dictionary<DateOnly, (long Input, long Output, int Sessions)>();
 
@@ -440,6 +481,9 @@ public sealed class TraceStore
     /// </summary>
     public long GetLongestTurnDurationMs()
     {
+        if (_stateRuntime != null)
+            return GetLongestTurnDurationMsFromDb();
+
         long max = 0;
         foreach (var session in _sessions.Values)
             max = Math.Max(max, session.MaxTurnDurationMs);
@@ -457,9 +501,11 @@ public sealed class TraceStore
     public ProfileInsights GetProfileInsights(int topSkills = 5)
     {
         var limit = Math.Clamp(topSkills, 1, 50);
-        return _stateRuntime != null
-            ? GetProfileInsightsFromDb(limit)
-            : GetProfileInsightsFromMemory(limit);
+        if (_stateRuntime == null)
+            return GetProfileInsightsFromMemory(limit);
+
+        WaitForPendingPersistence();
+        return GetProfileInsightsFromDb(limit);
     }
 
     private ProfileInsights GetProfileInsightsFromDb(int topSkills)
@@ -581,7 +627,9 @@ public sealed class TraceStore
     {
         if (_stateRuntime != null)
         {
-            LoadFromDb();
+            // State-backed stores keep historical events in SQLite and read them on demand.
+            // Startup only needs the table schema opened by StateRuntime; materializing every
+            // event_json row here inflates appserver memory for large workspaces.
             return;
         }
 
@@ -614,11 +662,7 @@ public sealed class TraceStore
 
     private void ApplyEvent(TraceEvent evt, bool writeToSse)
     {
-        var session = _sessions.GetOrAdd(evt.SessionKey, key => new TraceSession
-        {
-            SessionKey = key,
-            StartedAt = evt.Timestamp
-        });
+        var session = GetOrAddSessionForEvent(evt);
 
         if (session.StartedAt > evt.Timestamp)
         {
@@ -627,12 +671,21 @@ public sealed class TraceStore
         }
 
         session.LastActivityAt = evt.Timestamp;
+        ApplyEventToSession(session, evt);
 
+        AddInMemoryEvent(session, evt);
+
+        if (writeToSse)
+            _sseChannel.Writer.TryWrite(evt);
+    }
+
+    private void ApplyEventToSession(TraceSession session, TraceEvent evt)
+    {
         switch (evt.Type)
         {
             case TraceEventType.SessionMetadata:
-                UpsertSessionMetadata(
-                    evt.SessionKey,
+                ApplySessionMetadata(
+                    session,
                     evt.FinalSystemPrompt,
                     evt.ToolNames,
                     evt.SystemPromptHash,
@@ -696,11 +749,6 @@ public sealed class TraceStore
                 session.ThinkingCount++;
                 break;
         }
-
-        AddInMemoryEvent(session, evt);
-
-        if (writeToSse)
-            _sseChannel.Writer.TryWrite(evt);
     }
 
     private static void ApplyPromptCacheChangeSummary(TraceSession session, TraceEvent evt)
@@ -934,15 +982,134 @@ public sealed class TraceStore
         command.ExecuteNonQuery();
     }
 
-    private void LoadFromDb()
+    private TraceSession GetOrAddSessionForEvent(TraceEvent evt)
     {
+        return _sessions.GetOrAdd(evt.SessionKey, key =>
+            _stateRuntime != null
+                ? LoadSessionFromDbEvents(key, keepEvents: false) ?? new TraceSession
+                {
+                    SessionKey = key,
+                    StartedAt = evt.Timestamp
+                }
+                : new TraceSession
+                {
+                    SessionKey = key,
+                    StartedAt = evt.Timestamp
+                });
+    }
+
+    private IReadOnlyList<TraceSession> GetSessionsFromDb()
+    {
+        WaitForPendingPersistence();
+
+        using var connection = _stateRuntime!.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT
+                session_key,
+                started_at,
+                last_activity_at,
+                request_count,
+                maintenance_fork_request_count,
+                response_count,
+                maintenance_fork_response_count,
+                tool_call_count,
+                error_count,
+                context_compaction_count,
+                thinking_count,
+                token_usage_count,
+                total_input_tokens,
+                total_output_tokens,
+                total_cached_input_tokens,
+                total_cache_write_input_tokens,
+                total_reasoning_output_tokens,
+                total_tool_duration_ms,
+                max_tool_duration_ms,
+                max_turn_duration_ms,
+                last_finish_reason,
+                final_system_prompt,
+                tool_names_json
+            FROM trace_sessions
+            ORDER BY last_activity_at DESC, session_key DESC
+            """;
+
+        var sessions = new List<TraceSession>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+            sessions.Add(ReadSessionSummary(reader));
+
+        return sessions;
+    }
+
+    private TraceSession? GetSessionFromDb(string sessionKey)
+    {
+        if (string.IsNullOrWhiteSpace(sessionKey))
+            return null;
+
+        WaitForPendingPersistence();
+        var replayed = LoadSessionFromDbEvents(sessionKey, keepEvents: false);
+        if (replayed != null)
+            return replayed;
+
+        using var connection = _stateRuntime!.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT
+                session_key,
+                started_at,
+                last_activity_at,
+                request_count,
+                maintenance_fork_request_count,
+                response_count,
+                maintenance_fork_response_count,
+                tool_call_count,
+                error_count,
+                context_compaction_count,
+                thinking_count,
+                token_usage_count,
+                total_input_tokens,
+                total_output_tokens,
+                total_cached_input_tokens,
+                total_cache_write_input_tokens,
+                total_reasoning_output_tokens,
+                total_tool_duration_ms,
+                max_tool_duration_ms,
+                max_turn_duration_ms,
+                last_finish_reason,
+                final_system_prompt,
+                tool_names_json
+            FROM trace_sessions
+            WHERE session_key = $session_key
+            """;
+        command.Parameters.AddWithValue("$session_key", sessionKey);
+        using var reader = command.ExecuteReader();
+        return reader.Read() ? ReadSessionSummary(reader) : null;
+    }
+
+    private IReadOnlyList<TraceEvent> GetEventsFromDb(string sessionKey)
+    {
+        if (_maxEventsPerSession <= 0 || string.IsNullOrWhiteSpace(sessionKey))
+            return [];
+
+        WaitForPendingPersistence();
+
         using var connection = _stateRuntime!.OpenConnection();
         using var command = connection.CreateCommand();
         command.CommandText = """
             SELECT event_json
-            FROM trace_events
-            ORDER BY timestamp, id
+            FROM (
+                SELECT timestamp, id, event_json
+                FROM trace_events
+                WHERE session_key = $session_key
+                ORDER BY timestamp DESC, id DESC
+                LIMIT $limit
+            )
+            ORDER BY timestamp ASC, id ASC
             """;
+        command.Parameters.AddWithValue("$session_key", sessionKey);
+        command.Parameters.AddWithValue("$limit", _maxEventsPerSession);
+
+        var events = new List<TraceEvent>();
         using var reader = command.ExecuteReader();
         while (reader.Read())
         {
@@ -950,14 +1117,245 @@ public sealed class TraceStore
             {
                 var evt = JsonSerializer.Deserialize<TraceEvent>(reader.GetString(0), PersistJsonOptions);
                 if (evt != null)
-                    ApplyEvent(evt, writeToSse: false);
+                    events.Add(evt);
             }
             catch
             {
                 // Skip corrupted rows.
             }
         }
+
+        return events;
     }
+
+    private TraceSummary GetSummaryFromDb()
+    {
+        WaitForPendingPersistence();
+
+        using var connection = _stateRuntime!.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT
+                COUNT(*),
+                COALESCE(SUM(request_count), 0),
+                COALESCE(SUM(maintenance_fork_request_count), 0),
+                COALESCE(SUM(response_count), 0),
+                COALESCE(SUM(maintenance_fork_response_count), 0),
+                COALESCE(SUM(tool_call_count), 0),
+                COALESCE(SUM(error_count), 0),
+                COALESCE(SUM(context_compaction_count), 0),
+                COALESCE(SUM(total_tool_duration_ms), 0),
+                COALESCE(MAX(max_tool_duration_ms), 0),
+                COALESCE(MAX(max_turn_duration_ms), 0),
+                COALESCE(SUM(total_input_tokens), 0),
+                COALESCE(SUM(total_output_tokens), 0),
+                COALESCE(SUM(total_cached_input_tokens), 0),
+                COALESCE(SUM(total_cache_write_input_tokens), 0),
+                COALESCE(SUM(total_reasoning_output_tokens), 0)
+            FROM trace_sessions
+            """;
+
+        using var reader = command.ExecuteReader();
+        if (!reader.Read())
+            return new TraceSummary();
+
+        var totalToolCalls = ReadInt32(reader, 5);
+        var totalToolDuration = ReadInt64(reader, 8);
+        var totalInput = ReadInt64(reader, 11);
+        var totalOutput = ReadInt64(reader, 12);
+        return new TraceSummary
+        {
+            SessionCount = ReadInt32(reader, 0),
+            TotalRequests = ReadInt32(reader, 1),
+            TotalMaintenanceForkRequests = ReadInt32(reader, 2),
+            TotalResponses = ReadInt32(reader, 3),
+            TotalMaintenanceForkResponses = ReadInt32(reader, 4),
+            TotalToolCalls = totalToolCalls,
+            TotalErrors = ReadInt32(reader, 6),
+            TotalContextCompactions = ReadInt32(reader, 7),
+            TotalToolDurationMs = totalToolDuration,
+            AvgToolDurationMs = totalToolCalls > 0 ? totalToolDuration / (double)totalToolCalls : 0,
+            MaxToolDurationMs = ReadInt64(reader, 9),
+            MaxTurnDurationMs = ReadInt64(reader, 10),
+            TotalInputTokens = totalInput,
+            TotalOutputTokens = totalOutput,
+            TotalCachedInputTokens = ReadInt64(reader, 13),
+            TotalCacheWriteInputTokens = ReadInt64(reader, 14),
+            TotalReasoningOutputTokens = ReadInt64(reader, 15),
+            TotalTokens = totalInput + totalOutput
+        };
+    }
+
+    private IReadOnlyList<DailyUsageBucket> GetDailyUsageFromDb(DateOnly? from, DateOnly? to, int tzOffsetMinutes)
+    {
+        WaitForPendingPersistence();
+
+        var offset = TimeSpan.FromMinutes(tzOffsetMinutes);
+        var buckets = new Dictionary<DateOnly, (long Input, long Output, int Sessions)>();
+        using var connection = _stateRuntime!.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT started_at, total_input_tokens, total_output_tokens
+            FROM trace_sessions
+            """;
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var localWallClock = ParseTimestamp(reader.GetString(0)).ToUniversalTime().Add(offset).DateTime;
+            var date = DateOnly.FromDateTime(localWallClock);
+            if (from.HasValue && date < from.Value)
+                continue;
+            if (to.HasValue && date > to.Value)
+                continue;
+
+            var current = buckets.GetValueOrDefault(date);
+            buckets[date] = (
+                current.Input + ReadInt64(reader, 1),
+                current.Output + ReadInt64(reader, 2),
+                current.Sessions + 1);
+        }
+
+        return buckets
+            .OrderBy(kv => kv.Key)
+            .Select(kv => new DailyUsageBucket
+            {
+                Date = kv.Key,
+                InputTokens = kv.Value.Input,
+                OutputTokens = kv.Value.Output,
+                SessionCount = kv.Value.Sessions
+            })
+            .ToList();
+    }
+
+    private long GetLongestTurnDurationMsFromDb()
+    {
+        WaitForPendingPersistence();
+
+        using var connection = _stateRuntime!.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COALESCE(MAX(max_turn_duration_ms), 0) FROM trace_sessions";
+        return Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private TraceSession? LoadSessionFromDbEvents(string sessionKey, bool keepEvents)
+    {
+        using var connection = _stateRuntime!.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT event_json
+            FROM trace_events
+            WHERE session_key = $session_key
+            ORDER BY timestamp, id
+            """;
+        command.Parameters.AddWithValue("$session_key", sessionKey);
+
+        TraceSession? session = null;
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            TraceEvent? evt;
+            try
+            {
+                evt = JsonSerializer.Deserialize<TraceEvent>(reader.GetString(0), PersistJsonOptions);
+            }
+            catch
+            {
+                // Skip corrupted rows.
+                continue;
+            }
+
+            if (evt == null || !string.Equals(evt.SessionKey, sessionKey, StringComparison.Ordinal))
+                continue;
+
+            session ??= new TraceSession
+            {
+                SessionKey = evt.SessionKey,
+                StartedAt = evt.Timestamp
+            };
+
+            if (session.StartedAt > evt.Timestamp)
+                session = CloneSessionWithStartedAt(session, evt.Timestamp);
+
+            session.LastActivityAt = evt.Timestamp;
+            ApplyEventToSession(session, evt);
+            if (keepEvents)
+                AddInMemoryEvent(session, evt);
+        }
+
+        return session;
+    }
+
+    private static TraceSession ReadSessionSummary(DbDataReader reader)
+    {
+        var session = new TraceSession
+        {
+            SessionKey = reader.GetString(0),
+            StartedAt = ParseTimestamp(reader.GetString(1)),
+            LastActivityAt = ParseTimestamp(reader.GetString(2)),
+            RequestCount = ReadInt32(reader, 3),
+            MaintenanceForkRequestCount = ReadInt32(reader, 4),
+            ResponseCount = ReadInt32(reader, 5),
+            MaintenanceForkResponseCount = ReadInt32(reader, 6),
+            ToolCallCount = ReadInt32(reader, 7),
+            ErrorCount = ReadInt32(reader, 8),
+            ContextCompactionCount = ReadInt32(reader, 9),
+            ThinkingCount = ReadInt32(reader, 10),
+            TokenUsageCount = ReadInt32(reader, 11),
+            LastFinishReason = ReadStringOrNull(reader, 20),
+            FinalSystemPrompt = ReadStringOrNull(reader, 21)
+        };
+        session.LoadAggregateSnapshot(
+            ReadInt64(reader, 12),
+            ReadInt64(reader, 13),
+            ReadInt64(reader, 14),
+            ReadInt64(reader, 15),
+            ReadInt64(reader, 16),
+            ReadInt64(reader, 17),
+            ReadInt64(reader, 18),
+            ReadInt64(reader, 19));
+        session.SetToolNames(ReadToolNames(reader, 22));
+        return session;
+    }
+
+    private static IReadOnlyList<string> ReadToolNames(DbDataReader reader, int ordinal)
+    {
+        if (reader.IsDBNull(ordinal))
+            return [];
+
+        try
+        {
+            return JsonSerializer.Deserialize<string[]>(reader.GetString(ordinal), PersistJsonOptions) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static DateTimeOffset ParseTimestamp(string value)
+    {
+        return DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : DateTimeOffset.UtcNow;
+    }
+
+    private static int ReadInt32(DbDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal)
+            ? 0
+            : Convert.ToInt32(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    private static long ReadInt64(DbDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal)
+            ? 0
+            : Convert.ToInt64(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    private static string? ReadStringOrNull(DbDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
 
     private void DeleteSessionFile(string sessionKey)
     {

--- a/src/DotCraft.Core/Tracing/TraceStore.cs
+++ b/src/DotCraft.Core/Tracing/TraceStore.cs
@@ -30,39 +30,40 @@ public sealed class TraceStore
     private int _persistInFlight;
     private const int DefaultEventPageLimit = 1000;
     private const int MaxEventPageLimit = 1000;
-    private const string TraceSessionSummaryColumns = """
-                session_key,
-                started_at,
-                last_activity_at,
-                request_count,
-                maintenance_fork_request_count,
-                response_count,
-                maintenance_fork_response_count,
-                tool_call_count,
-                error_count,
-                context_compaction_count,
-                thinking_count,
-                token_usage_count,
-                total_input_tokens,
-                total_output_tokens,
-                total_cached_input_tokens,
-                total_cache_write_input_tokens,
-                total_reasoning_output_tokens,
-                total_tool_duration_ms,
-                max_tool_duration_ms,
-                max_turn_duration_ms,
-                last_finish_reason,
-                final_system_prompt,
-                tool_names_json,
-                first_user_request,
-                system_prompt_hash,
-                tool_schema_hash,
-                prompt_drift_count,
-                session_metadata_captured_at,
-                last_prompt_cache_change_at,
-                last_prompt_cache_change_kind,
-                last_prompt_cache_changed_fields_json
-        """;
+    private static readonly TraceSessionSummaryColumn[] TraceSessionSummaryColumns =
+    [
+        new("session_key", "session_key"),
+        new("started_at", "started_at"),
+        new("last_activity_at", "started_at"),
+        new("request_count", "0"),
+        new("maintenance_fork_request_count", "0"),
+        new("response_count", "0"),
+        new("maintenance_fork_response_count", "0"),
+        new("tool_call_count", "0"),
+        new("error_count", "0"),
+        new("context_compaction_count", "0"),
+        new("thinking_count", "0"),
+        new("token_usage_count", "0"),
+        new("total_input_tokens", "0"),
+        new("total_output_tokens", "0"),
+        new("total_cached_input_tokens", "0"),
+        new("total_cache_write_input_tokens", "0"),
+        new("total_reasoning_output_tokens", "0"),
+        new("total_tool_duration_ms", "0"),
+        new("max_tool_duration_ms", "0"),
+        new("max_turn_duration_ms", "0"),
+        new("last_finish_reason", "NULL"),
+        new("final_system_prompt", "NULL"),
+        new("tool_names_json", "'[]'"),
+        new("first_user_request", "NULL"),
+        new("system_prompt_hash", "NULL"),
+        new("tool_schema_hash", "NULL"),
+        new("prompt_drift_count", "0"),
+        new("session_metadata_captured_at", "NULL"),
+        new("last_prompt_cache_change_at", "NULL"),
+        new("last_prompt_cache_change_kind", "NULL"),
+        new("last_prompt_cache_changed_fields_json", "NULL")
+    ];
 
     private static readonly JsonSerializerOptions PersistJsonOptions = new()
     {
@@ -1124,10 +1125,11 @@ public sealed class TraceStore
         WaitForPendingPersistence();
 
         using var connection = _stateRuntime!.OpenConnection();
+        var selectList = BuildTraceSessionSummarySelectList(connection);
         using var command = connection.CreateCommand();
         command.CommandText = $"""
             SELECT
-            {TraceSessionSummaryColumns}
+            {selectList}
             FROM trace_sessions
             ORDER BY last_activity_at DESC, session_key DESC
             """;
@@ -1152,10 +1154,11 @@ public sealed class TraceStore
     private TraceSession? LoadSessionSummaryFromDb(string sessionKey)
     {
         using var connection = _stateRuntime!.OpenConnection();
+        var selectList = BuildTraceSessionSummarySelectList(connection);
         using var command = connection.CreateCommand();
         command.CommandText = $"""
             SELECT
-            {TraceSessionSummaryColumns}
+            {selectList}
             FROM trace_sessions
             WHERE session_key = $session_key
             """;
@@ -1402,6 +1405,28 @@ public sealed class TraceStore
             ReadInt64(reader, 19));
         session.SetToolNames(ReadStringArray(reader, 22));
         return session;
+    }
+
+    private static string BuildTraceSessionSummarySelectList(DbConnection connection)
+    {
+        var availableColumns = GetTableColumns(connection, "trace_sessions");
+        return string.Join(
+            ",\n",
+            TraceSessionSummaryColumns.Select(column =>
+                availableColumns.Contains(column.Name)
+                    ? "                " + column.Name
+                    : $"                {column.FallbackExpression} AS {column.Name}"));
+    }
+
+    private static HashSet<string> GetTableColumns(DbConnection connection, string tableName)
+    {
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA table_info({tableName})";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+            columns.Add(reader.GetString(1));
+        return columns;
     }
 
     private static string[] ReadStringArray(DbDataReader reader, int ordinal)
@@ -1761,6 +1786,8 @@ public sealed class TraceStore
         => string.Concat(value.Split(Path.GetInvalidFileNameChars()));
 
     private sealed record TraceEventDbRow(long RowId, string Timestamp, string EventJson);
+
+    private sealed record TraceSessionSummaryColumn(string Name, string FallbackExpression);
 }
 
 public sealed record TraceEventPage(

--- a/src/DotCraft.Core/Tracing/TraceStore.cs
+++ b/src/DotCraft.Core/Tracing/TraceStore.cs
@@ -30,6 +30,39 @@ public sealed class TraceStore
     private int _persistInFlight;
     private const int DefaultEventPageLimit = 1000;
     private const int MaxEventPageLimit = 1000;
+    private const string TraceSessionSummaryColumns = """
+                session_key,
+                started_at,
+                last_activity_at,
+                request_count,
+                maintenance_fork_request_count,
+                response_count,
+                maintenance_fork_response_count,
+                tool_call_count,
+                error_count,
+                context_compaction_count,
+                thinking_count,
+                token_usage_count,
+                total_input_tokens,
+                total_output_tokens,
+                total_cached_input_tokens,
+                total_cache_write_input_tokens,
+                total_reasoning_output_tokens,
+                total_tool_duration_ms,
+                max_tool_duration_ms,
+                max_turn_duration_ms,
+                last_finish_reason,
+                final_system_prompt,
+                tool_names_json,
+                first_user_request,
+                system_prompt_hash,
+                tool_schema_hash,
+                prompt_drift_count,
+                session_metadata_captured_at,
+                last_prompt_cache_change_at,
+                last_prompt_cache_change_kind,
+                last_prompt_cache_changed_fields_json
+        """;
 
     private static readonly JsonSerializerOptions PersistJsonOptions = new()
     {
@@ -906,7 +939,15 @@ public sealed class TraceStore
                 max_turn_duration_ms,
                 last_finish_reason,
                 final_system_prompt,
-                tool_names_json
+                tool_names_json,
+                first_user_request,
+                system_prompt_hash,
+                tool_schema_hash,
+                prompt_drift_count,
+                session_metadata_captured_at,
+                last_prompt_cache_change_at,
+                last_prompt_cache_change_kind,
+                last_prompt_cache_changed_fields_json
             ) VALUES (
                 $session_key,
                 $started_at,
@@ -930,31 +971,93 @@ public sealed class TraceStore
                 $max_turn_duration_ms,
                 $last_finish_reason,
                 $final_system_prompt,
-                $tool_names_json
+                $tool_names_json,
+                $first_user_request,
+                $system_prompt_hash,
+                $tool_schema_hash,
+                $prompt_drift_count,
+                $session_metadata_captured_at,
+                $last_prompt_cache_change_at,
+                $last_prompt_cache_change_kind,
+                $last_prompt_cache_changed_fields_json
             )
             ON CONFLICT(session_key) DO UPDATE SET
-                started_at = excluded.started_at,
-                last_activity_at = excluded.last_activity_at,
-                request_count = excluded.request_count,
-                maintenance_fork_request_count = excluded.maintenance_fork_request_count,
-                response_count = excluded.response_count,
-                maintenance_fork_response_count = excluded.maintenance_fork_response_count,
-                tool_call_count = excluded.tool_call_count,
-                error_count = excluded.error_count,
-                context_compaction_count = excluded.context_compaction_count,
-                thinking_count = excluded.thinking_count,
-                token_usage_count = excluded.token_usage_count,
-                total_input_tokens = excluded.total_input_tokens,
-                total_output_tokens = excluded.total_output_tokens,
-                total_cached_input_tokens = excluded.total_cached_input_tokens,
-                total_cache_write_input_tokens = excluded.total_cache_write_input_tokens,
-                total_reasoning_output_tokens = excluded.total_reasoning_output_tokens,
-                total_tool_duration_ms = excluded.total_tool_duration_ms,
-                max_tool_duration_ms = excluded.max_tool_duration_ms,
-                max_turn_duration_ms = excluded.max_turn_duration_ms,
-                last_finish_reason = excluded.last_finish_reason,
-                final_system_prompt = excluded.final_system_prompt,
-                tool_names_json = excluded.tool_names_json
+                started_at = CASE
+                    WHEN excluded.started_at < trace_sessions.started_at THEN excluded.started_at
+                    ELSE trace_sessions.started_at
+                END,
+                last_activity_at = CASE
+                    WHEN excluded.last_activity_at > trace_sessions.last_activity_at THEN excluded.last_activity_at
+                    ELSE trace_sessions.last_activity_at
+                END,
+                request_count = MAX(trace_sessions.request_count, excluded.request_count),
+                maintenance_fork_request_count = MAX(trace_sessions.maintenance_fork_request_count, excluded.maintenance_fork_request_count),
+                response_count = MAX(trace_sessions.response_count, excluded.response_count),
+                maintenance_fork_response_count = MAX(trace_sessions.maintenance_fork_response_count, excluded.maintenance_fork_response_count),
+                tool_call_count = MAX(trace_sessions.tool_call_count, excluded.tool_call_count),
+                error_count = MAX(trace_sessions.error_count, excluded.error_count),
+                context_compaction_count = MAX(trace_sessions.context_compaction_count, excluded.context_compaction_count),
+                thinking_count = MAX(trace_sessions.thinking_count, excluded.thinking_count),
+                token_usage_count = MAX(trace_sessions.token_usage_count, excluded.token_usage_count),
+                total_input_tokens = MAX(trace_sessions.total_input_tokens, excluded.total_input_tokens),
+                total_output_tokens = MAX(trace_sessions.total_output_tokens, excluded.total_output_tokens),
+                total_cached_input_tokens = MAX(trace_sessions.total_cached_input_tokens, excluded.total_cached_input_tokens),
+                total_cache_write_input_tokens = MAX(trace_sessions.total_cache_write_input_tokens, excluded.total_cache_write_input_tokens),
+                total_reasoning_output_tokens = MAX(trace_sessions.total_reasoning_output_tokens, excluded.total_reasoning_output_tokens),
+                total_tool_duration_ms = MAX(trace_sessions.total_tool_duration_ms, excluded.total_tool_duration_ms),
+                max_tool_duration_ms = MAX(trace_sessions.max_tool_duration_ms, excluded.max_tool_duration_ms),
+                max_turn_duration_ms = MAX(trace_sessions.max_turn_duration_ms, excluded.max_turn_duration_ms),
+                last_finish_reason = COALESCE(excluded.last_finish_reason, trace_sessions.last_finish_reason),
+                final_system_prompt = CASE
+                    WHEN excluded.session_metadata_captured_at IS NOT NULL
+                      AND (trace_sessions.session_metadata_captured_at IS NULL OR excluded.session_metadata_captured_at >= trace_sessions.session_metadata_captured_at)
+                    THEN excluded.final_system_prompt
+                    ELSE COALESCE(trace_sessions.final_system_prompt, excluded.final_system_prompt)
+                END,
+                tool_names_json = CASE
+                    WHEN excluded.session_metadata_captured_at IS NOT NULL
+                      AND (trace_sessions.session_metadata_captured_at IS NULL OR excluded.session_metadata_captured_at >= trace_sessions.session_metadata_captured_at)
+                    THEN excluded.tool_names_json
+                    ELSE COALESCE(trace_sessions.tool_names_json, excluded.tool_names_json)
+                END,
+                first_user_request = COALESCE(NULLIF(trace_sessions.first_user_request, ''), excluded.first_user_request),
+                system_prompt_hash = CASE
+                    WHEN excluded.session_metadata_captured_at IS NOT NULL
+                      AND (trace_sessions.session_metadata_captured_at IS NULL OR excluded.session_metadata_captured_at >= trace_sessions.session_metadata_captured_at)
+                    THEN excluded.system_prompt_hash
+                    ELSE COALESCE(trace_sessions.system_prompt_hash, excluded.system_prompt_hash)
+                END,
+                tool_schema_hash = CASE
+                    WHEN excluded.session_metadata_captured_at IS NOT NULL
+                      AND (trace_sessions.session_metadata_captured_at IS NULL OR excluded.session_metadata_captured_at >= trace_sessions.session_metadata_captured_at)
+                    THEN excluded.tool_schema_hash
+                    ELSE COALESCE(trace_sessions.tool_schema_hash, excluded.tool_schema_hash)
+                END,
+                prompt_drift_count = MAX(trace_sessions.prompt_drift_count, excluded.prompt_drift_count),
+                session_metadata_captured_at = CASE
+                    WHEN excluded.session_metadata_captured_at IS NOT NULL
+                      AND (trace_sessions.session_metadata_captured_at IS NULL OR excluded.session_metadata_captured_at > trace_sessions.session_metadata_captured_at)
+                    THEN excluded.session_metadata_captured_at
+                    ELSE trace_sessions.session_metadata_captured_at
+                END,
+                last_prompt_cache_change_at = CASE
+                    WHEN excluded.last_prompt_cache_change_at IS NOT NULL
+                      AND (trace_sessions.last_prompt_cache_change_at IS NULL OR excluded.last_prompt_cache_change_at > trace_sessions.last_prompt_cache_change_at)
+                    THEN excluded.last_prompt_cache_change_at
+                    ELSE trace_sessions.last_prompt_cache_change_at
+                END,
+                last_prompt_cache_change_kind = CASE
+                    WHEN excluded.last_prompt_cache_change_at IS NOT NULL
+                      AND (trace_sessions.last_prompt_cache_change_at IS NULL OR excluded.last_prompt_cache_change_at >= trace_sessions.last_prompt_cache_change_at)
+                    THEN excluded.last_prompt_cache_change_kind
+                    ELSE trace_sessions.last_prompt_cache_change_kind
+                END,
+                last_prompt_cache_changed_fields_json = CASE
+                    WHEN excluded.last_prompt_cache_change_at IS NOT NULL
+                      AND (trace_sessions.last_prompt_cache_change_at IS NULL OR excluded.last_prompt_cache_change_at >= trace_sessions.last_prompt_cache_change_at)
+                    THEN excluded.last_prompt_cache_changed_fields_json
+                    ELSE trace_sessions.last_prompt_cache_changed_fields_json
+                END
             """;
         command.Parameters.AddWithValue("$session_key", session.SessionKey);
         command.Parameters.AddWithValue("$started_at", session.StartedAt.UtcDateTime.ToString("O"));
@@ -979,6 +1082,24 @@ public sealed class TraceStore
         command.Parameters.AddWithValue("$last_finish_reason", (object?)session.LastFinishReason ?? DBNull.Value);
         command.Parameters.AddWithValue("$final_system_prompt", (object?)session.FinalSystemPrompt ?? DBNull.Value);
         command.Parameters.AddWithValue("$tool_names_json", JsonSerializer.Serialize(session.ToolNames, PersistJsonOptions));
+        command.Parameters.AddWithValue("$first_user_request", (object?)session.FirstUserRequest ?? DBNull.Value);
+        command.Parameters.AddWithValue("$system_prompt_hash", (object?)session.SystemPromptHash ?? DBNull.Value);
+        command.Parameters.AddWithValue("$tool_schema_hash", (object?)session.ToolSchemaHash ?? DBNull.Value);
+        command.Parameters.AddWithValue("$prompt_drift_count", session.PromptDriftCount);
+        command.Parameters.AddWithValue(
+            "$session_metadata_captured_at",
+            session.SessionMetadataCapturedAt.HasValue
+                ? session.SessionMetadataCapturedAt.Value.UtcDateTime.ToString("O")
+                : DBNull.Value);
+        command.Parameters.AddWithValue(
+            "$last_prompt_cache_change_at",
+            session.LastPromptCacheChangeAt.HasValue
+                ? session.LastPromptCacheChangeAt.Value.UtcDateTime.ToString("O")
+                : DBNull.Value);
+        command.Parameters.AddWithValue("$last_prompt_cache_change_kind", (object?)session.LastPromptCacheChangeKind ?? DBNull.Value);
+        command.Parameters.AddWithValue(
+            "$last_prompt_cache_changed_fields_json",
+            JsonSerializer.Serialize(session.LastPromptCacheChangedFields, PersistJsonOptions));
         command.ExecuteNonQuery();
     }
 
@@ -986,7 +1107,7 @@ public sealed class TraceStore
     {
         return _sessions.GetOrAdd(evt.SessionKey, key =>
             _stateRuntime != null
-                ? LoadSessionFromDbEvents(key, keepEvents: false) ?? new TraceSession
+                ? LoadSessionSummaryFromDb(key) ?? LoadSessionFromDbEvents(key, keepEvents: false) ?? new TraceSession
                 {
                     SessionKey = key,
                     StartedAt = evt.Timestamp
@@ -1004,31 +1125,9 @@ public sealed class TraceStore
 
         using var connection = _stateRuntime!.OpenConnection();
         using var command = connection.CreateCommand();
-        command.CommandText = """
+        command.CommandText = $"""
             SELECT
-                session_key,
-                started_at,
-                last_activity_at,
-                request_count,
-                maintenance_fork_request_count,
-                response_count,
-                maintenance_fork_response_count,
-                tool_call_count,
-                error_count,
-                context_compaction_count,
-                thinking_count,
-                token_usage_count,
-                total_input_tokens,
-                total_output_tokens,
-                total_cached_input_tokens,
-                total_cache_write_input_tokens,
-                total_reasoning_output_tokens,
-                total_tool_duration_ms,
-                max_tool_duration_ms,
-                max_turn_duration_ms,
-                last_finish_reason,
-                final_system_prompt,
-                tool_names_json
+            {TraceSessionSummaryColumns}
             FROM trace_sessions
             ORDER BY last_activity_at DESC, session_key DESC
             """;
@@ -1047,37 +1146,16 @@ public sealed class TraceStore
             return null;
 
         WaitForPendingPersistence();
-        var replayed = LoadSessionFromDbEvents(sessionKey, keepEvents: false);
-        if (replayed != null)
-            return replayed;
+        return LoadSessionSummaryFromDb(sessionKey) ?? LoadSessionFromDbEvents(sessionKey, keepEvents: false);
+    }
 
+    private TraceSession? LoadSessionSummaryFromDb(string sessionKey)
+    {
         using var connection = _stateRuntime!.OpenConnection();
         using var command = connection.CreateCommand();
-        command.CommandText = """
+        command.CommandText = $"""
             SELECT
-                session_key,
-                started_at,
-                last_activity_at,
-                request_count,
-                maintenance_fork_request_count,
-                response_count,
-                maintenance_fork_response_count,
-                tool_call_count,
-                error_count,
-                context_compaction_count,
-                thinking_count,
-                token_usage_count,
-                total_input_tokens,
-                total_output_tokens,
-                total_cached_input_tokens,
-                total_cache_write_input_tokens,
-                total_reasoning_output_tokens,
-                total_tool_duration_ms,
-                max_tool_duration_ms,
-                max_turn_duration_ms,
-                last_finish_reason,
-                final_system_prompt,
-                tool_names_json
+            {TraceSessionSummaryColumns}
             FROM trace_sessions
             WHERE session_key = $session_key
             """;
@@ -1303,7 +1381,15 @@ public sealed class TraceStore
             ThinkingCount = ReadInt32(reader, 10),
             TokenUsageCount = ReadInt32(reader, 11),
             LastFinishReason = ReadStringOrNull(reader, 20),
-            FinalSystemPrompt = ReadStringOrNull(reader, 21)
+            FinalSystemPrompt = ReadStringOrNull(reader, 21),
+            FirstUserRequest = ReadStringOrNull(reader, 23),
+            SystemPromptHash = ReadStringOrNull(reader, 24),
+            ToolSchemaHash = ReadStringOrNull(reader, 25),
+            PromptDriftCount = ReadInt32(reader, 26),
+            SessionMetadataCapturedAt = ReadDateTimeOffsetOrNull(reader, 27),
+            LastPromptCacheChangeAt = ReadDateTimeOffsetOrNull(reader, 28),
+            LastPromptCacheChangeKind = ReadStringOrNull(reader, 29),
+            LastPromptCacheChangedFields = ReadStringArray(reader, 30)
         };
         session.LoadAggregateSnapshot(
             ReadInt64(reader, 12),
@@ -1314,11 +1400,11 @@ public sealed class TraceStore
             ReadInt64(reader, 17),
             ReadInt64(reader, 18),
             ReadInt64(reader, 19));
-        session.SetToolNames(ReadToolNames(reader, 22));
+        session.SetToolNames(ReadStringArray(reader, 22));
         return session;
     }
 
-    private static IReadOnlyList<string> ReadToolNames(DbDataReader reader, int ordinal)
+    private static string[] ReadStringArray(DbDataReader reader, int ordinal)
     {
         if (reader.IsDBNull(ordinal))
             return [];
@@ -1356,6 +1442,24 @@ public sealed class TraceStore
 
     private static string? ReadStringOrNull(DbDataReader reader, int ordinal)
         => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+
+    private static DateTimeOffset? ReadDateTimeOffsetOrNull(DbDataReader reader, int ordinal)
+    {
+        if (reader.IsDBNull(ordinal))
+            return null;
+
+        var value = reader.GetString(ordinal);
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : null;
+    }
 
     private void DeleteSessionFile(string sessionKey)
     {

--- a/src/DotCraft.Core/Tracing/TraceStore.cs
+++ b/src/DotCraft.Core/Tracing/TraceStore.cs
@@ -1214,25 +1214,26 @@ public sealed class TraceStore
         WaitForPendingPersistence();
 
         using var connection = _stateRuntime!.OpenConnection();
+        var columns = GetTableColumns(connection, "trace_sessions");
         using var command = connection.CreateCommand();
-        command.CommandText = """
+        command.CommandText = $"""
             SELECT
                 COUNT(*),
-                COALESCE(SUM(request_count), 0),
-                COALESCE(SUM(maintenance_fork_request_count), 0),
-                COALESCE(SUM(response_count), 0),
-                COALESCE(SUM(maintenance_fork_response_count), 0),
-                COALESCE(SUM(tool_call_count), 0),
-                COALESCE(SUM(error_count), 0),
-                COALESCE(SUM(context_compaction_count), 0),
-                COALESCE(SUM(total_tool_duration_ms), 0),
-                COALESCE(MAX(max_tool_duration_ms), 0),
-                COALESCE(MAX(max_turn_duration_ms), 0),
-                COALESCE(SUM(total_input_tokens), 0),
-                COALESCE(SUM(total_output_tokens), 0),
-                COALESCE(SUM(total_cached_input_tokens), 0),
-                COALESCE(SUM(total_cache_write_input_tokens), 0),
-                COALESCE(SUM(total_reasoning_output_tokens), 0)
+                {SumTraceSessionColumnOrZero(columns, "request_count")},
+                {SumTraceSessionColumnOrZero(columns, "maintenance_fork_request_count")},
+                {SumTraceSessionColumnOrZero(columns, "response_count")},
+                {SumTraceSessionColumnOrZero(columns, "maintenance_fork_response_count")},
+                {SumTraceSessionColumnOrZero(columns, "tool_call_count")},
+                {SumTraceSessionColumnOrZero(columns, "error_count")},
+                {SumTraceSessionColumnOrZero(columns, "context_compaction_count")},
+                {SumTraceSessionColumnOrZero(columns, "total_tool_duration_ms")},
+                {MaxTraceSessionColumnOrZero(columns, "max_tool_duration_ms")},
+                {MaxTraceSessionColumnOrZero(columns, "max_turn_duration_ms")},
+                {SumTraceSessionColumnOrZero(columns, "total_input_tokens")},
+                {SumTraceSessionColumnOrZero(columns, "total_output_tokens")},
+                {SumTraceSessionColumnOrZero(columns, "total_cached_input_tokens")},
+                {SumTraceSessionColumnOrZero(columns, "total_cache_write_input_tokens")},
+                {SumTraceSessionColumnOrZero(columns, "total_reasoning_output_tokens")}
             FROM trace_sessions
             """;
 
@@ -1314,6 +1315,10 @@ public sealed class TraceStore
         WaitForPendingPersistence();
 
         using var connection = _stateRuntime!.OpenConnection();
+        var columns = GetTableColumns(connection, "trace_sessions");
+        if (!columns.Contains("max_turn_duration_ms"))
+            return 0;
+
         using var command = connection.CreateCommand();
         command.CommandText = "SELECT COALESCE(MAX(max_turn_duration_ms), 0) FROM trace_sessions";
         return Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture);
@@ -1428,6 +1433,12 @@ public sealed class TraceStore
             columns.Add(reader.GetString(1));
         return columns;
     }
+
+    private static string SumTraceSessionColumnOrZero(IReadOnlySet<string> availableColumns, string columnName)
+        => availableColumns.Contains(columnName) ? $"COALESCE(SUM({columnName}), 0)" : "0";
+
+    private static string MaxTraceSessionColumnOrZero(IReadOnlySet<string> availableColumns, string columnName)
+        => availableColumns.Contains(columnName) ? $"COALESCE(MAX({columnName}), 0)" : "0";
 
     private static string[] ReadStringArray(DbDataReader reader, int ordinal)
     {

--- a/tests/DotCraft.Core.Tests/Protocol/ThreadAttachmentStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ThreadAttachmentStoreTests.cs
@@ -1,4 +1,5 @@
 using DotCraft.Protocol;
+using DotCraft.State;
 
 namespace DotCraft.Tests.Protocol;
 
@@ -54,6 +55,23 @@ public sealed class ThreadAttachmentStoreTests : IDisposable
         Assert.True(File.Exists(imagePath));
     }
 
+    [Fact]
+    public async Task ConstructingThreadStore_DoesNotRebuildAttachmentReferences()
+    {
+        var imagePath = CreateAttachment("lazy-startup.png");
+        var thread = CreateThread("thread_lazy_attachment_index", imagePath);
+        await _store.SaveThreadAsync(thread);
+        Assert.Equal(1, CountAttachmentRows());
+
+        ClearAttachmentRows();
+        Assert.Equal(0, CountAttachmentRows());
+
+        _ = new ThreadStore(_root);
+
+        Assert.Equal(0, CountAttachmentRows());
+        Assert.True(File.Exists(imagePath));
+    }
+
     public void Dispose()
     {
         try
@@ -74,6 +92,24 @@ public sealed class ThreadAttachmentStoreTests : IDisposable
         var path = Path.Combine(dir, fileName);
         File.WriteAllBytes(path, [1, 2, 3, 4]);
         return path;
+    }
+
+    private int CountAttachmentRows()
+    {
+        var runtime = new StateRuntime(_root);
+        using var connection = runtime.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM thread_attachments";
+        return Convert.ToInt32(command.ExecuteScalar());
+    }
+
+    private void ClearAttachmentRows()
+    {
+        var runtime = new StateRuntime(_root);
+        using var connection = runtime.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM thread_attachments";
+        command.ExecuteNonQuery();
     }
 
     private static SessionThread CreateThread(string id, string imagePath)

--- a/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
@@ -88,18 +88,40 @@ public sealed class StateBackedStoreTests : IDisposable
     public void TraceStore_StateDbSummary_DoesNotRequire_EventJson_Load()
     {
         var writer = new TraceStore(_tracingPath, 5000, true, _stateRuntime);
+        var startedAt = new DateTimeOffset(2026, 6, 18, 8, 0, 0, TimeSpan.Zero);
         writer.Record(new TraceEvent
         {
             SessionKey = "thread-summary-only",
             Type = TraceEventType.Request,
-            Content = "hello"
+            Content = "hello",
+            Timestamp = startedAt
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-summary-only",
+            Type = TraceEventType.SessionMetadata,
+            SystemPromptHash = "aaa",
+            ToolSchemaHash = "bbb",
+            PromptCacheEventKind = PromptCacheEventKinds.Baseline,
+            Timestamp = startedAt.AddSeconds(1)
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-summary-only",
+            Type = TraceEventType.SessionMetadata,
+            SystemPromptHash = "ccc",
+            ToolSchemaHash = "bbb",
+            PromptCacheEventKind = PromptCacheEventKinds.Drift,
+            PromptCacheChangedFields = [PromptCacheChangedFields.Prompt],
+            Timestamp = startedAt.AddSeconds(2)
         });
         writer.Record(new TraceEvent
         {
             SessionKey = "thread-summary-only",
             Type = TraceEventType.TokenUsage,
             InputTokens = 11,
-            OutputTokens = 7
+            OutputTokens = 7,
+            Timestamp = startedAt.AddSeconds(3)
         });
 
         using (var connection = _stateRuntime.OpenConnection())
@@ -117,6 +139,16 @@ public sealed class StateBackedStoreTests : IDisposable
         Assert.Equal(1, summary.SessionCount);
         Assert.Equal(1, summary.TotalRequests);
         Assert.Equal(18, summary.TotalTokens);
+
+        var session = Assert.Single(reader.GetSessions());
+        Assert.Equal("hello", session.FirstUserRequest);
+        Assert.Equal("ccc", session.SystemPromptHash);
+        Assert.Equal("bbb", session.ToolSchemaHash);
+        Assert.Equal(1, session.PromptDriftCount);
+        Assert.Equal(startedAt.AddSeconds(2), session.SessionMetadataCapturedAt);
+        Assert.Equal(startedAt.AddSeconds(2), session.LastPromptCacheChangeAt);
+        Assert.Equal(PromptCacheEventKinds.Drift, session.LastPromptCacheChangeKind);
+        Assert.Equal([PromptCacheChangedFields.Prompt], session.LastPromptCacheChangedFields);
     }
 
     [Fact]
@@ -295,6 +327,101 @@ public sealed class StateBackedStoreTests : IDisposable
         var session = reader.GetSession("prompt-cache-session");
         Assert.NotNull(session);
         Assert.Equal(1, session.PromptDriftCount);
+        Assert.Equal(PromptCacheEventKinds.Drift, session.LastPromptCacheChangeKind);
+        Assert.Equal([PromptCacheChangedFields.Prompt], session.LastPromptCacheChangedFields);
+
+        var listed = Assert.Single(reader.GetSessions());
+        Assert.Equal("ccc", listed.SystemPromptHash);
+        Assert.Equal("bbb", listed.ToolSchemaHash);
+        Assert.Equal(1, listed.PromptDriftCount);
+        Assert.Equal(PromptCacheEventKinds.Drift, listed.LastPromptCacheChangeKind);
+        Assert.Equal([PromptCacheChangedFields.Prompt], listed.LastPromptCacheChangedFields);
+    }
+
+    [Fact]
+    public void TraceStore_Backfills_SessionSummaryMetadata_From_StateDbEvents()
+    {
+        var writer = new TraceStore(_tracingPath, 5000, true, _stateRuntime);
+        var startedAt = new DateTimeOffset(2026, 6, 18, 9, 0, 0, TimeSpan.Zero);
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-backfill",
+            Type = TraceEventType.Request,
+            Content = "first backfill request",
+            Timestamp = startedAt
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-backfill",
+            Type = TraceEventType.SessionMetadata,
+            SystemPromptHash = "old-system",
+            ToolSchemaHash = "tools",
+            PromptCacheEventKind = PromptCacheEventKinds.Baseline,
+            Timestamp = startedAt.AddSeconds(1)
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-backfill",
+            Type = TraceEventType.ToolInjection,
+            PromptCacheEventKind = PromptCacheEventKinds.ToolExtension,
+            PromptCacheChangedFields = [PromptCacheChangedFields.Tools],
+            Timestamp = startedAt.AddSeconds(2)
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-backfill",
+            Type = TraceEventType.SessionMetadata,
+            SystemPromptHash = "new-system",
+            ToolSchemaHash = "tools",
+            PromptCacheEventKind = PromptCacheEventKinds.Drift,
+            PromptCacheChangedFields = [PromptCacheChangedFields.Prompt],
+            Timestamp = startedAt.AddSeconds(3)
+        });
+
+        using (var connection = _stateRuntime.OpenConnection())
+        {
+            using (var clear = connection.CreateCommand())
+            {
+                clear.CommandText = """
+                    UPDATE trace_sessions
+                    SET
+                        first_user_request = NULL,
+                        system_prompt_hash = NULL,
+                        tool_schema_hash = NULL,
+                        prompt_drift_count = 0,
+                        session_metadata_captured_at = NULL,
+                        last_prompt_cache_change_at = NULL,
+                        last_prompt_cache_change_kind = NULL,
+                        last_prompt_cache_changed_fields_json = NULL
+                    WHERE session_key = $session_key;
+
+                    DELETE FROM state_info WHERE key = 'trace_sessions.summary_metadata_backfill_v1';
+                    """;
+                clear.Parameters.AddWithValue("$session_key", "thread-backfill");
+                clear.ExecuteNonQuery();
+            }
+
+            using var corrupt = connection.CreateCommand();
+            corrupt.CommandText = """
+                INSERT INTO trace_events(event_id, session_key, timestamp, type, event_json)
+                VALUES ('broken-backfill', $session_key, $timestamp, 'Request', '{ broken json')
+                """;
+            corrupt.Parameters.AddWithValue("$session_key", "thread-backfill");
+            corrupt.Parameters.AddWithValue("$timestamp", startedAt.AddSeconds(-1).UtcDateTime.ToString("O"));
+            corrupt.ExecuteNonQuery();
+        }
+
+        var migratedRuntime = new StateRuntime(_craftPath);
+        var reader = new TraceStore(_tracingPath, 5000, false, migratedRuntime);
+        reader.LoadFromDisk();
+
+        var session = Assert.Single(reader.GetSessions());
+        Assert.Equal("first backfill request", session.FirstUserRequest);
+        Assert.Equal("new-system", session.SystemPromptHash);
+        Assert.Equal("tools", session.ToolSchemaHash);
+        Assert.Equal(1, session.PromptDriftCount);
+        Assert.Equal(startedAt.AddSeconds(3), session.SessionMetadataCapturedAt);
+        Assert.Equal(startedAt.AddSeconds(3), session.LastPromptCacheChangeAt);
         Assert.Equal(PromptCacheEventKinds.Drift, session.LastPromptCacheChangeKind);
         Assert.Equal([PromptCacheChangedFields.Prompt], session.LastPromptCacheChangedFields);
     }

--- a/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
@@ -440,6 +440,16 @@ public sealed class StateBackedStoreTests : IDisposable
         writer.Record(new TraceEvent
         {
             SessionKey = "thread-readonly-legacy",
+            Type = TraceEventType.TokenUsage,
+            InputTokens = 13,
+            OutputTokens = 8,
+            CachedInputTokens = 5,
+            CacheWriteInputTokens = 3,
+            ReasoningOutputTokens = 2
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-readonly-legacy",
             Type = TraceEventType.SessionMetadata,
             SystemPromptHash = "system-hash",
             ToolSchemaHash = "tool-hash",
@@ -456,22 +466,15 @@ public sealed class StateBackedStoreTests : IDisposable
                     started_at TEXT NOT NULL,
                     last_activity_at TEXT NOT NULL,
                     request_count INTEGER NOT NULL DEFAULT 0,
-                    maintenance_fork_request_count INTEGER NOT NULL DEFAULT 0,
                     response_count INTEGER NOT NULL DEFAULT 0,
-                    maintenance_fork_response_count INTEGER NOT NULL DEFAULT 0,
                     tool_call_count INTEGER NOT NULL DEFAULT 0,
                     error_count INTEGER NOT NULL DEFAULT 0,
                     context_compaction_count INTEGER NOT NULL DEFAULT 0,
                     thinking_count INTEGER NOT NULL DEFAULT 0,
-                    token_usage_count INTEGER NOT NULL DEFAULT 0,
                     total_input_tokens INTEGER NOT NULL DEFAULT 0,
                     total_output_tokens INTEGER NOT NULL DEFAULT 0,
-                    total_cached_input_tokens INTEGER NOT NULL DEFAULT 0,
-                    total_cache_write_input_tokens INTEGER NOT NULL DEFAULT 0,
-                    total_reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
                     total_tool_duration_ms INTEGER NOT NULL DEFAULT 0,
                     max_tool_duration_ms INTEGER NOT NULL DEFAULT 0,
-                    max_turn_duration_ms INTEGER NOT NULL DEFAULT 0,
                     last_finish_reason TEXT,
                     final_system_prompt TEXT,
                     tool_names_json TEXT
@@ -482,22 +485,15 @@ public sealed class StateBackedStoreTests : IDisposable
                     started_at,
                     last_activity_at,
                     request_count,
-                    maintenance_fork_request_count,
                     response_count,
-                    maintenance_fork_response_count,
                     tool_call_count,
                     error_count,
                     context_compaction_count,
                     thinking_count,
-                    token_usage_count,
                     total_input_tokens,
                     total_output_tokens,
-                    total_cached_input_tokens,
-                    total_cache_write_input_tokens,
-                    total_reasoning_output_tokens,
                     total_tool_duration_ms,
                     max_tool_duration_ms,
-                    max_turn_duration_ms,
                     last_finish_reason,
                     final_system_prompt,
                     tool_names_json
@@ -507,22 +503,15 @@ public sealed class StateBackedStoreTests : IDisposable
                     started_at,
                     last_activity_at,
                     request_count,
-                    maintenance_fork_request_count,
                     response_count,
-                    maintenance_fork_response_count,
                     tool_call_count,
                     error_count,
                     context_compaction_count,
                     thinking_count,
-                    token_usage_count,
                     total_input_tokens,
                     total_output_tokens,
-                    total_cached_input_tokens,
-                    total_cache_write_input_tokens,
-                    total_reasoning_output_tokens,
                     total_tool_duration_ms,
                     max_tool_duration_ms,
-                    max_turn_duration_ms,
                     last_finish_reason,
                     final_system_prompt,
                     tool_names_json
@@ -540,12 +529,36 @@ public sealed class StateBackedStoreTests : IDisposable
         Assert.True(stores.UsesStateDb);
         Assert.Equal("thread-readonly-legacy", session.SessionKey);
         Assert.Equal(1, session.RequestCount);
+        Assert.Equal(0, session.MaintenanceForkRequestCount);
+        Assert.Equal(0, session.TokenUsageCount);
+        Assert.Equal(13, session.TotalInputTokens);
+        Assert.Equal(8, session.TotalOutputTokens);
+        Assert.Equal(0, session.TotalCachedInputTokens);
+        Assert.Equal(0, session.TotalCacheWriteInputTokens);
+        Assert.Equal(0, session.TotalReasoningOutputTokens);
+        Assert.Equal(0, session.MaxTurnDurationMs);
         Assert.Null(session.FirstUserRequest);
         Assert.Null(session.SystemPromptHash);
         Assert.Null(session.ToolSchemaHash);
         Assert.Equal(0, session.PromptDriftCount);
         Assert.Null(session.LastPromptCacheChangeKind);
         Assert.Empty(session.LastPromptCacheChangedFields);
+
+        var summary = stores.TraceStore.GetSummary();
+        Assert.Equal(1, summary.SessionCount);
+        Assert.Equal(1, summary.TotalRequests);
+        Assert.Equal(0, summary.TotalMaintenanceForkRequests);
+        Assert.Equal(13, summary.TotalInputTokens);
+        Assert.Equal(8, summary.TotalOutputTokens);
+        Assert.Equal(0, summary.TotalCachedInputTokens);
+        Assert.Equal(0, summary.TotalCacheWriteInputTokens);
+        Assert.Equal(0, summary.TotalReasoningOutputTokens);
+        Assert.Equal(0, summary.MaxTurnDurationMs);
+        Assert.Equal(0, stores.TraceStore.GetLongestTurnDurationMs());
+
+        var usage = Assert.Single(stores.TraceStore.GetDailyUsage(null, null, 0));
+        Assert.Equal(13, usage.InputTokens);
+        Assert.Equal(8, usage.OutputTokens);
     }
 
     [Fact]

--- a/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DotCraft.DashBoard;
 using DotCraft.State;
 using DotCraft.Protocol;
 using DotCraft.Tracing;
@@ -424,6 +425,127 @@ public sealed class StateBackedStoreTests : IDisposable
         Assert.Equal(startedAt.AddSeconds(3), session.LastPromptCacheChangeAt);
         Assert.Equal(PromptCacheEventKinds.Drift, session.LastPromptCacheChangeKind);
         Assert.Equal([PromptCacheChangedFields.Prompt], session.LastPromptCacheChangedFields);
+    }
+
+    [Fact]
+    public void DashBoardReadOnlyStoreLoader_Tolerates_Unmigrated_TraceSessionSummaryColumns()
+    {
+        var writer = new TraceStore(_tracingPath, 5000, true, _stateRuntime);
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-readonly-legacy",
+            Type = TraceEventType.Request,
+            Content = "legacy preview"
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-readonly-legacy",
+            Type = TraceEventType.SessionMetadata,
+            SystemPromptHash = "system-hash",
+            ToolSchemaHash = "tool-hash",
+            PromptCacheEventKind = PromptCacheEventKinds.Drift,
+            PromptCacheChangedFields = [PromptCacheChangedFields.Prompt]
+        });
+
+        using (var connection = _stateRuntime.OpenConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                CREATE TABLE trace_sessions_legacy (
+                    session_key TEXT PRIMARY KEY,
+                    started_at TEXT NOT NULL,
+                    last_activity_at TEXT NOT NULL,
+                    request_count INTEGER NOT NULL DEFAULT 0,
+                    maintenance_fork_request_count INTEGER NOT NULL DEFAULT 0,
+                    response_count INTEGER NOT NULL DEFAULT 0,
+                    maintenance_fork_response_count INTEGER NOT NULL DEFAULT 0,
+                    tool_call_count INTEGER NOT NULL DEFAULT 0,
+                    error_count INTEGER NOT NULL DEFAULT 0,
+                    context_compaction_count INTEGER NOT NULL DEFAULT 0,
+                    thinking_count INTEGER NOT NULL DEFAULT 0,
+                    token_usage_count INTEGER NOT NULL DEFAULT 0,
+                    total_input_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_output_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_cache_write_input_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_reasoning_output_tokens INTEGER NOT NULL DEFAULT 0,
+                    total_tool_duration_ms INTEGER NOT NULL DEFAULT 0,
+                    max_tool_duration_ms INTEGER NOT NULL DEFAULT 0,
+                    max_turn_duration_ms INTEGER NOT NULL DEFAULT 0,
+                    last_finish_reason TEXT,
+                    final_system_prompt TEXT,
+                    tool_names_json TEXT
+                );
+
+                INSERT INTO trace_sessions_legacy (
+                    session_key,
+                    started_at,
+                    last_activity_at,
+                    request_count,
+                    maintenance_fork_request_count,
+                    response_count,
+                    maintenance_fork_response_count,
+                    tool_call_count,
+                    error_count,
+                    context_compaction_count,
+                    thinking_count,
+                    token_usage_count,
+                    total_input_tokens,
+                    total_output_tokens,
+                    total_cached_input_tokens,
+                    total_cache_write_input_tokens,
+                    total_reasoning_output_tokens,
+                    total_tool_duration_ms,
+                    max_tool_duration_ms,
+                    max_turn_duration_ms,
+                    last_finish_reason,
+                    final_system_prompt,
+                    tool_names_json
+                )
+                SELECT
+                    session_key,
+                    started_at,
+                    last_activity_at,
+                    request_count,
+                    maintenance_fork_request_count,
+                    response_count,
+                    maintenance_fork_response_count,
+                    tool_call_count,
+                    error_count,
+                    context_compaction_count,
+                    thinking_count,
+                    token_usage_count,
+                    total_input_tokens,
+                    total_output_tokens,
+                    total_cached_input_tokens,
+                    total_cache_write_input_tokens,
+                    total_reasoning_output_tokens,
+                    total_tool_duration_ms,
+                    max_tool_duration_ms,
+                    max_turn_duration_ms,
+                    last_finish_reason,
+                    final_system_prompt,
+                    tool_names_json
+                FROM trace_sessions;
+
+                DROP TABLE trace_sessions;
+                ALTER TABLE trace_sessions_legacy RENAME TO trace_sessions;
+                """;
+            command.ExecuteNonQuery();
+        }
+
+        var stores = DashBoardReadOnlyStoreLoader.Load(_craftPath);
+        var session = Assert.Single(stores.TraceStore.GetSessions());
+
+        Assert.True(stores.UsesStateDb);
+        Assert.Equal("thread-readonly-legacy", session.SessionKey);
+        Assert.Equal(1, session.RequestCount);
+        Assert.Null(session.FirstUserRequest);
+        Assert.Null(session.SystemPromptHash);
+        Assert.Null(session.ToolSchemaHash);
+        Assert.Equal(0, session.PromptDriftCount);
+        Assert.Null(session.LastPromptCacheChangeKind);
+        Assert.Empty(session.LastPromptCacheChangedFields);
     }
 
     [Fact]

--- a/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
@@ -85,6 +85,41 @@ public sealed class StateBackedStoreTests : IDisposable
     }
 
     [Fact]
+    public void TraceStore_StateDbSummary_DoesNotRequire_EventJson_Load()
+    {
+        var writer = new TraceStore(_tracingPath, 5000, true, _stateRuntime);
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-summary-only",
+            Type = TraceEventType.Request,
+            Content = "hello"
+        });
+        writer.Record(new TraceEvent
+        {
+            SessionKey = "thread-summary-only",
+            Type = TraceEventType.TokenUsage,
+            InputTokens = 11,
+            OutputTokens = 7
+        });
+
+        using (var connection = _stateRuntime.OpenConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "UPDATE trace_events SET event_json = '{ broken json' WHERE session_key = $session_key";
+            command.Parameters.AddWithValue("$session_key", "thread-summary-only");
+            command.ExecuteNonQuery();
+        }
+
+        var reader = new TraceStore(_tracingPath, 5000, false, _stateRuntime);
+        reader.LoadFromDisk();
+
+        var summary = reader.GetSummary();
+        Assert.Equal(1, summary.SessionCount);
+        Assert.Equal(1, summary.TotalRequests);
+        Assert.Equal(18, summary.TotalTokens);
+    }
+
+    [Fact]
     public void TraceStore_PageQuery_Returns_Latest_StateDb_Events_Beyond_InMemory_Cap()
     {
         var writer = new TraceStore(_tracingPath, 5000, true, _stateRuntime);


### PR DESCRIPTION
- Optimizes DotCraft startup memory usage by avoiding full deserialization of historical trace events; summaries now read from SQLite and events are loaded on demand.  
- Also removes eager thread attachment index rebuilding on startup and reduces GPU/rendering overhead for the standalone tray process.

Refs #48 