### PR TITLE
fix: desktop startup foreground restore

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -86,8 +86,7 @@ import {
 import {
   NO_WORKSPACE_ARG,
   hasRemoteEndpointArg,
-  resolveWorkspacePathFromArgs,
-  shouldOpenDefaultChatWorkspaceOnStartup
+  resolveStartupWorkspacePath
 } from './workspaceArgs'
 import {
   ensureDefaultChatWorkspace,
@@ -777,27 +776,22 @@ browserUseManager.setPolicyHost({
   updateSettings: updateSharedSettings
 })
 
-function resolveWorkspacePath(settings: AppSettings): string | null {
-  return resolveWorkspacePathFromArgs(settings, process.argv, existsSync)
-}
-
 function resolveConnectionMode(settings: AppSettings): ConnectionMode {
   const mode = settings.connectionMode
   return mode === 'remote' ? 'remote' : 'local'
 }
 
 function resolveInitialWorkspacePath(settings: AppSettings): string | null {
-  const workspacePath = resolveWorkspacePath(settings)
-  if (!shouldOpenDefaultChatWorkspaceOnStartup(
+  const workspacePath = resolveStartupWorkspacePath(
     settings,
     process.argv,
     existsSync,
+    resolveDefaultChatWorkspacePath(),
     resolveConnectionMode(settings)
-  )) {
-    return workspacePath
-  }
-
-  return ensureDefaultChatWorkspace()
+  )
+  return workspacePath && isDefaultChatWorkspace(workspacePath)
+    ? ensureDefaultChatWorkspace()
+    : workspacePath
 }
 
 function workspaceTitleName(workspacePath: string | null | undefined, locale: AppLocale): string {
@@ -2382,6 +2376,8 @@ function buildCallbacks(): IpcHandlerCallbacks {
       // Ensure its skeleton first so it never diverts into the setup wizard.
       if (isDefaultChatWorkspace(newPath)) {
         ensureDefaultChatWorkspace()
+        sharedSettings.lastForegroundEntry = 'chats'
+        saveSettings(sharedSettings)
       } else {
         addRecentWorkspace(sharedSettings, newPath)
         saveSettings(sharedSettings)
@@ -2515,7 +2511,7 @@ async function clearWorkspaceSelection(): Promise<void> {
   setViewerWorkspaceRoot('')
   currentWorkspacePath = ''
   ensureWorkspaceActivation('')
-  delete sharedSettings.lastWorkspacePath
+  sharedSettings.lastForegroundEntry = 'welcome'
   saveSettings(sharedSettings)
 
   const win = mainWindow
@@ -2992,7 +2988,10 @@ app.whenReady().then(async () => {
     if (!initialActiveStack) {
       acquireWorkspaceLock(workspacePath)
     }
-    if (!isDefaultChatWorkspace(workspacePath)) {
+    if (isDefaultChatWorkspace(workspacePath)) {
+      sharedSettings.lastForegroundEntry = 'chats'
+      saveSettings(sharedSettings)
+    } else {
       addRecentWorkspace(sharedSettings, workspacePath)
       saveSettings(sharedSettings)
     }
@@ -3054,7 +3053,10 @@ app.whenReady().then(async () => {
         if (!activeStack) {
           acquireWorkspaceLock(wsPath)
         }
-        if (!isDefaultChatWorkspace(wsPath)) {
+        if (isDefaultChatWorkspace(wsPath)) {
+          sharedSettings.lastForegroundEntry = 'chats'
+          saveSettings(sharedSettings)
+        } else {
           addRecentWorkspace(sharedSettings, wsPath)
           saveSettings(sharedSettings)
         }

--- a/desktop/src/main/settings.ts
+++ b/desktop/src/main/settings.ts
@@ -29,6 +29,7 @@ export interface RecentWorkspace {
 export type UiTheme = 'system' | 'dark' | 'light'
 export type ConnectionMode = 'local' | 'remote'
 export type BinarySource = 'bundled' | 'path' | 'custom'
+export type LastForegroundEntry = 'workspace' | 'chats' | 'welcome'
 export type LastOpenEditorId =
   | 'explorer'
   | 'vs'
@@ -76,6 +77,7 @@ export interface ProfileSettings {
 
 export interface AppSettings {
   lastWorkspacePath?: string
+  lastForegroundEntry?: LastForegroundEntry
   modulesDirectory?: string
   activeModuleVariants?: Record<string, string>
   binarySource?: BinarySource
@@ -329,6 +331,13 @@ function normalizeActiveRemoteStack(settings: AppSettings): ActiveRemoteStackSet
   return hostId && stackId ? { hostId, stackId } : undefined
 }
 
+function normalizeLastForegroundEntry(settings: AppSettings): LastForegroundEntry | undefined {
+  const value = settings.lastForegroundEntry
+  return value === 'workspace' || value === 'chats' || value === 'welcome'
+    ? value
+    : undefined
+}
+
 export function normalizePinnedThreadIdsByWorkspace(settings: AppSettings): Record<string, string[]> | undefined {
   const raw = settings.pinnedThreadIdsByWorkspace
   if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -370,6 +379,7 @@ export function loadSettings(): AppSettings {
   try {
     if (existsSync(filePath)) {
       const raw = JSON.parse(readFileSync(filePath, 'utf8')) as AppSettings
+      raw.lastForegroundEntry = normalizeLastForegroundEntry(raw)
       raw.binarySource = normalizeBinarySource(raw)
       raw.connectionMode = normalizeConnectionMode(raw)
       raw.modulesDirectory = normalizeModulesDirectory(raw)
@@ -417,6 +427,7 @@ export function saveSettings(settings: AppSettings): void {
     const dir = join(filePath, '..')
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
     settings.binarySource = normalizeBinarySource(settings)
+    settings.lastForegroundEntry = normalizeLastForegroundEntry(settings)
     settings.connectionMode = normalizeConnectionMode(settings)
     settings.modulesDirectory = normalizeModulesDirectory(settings)
     settings.lastOpenEditorId = normalizeLastOpenEditorId(settings)
@@ -467,6 +478,7 @@ export function addRecentWorkspace(settings: AppSettings, workspacePath: string)
   const filtered = existing.filter((r) => !sameWorkspaceProjectKey(r.path, workspacePath))
   settings.recentWorkspaces = [entry, ...filtered].slice(0, MAX_RECENT)
   settings.lastWorkspacePath = workspacePath
+  settings.lastForegroundEntry = 'workspace'
   return settings
 }
 

--- a/desktop/src/main/tests/workspaceArgs.test.ts
+++ b/desktop/src/main/tests/workspaceArgs.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   NO_WORKSPACE_ARG,
-  resolveWorkspacePathFromArgs,
-  shouldOpenDefaultChatWorkspaceOnStartup
+  resolveStartupWorkspacePath,
+  resolveWorkspacePathFromArgs
 } from '../workspaceArgs'
+
+const defaultChatsPath = 'C:/Users/me/.craft/workspaces/chats'
 
 describe('workspace argument resolution', () => {
   it('uses the last workspace when no explicit workspace mode is provided', () => {
@@ -41,40 +43,90 @@ describe('workspace argument resolution', () => {
     )).toBe('E:/linked')
   })
 
-  it('uses the default chat workspace only for ordinary local startup with no workspace', () => {
-    expect(shouldOpenDefaultChatWorkspaceOnStartup(
+  it('shows welcome on first launch with no foreground entry or legacy workspace', () => {
+    expect(resolveStartupWorkspacePath(
       {},
       ['electron', 'main.js'],
       () => false,
+      defaultChatsPath,
       'local'
-    )).toBe(true)
+    )).toBeNull()
+  })
 
-    expect(shouldOpenDefaultChatWorkspaceOnStartup(
+  it('restores a legacy last workspace when no foreground entry has been recorded yet', () => {
+    const exists = vi.fn(() => true)
+
+    expect(resolveStartupWorkspacePath(
       { lastWorkspacePath: 'E:/recent' },
       ['electron', 'main.js'],
-      () => true,
+      exists,
+      defaultChatsPath,
       'local'
-    )).toBe(false)
+    )).toBe('E:/recent')
+    expect(exists).toHaveBeenCalledWith('E:/recent')
+  })
 
-    expect(shouldOpenDefaultChatWorkspaceOnStartup(
-      { lastWorkspacePath: 'E:/recent' },
+  it('restores Chats when it was the last foreground entry', () => {
+    const exists = vi.fn(() => true)
+
+    expect(resolveStartupWorkspacePath(
+      { lastForegroundEntry: 'chats', lastWorkspacePath: 'E:/recent' },
+      ['electron', 'main.js'],
+      exists,
+      defaultChatsPath,
+      'local'
+    )).toBe(defaultChatsPath)
+    expect(exists).not.toHaveBeenCalled()
+  })
+
+  it('keeps the welcome chooser when it was the last foreground entry', () => {
+    const exists = vi.fn(() => true)
+
+    expect(resolveStartupWorkspacePath(
+      { lastForegroundEntry: 'welcome', lastWorkspacePath: 'E:/recent' },
+      ['electron', 'main.js'],
+      exists,
+      defaultChatsPath,
+      'local'
+    )).toBeNull()
+    expect(exists).not.toHaveBeenCalled()
+  })
+
+  it('lets explicit startup targets override the recorded foreground entry', () => {
+    expect(resolveStartupWorkspacePath(
+      { lastForegroundEntry: 'welcome', lastWorkspacePath: 'E:/recent' },
+      ['electron', 'main.js', '--workspace', 'E:/arg'],
+      () => true,
+      defaultChatsPath,
+      'local'
+    )).toBe('E:/arg')
+
+    expect(resolveStartupWorkspacePath(
+      { lastForegroundEntry: 'welcome', lastWorkspacePath: 'E:/recent' },
+      ['electron', 'main.js', 'dotcraft://workspace/open?path=E%3A%2Flinked'],
+      () => true,
+      defaultChatsPath,
+      'local'
+    )).toBe('E:/linked')
+  })
+
+  it('lets no-workspace suppress the recorded foreground entry', () => {
+    expect(resolveStartupWorkspacePath(
+      { lastForegroundEntry: 'chats', lastWorkspacePath: 'E:/recent' },
       ['electron', 'main.js', NO_WORKSPACE_ARG],
       () => true,
+      defaultChatsPath,
       'local'
-    )).toBe(false)
+    )).toBeNull()
+  })
 
-    expect(shouldOpenDefaultChatWorkspaceOnStartup(
-      {},
-      ['electron', 'main.js'],
-      () => false,
-      'remote'
-    )).toBe(false)
-
-    expect(shouldOpenDefaultChatWorkspaceOnStartup(
-      {},
+  it('does not restore Chats for remote endpoint startup', () => {
+    expect(resolveStartupWorkspacePath(
+      { lastForegroundEntry: 'chats' },
       ['electron', 'main.js', '--remote', 'ws://127.0.0.1:9100/ws'],
       () => false,
+      defaultChatsPath,
       'local'
-    )).toBe(false)
+    )).toBeNull()
   })
 })

--- a/desktop/src/main/workspaceArgs.ts
+++ b/desktop/src/main/workspaceArgs.ts
@@ -13,11 +13,7 @@ export function hasRemoteEndpointArg(argv: readonly string[] = process.argv): bo
   return remoteIdx !== -1 && Boolean(argv[remoteIdx + 1])
 }
 
-export function resolveWorkspacePathFromArgs(
-  settings: AppSettings,
-  argv: readonly string[] = process.argv,
-  pathExists: (path: string) => boolean = existsSync
-): string | null {
+function resolveExplicitWorkspacePathFromArgs(argv: readonly string[]): string | null {
   const workspaceOpen = findWorkspaceOpenDeepLink(argv)
   if (workspaceOpen) {
     return workspaceOpen.workspacePath
@@ -28,7 +24,18 @@ export function resolveWorkspacePathFromArgs(
     return argv[argIdx + 1]
   }
 
-  if (argv.includes(NO_WORKSPACE_ARG)) {
+  return null
+}
+
+export function resolveWorkspacePathFromArgs(
+  settings: AppSettings,
+  argv: readonly string[] = process.argv,
+  pathExists: (path: string) => boolean = existsSync
+): string | null {
+  const explicitWorkspacePath = resolveExplicitWorkspacePathFromArgs(argv)
+  if (explicitWorkspacePath) return explicitWorkspacePath
+
+  if (hasNoWorkspaceArg(argv)) {
     return null
   }
 
@@ -39,14 +46,36 @@ export function resolveWorkspacePathFromArgs(
   return null
 }
 
-export function shouldOpenDefaultChatWorkspaceOnStartup(
+export function resolveStartupWorkspacePath(
   settings: AppSettings,
   argv: readonly string[] = process.argv,
   pathExists: (path: string) => boolean = existsSync,
+  defaultChatWorkspacePath = '',
   connectionMode: 'local' | 'remote' = 'local'
-): boolean {
-  if (connectionMode !== 'local') return false
-  if (hasNoWorkspaceArg(argv)) return false
-  if (hasRemoteEndpointArg(argv)) return false
-  return resolveWorkspacePathFromArgs(settings, argv, pathExists) == null
+): string | null {
+  const explicitWorkspacePath = resolveExplicitWorkspacePathFromArgs(argv)
+  if (explicitWorkspacePath) return explicitWorkspacePath
+
+  if (hasNoWorkspaceArg(argv)) {
+    return null
+  }
+
+  if (
+    connectionMode === 'local' &&
+    !hasRemoteEndpointArg(argv) &&
+    settings.lastForegroundEntry === 'chats' &&
+    defaultChatWorkspacePath.trim()
+  ) {
+    return defaultChatWorkspacePath
+  }
+
+  if (settings.lastForegroundEntry === 'welcome') {
+    return null
+  }
+
+  if (settings.lastWorkspacePath && pathExists(settings.lastWorkspacePath)) {
+    return settings.lastWorkspacePath
+  }
+
+  return null
 }

--- a/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -85,10 +85,14 @@ export function ThreadList({
   const dragHintTitle =
     dragActive?.kind === 'automation-task' ? dragActive.title : null
 
-  const showProjects = projects.length > 0
   // The default Chat workspace is surfaced as a dedicated `Chats` group sibling to
   // `Projects`. Once present it drives the same grouped layout so Chats always shows.
   const showChats = chat != null
+  const hasProjectRows = projects.length > 0
+  const chatIsCurrentWorkspace =
+    chat != null &&
+    sameWorkspacePath(chat.path, workspacePath || foregroundWorkspacePath || foregroundProjectId)
+  const showProjects = hasProjectRows || showChats
   const showGroupedLayout = showProjects || showChats
 
   if (loading && !showGroupedLayout) {
@@ -218,7 +222,7 @@ export function ThreadList({
         )}
         {showProjects && (
           <ProjectsSectionHeader
-            workspacePath={workspacePath || foregroundWorkspacePath}
+            workspacePath={hasProjectRows || !chatIsCurrentWorkspace ? (workspacePath || foregroundWorkspacePath) : ''}
             localWorkspacePath={localWorkspacePath}
             localActionsDisabled={localActionsDisabled}
             collapsed={projectsSectionCollapsed}

--- a/desktop/src/renderer/tests/ThreadListProjects.test.tsx
+++ b/desktop/src/renderer/tests/ThreadListProjects.test.tsx
@@ -1020,6 +1020,40 @@ describe('ThreadList project-first layout', () => {
     expect(screen.getByText('No chats')).toBeInTheDocument()
   })
 
+  it('keeps the Projects header available when Chats is foreground with no projects', async () => {
+    useWorkspaceProjectsStore.getState().setPayload({
+      foregroundWorkspacePath: '/chats',
+      foregroundProjectId: '/chats',
+      secondaryLimit: 8,
+      projects: [],
+      chat: {
+        projectId: '/chats',
+        kind: 'chat',
+        path: '/chats',
+        identityWorkspacePath: '/chats',
+        name: '/chats',
+        state: 'foreground',
+        running: true,
+        loaded: true,
+        threadCount: 0,
+        threads: [],
+        pinnedThreadIds: []
+      }
+    })
+
+    renderList({ workspacePath: '/chats' })
+
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+    expect(screen.getByText('Chats')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Workspace options' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '/chats' })).not.toBeInTheDocument()
+
+    fireEvent.mouseEnter(screen.getByText('Projects').parentElement as HTMLElement)
+    fireEvent.click(screen.getByRole('button', { name: 'Add project' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Use an existing folder' })).toBeInTheDocument()
+  })
+
   it('New chat in the Chats group switches to the chat workspace and opens a new chat', async () => {
     useThreadStore.getState().setActiveThreadId('old-thread')
     useWorkspaceProjectsStore.getState().setPayload({

--- a/desktop/src/renderer/tests/m7.test.ts
+++ b/desktop/src/renderer/tests/m7.test.ts
@@ -95,6 +95,7 @@ describe('recent workspaces LRU', () => {
     expect(recents).toHaveLength(1)
     expect(recents[0].path).toBe('/path/to/workspace-a')
     expect(recents[0].name).toBe('workspace-a')
+    expect(settings.lastForegroundEntry).toBe('workspace')
   })
 
   it('moves an existing workspace to the front on re-open', () => {


### PR DESCRIPTION
This PR updates desktop startup and sidebar behavior to restore the last foreground entry, whether Welcome, Chats, or a project, while keeping the Projects section and add-project entry available inside Chats.