### PR TITLE
feat(session): unify rollout serialization and harden replay safety

### DIFF
--- a/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/context-handoff/SKILL.md
+++ b/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/context-handoff/SKILL.md
@@ -55,7 +55,9 @@ dotcraft context export --thread thread_20260601_ab12cd --profile transcript --t
 ## What The Export Handles
 
 - Surviving rollout turns after rollback are exported; rolled-back tail turns are not treated as current context.
-- Compaction checkpoints are listed as continuity events. The latest surviving checkpoint is used to reconstruct current model-visible context when it can be decoded.
+- Current model context uses the same canonical rollout replay as runtime hydration: the latest decodable surviving checkpoint plus valid tail model history, with whole-Turn UI fallback when an exact batch is rejected.
+- Compaction checkpoints are listed as continuity events. Malformed checkpoints are skipped while replay continues toward an earlier valid checkpoint.
+- Replay warnings identify rejected records and fallback Turns without exposing reasoning, ProtectedData, AdditionalProperties, or internal provider metadata.
 - `MEMORY.md` is included, and `HISTORY.md` follows the selected `--history` mode.
 - Reasoning content is omitted. Tool calls are kept, and tool results follow `--tool-results`.
 

--- a/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/SKILL.md
+++ b/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/SKILL.md
@@ -7,11 +7,11 @@ description: Diagnose DotCraft LLM, agent, tool-call, LiteLLM, provider, context
 
 ## Overview
 
-Use this skill to reconstruct what happened during a failed DotCraft turn from persisted evidence. Treat `.craft/threads/.../*.jsonl` as the canonical UI/session rollout and `.craft/state.db` as queryable metadata, serialized agent session state, trace events, bindings, usage, goals, plans, and attachments.
+Use this skill to reconstruct what happened during a failed DotCraft turn from persisted evidence. Treat `.craft/threads/.../*.jsonl` as the authority for thread, turn, item, compaction, and model-history state. Treat `.craft/state.db` as queryable projections, runtime continuity state, traces, and independent business state such as goals, plans, spawn edges, and the subagent mailbox.
 
 ## Safety Rules
 
-- Work read-only unless the user explicitly asks for a repair. Do not edit `state.db`, thread JSONL, or serialized `thread_sessions.session_json` during diagnosis.
+- Work read-only unless the user explicitly asks for a repair. Do not edit `state.db` or thread JSONL during diagnosis.
 - Avoid dumping full user or assistant content. Prefer IDs, timestamps, event kinds, item types, tool names, status, token counts, and short error previews.
 - Copy the DB and thread file to a temporary location before experimental queries if a tool might open SQLite in write mode.
 - Preserve the evidence chain: every conclusion should cite the source table, event ID, line number, timestamp, or item ID that supports it.
@@ -59,25 +59,27 @@ sqlite3 "file:D:\path\to\workspace\.craft\state.db?mode=ro" `
    - Check whether the rollout path in DB points to the file being inspected.
 
 2. **Build the rollout timeline**
-   - Group JSONL records by `kind`: `thread_opened`, `turn_started`, `item_appended`, `turn_completed`, queued-input events, and status/name changes.
-   - For `item_appended`, count item `type` values such as `UserMessage`, `AgentMessage`, `ToolCall`, `ToolExecution`, `ToolResult`, `CommandExecution`, and `Error`.
-   - Locate explicit `Error` items and their `turnId`, `itemId`, timestamp, status, and payload keys.
+   - Apply `turn_state_replaced` by Turn ID and let it replace earlier incremental state for that Turn.
+   - Apply `thread_rolled_back` before reporting Turns; ignore rolled-back tail Turns as current evidence.
+   - Count `UserMessage`, `AgentMessage`, `ToolCall`, `ToolExecution`, `ToolResult`, `CommandExecution`, and `Error` only from surviving replacement state.
+   - Summarize model-history batches only by Turn, message count, schema version, content kinds, and rejected status. Never print model payloads, ProtectedData, or AdditionalProperties.
+   - Summarize compaction checkpoints only by boundary, message count, and decode status. Never print replacement history.
 
 3. **Correlate trace storage**
    - Read `trace_session_bindings` for `root_thread_id = thread_id`. The main session often has `binding_kind = threadMain`; subagents and maintenance forks may have different session keys.
    - For each session key, inspect `trace_sessions` counters: `request_count`, `response_count`, `tool_call_count`, `error_count`, token totals, and `last_finish_reason`.
    - Query `trace_events` by `session_key` and timestamp. Prioritize events with `type = 'Error'`, tool failures, unusual finish reasons, or a failed request immediately before the rollout `Error` item.
 
-4. **Inspect context and session shape**
+4. **Inspect context and recovery shape**
    - Use `thread_context_usage` to check whether context size or message count is suspicious.
-   - Confirm `thread_sessions` has a row and recent `updated_at`; do not print the full `session_json` unless the user explicitly asks.
-   - When resume behavior is involved, compare `thread_sessions.updated_at`, `threads.updated_at`, and the last rollout `turn_completed`.
+   - Use model-history and checkpoint decode status from the rollout to assess resume behavior.
+   - Treat `thread_sessions` as optional legacy evidence only. Its absence is normal and it must not participate in freshness or persistence-mismatch decisions.
 
 5. **Classify the failure**
    - **Provider/API error**: Trace `Error` content mentions HTTP status, provider, unsupported params, rate limit, authentication, model, or payload validation.
    - **Tool error**: The last `ToolCallCompleted`, `ToolResult`, or `CommandExecution` before the failure contains an exception, non-zero exit, timeout, or malformed output.
-   - **Persistence mismatch**: DB `threads.rollout_path`, rollout file location, `thread_sessions.updated_at`, or `turn_count` disagrees with the JSONL timeline.
-   - **Context/session error**: Context usage is extreme, compaction events appear around the failure, or serialized session state is missing/stale.
+   - **Persistence mismatch**: DB `threads.rollout_path`, projected offset or `turn_count` disagrees with the JSONL timeline.
+   - **Context/session error**: Context usage is extreme, model-history records are rejected, or no valid compaction checkpoint can be decoded.
    - **Adapter/channel error**: `origin_channel`, `channel_context`, queued input events, or status transitions show the failure happened outside model execution.
 
 6. **Recommend the fix**

--- a/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/scripts/analyze_dotcraft_thread.py
+++ b/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/scripts/analyze_dotcraft_thread.py
@@ -7,11 +7,12 @@ import argparse
 import collections
 import datetime as dt
 import json
-import os
 import pathlib
+import re
 import sqlite3
 import sys
 from typing import Any
+from urllib.parse import quote
 
 
 ERROR_NEEDLES = (
@@ -55,21 +56,63 @@ MODEL_CONTENT_KINDS = {
 }
 
 SENSITIVE_PROPERTY_KEYS = {
+    "access_token",
     "additionalproperties",
+    "api_key",
+    "apikey",
+    "authorization",
+    "channel_context",
+    "client_secret",
+    "cookie",
+    "credential",
+    "credentials",
+    "event_json",
+    "final_system_prompt",
+    "password",
+    "private_key",
     "protecteddata",
     "rawrepresentation",
+    "secret",
+    "system_prompt",
+    "token",
 }
+
+SENSITIVE_KEY_NORMALIZED = {
+    key.replace("_", "").replace("-", "").lower() for key in SENSITIVE_PROPERTY_KEYS
+}
+SECRET_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)(\b(?:api[_-]?key|access[_-]?token|client[_-]?secret|password|secret|token)\s*[:=]\s*)[^\s,;]+"),
+    re.compile(r"\b(?:sk|gh[pousr]|xox[baprs])-[-_A-Za-z0-9]{8,}\b"),
+)
+
+
+def is_sensitive_key(key: Any) -> bool:
+    normalized = str(key).replace("_", "").replace("-", "").lower()
+    return normalized in SENSITIVE_KEY_NORMALIZED
+
+
+def redact_text(value: str) -> str:
+    redacted = value
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub(
+            lambda match: (match.group(1) if match.lastindex else "") + "[REDACTED]",
+            redacted,
+        )
+    return redacted
 
 
 def sanitize_diagnostic_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {
-            key: sanitize_diagnostic_value(nested)
+            str(key): "[REDACTED]" if is_sensitive_key(key) else sanitize_diagnostic_value(nested)
             for key, nested in value.items()
-            if str(key).replace("_", "").lower() not in SENSITIVE_PROPERTY_KEYS
+            if not is_sensitive_key(key) or str(key).replace("_", "").lower() not in {"eventjson", "channelcontext", "finalsystemprompt"}
         }
     if isinstance(value, list):
         return [sanitize_diagnostic_value(nested) for nested in value]
+    if isinstance(value, str):
+        return redact_text(value)
     return value
 
 
@@ -80,6 +123,21 @@ def get_turn_id(payload: Any, line_number: int) -> str:
     if isinstance(turn, dict) and turn.get("id"):
         return str(turn["id"])
     return str(payload.get("turnId") or payload.get("id") or f"line:{line_number}")
+
+
+def object_payload(record: dict[str, Any], payload_name: str, line_number: int, result: dict[str, Any]) -> dict[str, Any] | None:
+    payload = record.get(payload_name)
+    if payload is None:
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    result["parse_errors"].append(
+        {
+            "line": line_number,
+            "error": f"{payload_name} must be a JSON object",
+        }
+    )
+    return None
 
 
 def summarize_item(
@@ -216,6 +274,14 @@ def preview(value: Any, limit: int) -> str:
     return text[: max(0, limit - 3)] + "..."
 
 
+def iter_text_lines(path: pathlib.Path, result: dict[str, Any]):
+    try:
+        with path.open("r", encoding="utf-8-sig") as handle:
+            yield from enumerate(handle, start=1)
+    except (OSError, UnicodeError) as exc:
+        result["read_error"] = f"{type(exc).__name__}: {exc}"
+
+
 def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, Any]:
     if path is None:
         return {}
@@ -244,8 +310,7 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
     active_turns: dict[str, dict[str, Any]] = {}
     turn_items: dict[str, list[dict[str, Any]]] = {}
 
-    with path.open("r", encoding="utf-8-sig") as handle:
-        for line_number, raw in enumerate(handle, start=1):
+    for line_number, raw in iter_text_lines(path, result):
             result["line_count"] = line_number
             raw = raw.strip()
             if not raw:
@@ -272,37 +337,48 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
                 )
 
             if kind == "turn_started":
-                payload = record.get("turnStarted") or {}
-                turn_id = get_turn_id(payload, line_number)
-                active_turns.setdefault(turn_id, {"turn_id": turn_id})
-                active_turns[turn_id].update({"started_at": timestamp, "start_line": line_number})
+                payload = object_payload(record, "turnStarted", line_number, result)
+                if payload is not None:
+                    turn_id = get_turn_id(payload, line_number)
+                    active_turns.setdefault(turn_id, {"turn_id": turn_id})
+                    active_turns[turn_id].update({"started_at": timestamp, "start_line": line_number})
             elif kind == "turn_completed":
-                payload = record.get("turnCompleted") or {}
-                turn_id = get_turn_id(payload, line_number)
-                active_turns.setdefault(turn_id, {"turn_id": turn_id})
-                active_turns[turn_id].update(
-                    {
-                        "completed_at": timestamp,
-                        "completed_line": line_number,
-                        "status": payload.get("status"),
-                    }
-                )
+                payload = object_payload(record, "turnCompleted", line_number, result)
+                if payload is not None:
+                    turn_id = get_turn_id(payload, line_number)
+                    active_turns.setdefault(turn_id, {"turn_id": turn_id})
+                    active_turns[turn_id].update(
+                        {
+                            "completed_at": timestamp,
+                            "completed_line": line_number,
+                            "status": payload.get("status"),
+                        }
+                    )
             elif kind == "item_appended":
-                payload = record.get("itemAppended") or {}
-                item = payload.get("item") or {}
-                item_type = item.get("type") or "(missing)"
-                item_type_counts[item_type] += 1
-                turn_id = payload.get("turnId") or item.get("turnId")
-                if turn_id:
-                    turn = active_turns.setdefault(turn_id, {"turn_id": turn_id})
-                    turn["last_item_line"] = line_number
-                    turn["last_item_type"] = item_type
-                    turn["last_item_id"] = item.get("id")
-                    item_summary = summarize_item(item, line_number, timestamp, max_error_preview)
-                    if item_summary:
-                        turn_items.setdefault(turn_id, []).append(item_summary)
+                payload = object_payload(record, "itemAppended", line_number, result)
+                if payload is not None:
+                    item = payload.get("item")
+                    if not isinstance(item, dict):
+                        result["parse_errors"].append(
+                            {"line": line_number, "error": "itemAppended.item must be a JSON object"}
+                        )
+                        item = None
+                    if item is not None:
+                        item_type = item.get("type") or "(missing)"
+                        item_type_counts[item_type] += 1
+                        turn_id = payload.get("turnId") or item.get("turnId")
+                        if turn_id:
+                            turn = active_turns.setdefault(turn_id, {"turn_id": turn_id})
+                            turn["last_item_line"] = line_number
+                            turn["last_item_type"] = item_type
+                            turn["last_item_id"] = item.get("id")
+                            item_summary = summarize_item(item, line_number, timestamp, max_error_preview)
+                            if item_summary:
+                                turn_items.setdefault(turn_id, []).append(item_summary)
             elif kind == "turn_state_replaced":
-                payload = record.get("turnStateReplaced") or {}
+                payload = object_payload(record, "turnStateReplaced", line_number, result)
+                if payload is None:
+                    continue
                 turn = payload.get("turn") if isinstance(payload, dict) else None
                 turn_id = str(turn.get("id")) if isinstance(turn, dict) and turn.get("id") else None
                 if turn_id:
@@ -327,14 +403,20 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
                         replacement["last_item_type"] = replacement_items[-1]["type"]
                         replacement["last_item_id"] = replacement_items[-1]["item_id"]
             elif kind == "thread_rolled_back":
-                payload = record.get("threadRolledBack") or {}
-                count = payload.get("numTurns") if isinstance(payload, dict) else None
+                payload = object_payload(record, "threadRolledBack", line_number, result)
+                if payload is None:
+                    continue
+                count = payload.get("numTurns")
                 removed: list[str] = []
-                if isinstance(count, int) and count > 0:
+                if isinstance(count, int) and not isinstance(count, bool) and count > 0:
                     removed = list(active_turns)[-count:]
                     for turn_id in removed:
                         active_turns.pop(turn_id, None)
                         turn_items.pop(turn_id, None)
+                elif count is not None and (not isinstance(count, int) or isinstance(count, bool)):
+                    result["parse_errors"].append(
+                        {"line": line_number, "error": "threadRolledBack.numTurns must be an integer"}
+                    )
                 result["rollbacks"].append(
                     {"line": line_number, "timestamp": timestamp, "num_turns": count, "removed_turn_ids": removed}
                 )
@@ -391,28 +473,52 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
 
 
 def open_db(path: pathlib.Path) -> sqlite3.Connection:
-    uri = f"file:{path}?mode=ro"
+    # Quote the path before constructing a read-only URI; unescaped '?', '#',
+    # and '%' in Windows paths must remain part of the filename.
+    encoded_path = quote(str(path.resolve()), safe="/:\\\\")
+    uri = f"file:{encoded_path}?mode=ro"
     connection = sqlite3.connect(uri, uri=True)
     connection.row_factory = sqlite3.Row
     return connection
 
 
+def quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
 def table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
-    row = connection.execute(
-        "select 1 from sqlite_master where type = 'table' and name = ?", (table_name,)
-    ).fetchone()
-    return row is not None
+    try:
+        row = connection.execute(
+            "select 1 from sqlite_master where type = 'table' and name = ?", (table_name,)
+        ).fetchone()
+        return row is not None
+    except sqlite3.Error:
+        return False
 
 
 def table_columns(connection: sqlite3.Connection, table_name: str) -> set[str]:
     try:
-        return {row["name"] for row in connection.execute(f"pragma table_info({table_name})")}
+        return {
+            row["name"]
+            for row in connection.execute(f"pragma table_info({quote_identifier(table_name)})")
+        }
     except sqlite3.Error:
         return set()
 
 
 def rows(connection: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
     return [dict(row) for row in connection.execute(sql, params).fetchall()]
+
+
+def optional_rows(
+    connection: sqlite3.Connection,
+    sql: str,
+    params: tuple[Any, ...] = (),
+) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        return rows(connection, sql, params), None
+    except sqlite3.Error as exc:
+        return [], f"{type(exc).__name__}: {exc}"
 
 
 def load_db(
@@ -424,185 +530,234 @@ def load_db(
     if path is None:
         return {}
 
-    result: dict[str, Any] = {"path": str(path), "exists": path.exists()}
+    result: dict[str, Any] = {"path": str(path), "exists": path.exists(), "warnings": []}
     if not path.exists():
         return result
 
     try:
         connection = open_db(path)
-    except sqlite3.Error as exc:
-        result["open_error"] = str(exc)
+    except (OSError, sqlite3.Error) as exc:
+        result["open_error"] = f"{type(exc).__name__}: {exc}"
         return result
 
-    with connection:
-        table_names = [
-            row["name"]
-            for row in connection.execute(
-                "select name from sqlite_master where type = 'table' order by name"
-            )
-        ]
+    try:
+        try:
+            table_names = [
+                row["name"]
+                for row in connection.execute(
+                    "select name from sqlite_master where type = 'table' order by name"
+                )
+            ]
+        except sqlite3.Error as exc:
+            result["query_error"] = f"{type(exc).__name__}: {exc}"
+            return result
+
         result["tables"] = table_names
         counts: dict[str, int] = {}
         for table in table_names:
             if table == "sqlite_sequence":
                 continue
             try:
-                counts[table] = int(connection.execute(f"select count(*) from {table}").fetchone()[0])
-            except sqlite3.Error:
-                pass
+                counts[table] = int(
+                    connection.execute(
+                        f"select count(*) from {quote_identifier(table)}"
+                    ).fetchone()[0]
+                )
+            except sqlite3.Error as exc:
+                result["warnings"].append(
+                    {"code": "table_count_failed", "table": table, "message": str(exc)}
+                )
         result["counts"] = counts
 
         if thread_id and table_exists(connection, "threads"):
-            thread_rows = rows(
-                connection,
-                """
-                select thread_id, rollout_path, workspace_path, origin_channel, channel_context,
-                       status, created_at, updated_at, archived_at, history_mode, turn_count
-                from threads
-                where thread_id = ?
-                """,
-                (thread_id,),
-            )
-            result["thread"] = thread_rows[0] if thread_rows else None
+            columns = table_columns(connection, "threads")
+            selected = [
+                column
+                for column in (
+                    "thread_id", "rollout_path", "workspace_path", "origin_channel",
+                    "status", "created_at", "updated_at", "archived_at", "history_mode", "turn_count",
+                )
+                if column in columns
+            ]
+            if selected and "thread_id" in selected:
+                try:
+                    thread_rows = rows(
+                        connection,
+                        f"select {', '.join(quote_identifier(column) for column in selected)} "
+                        "from \"threads\" where \"thread_id\" = ?",
+                        (thread_id,),
+                    )
+                    result["thread"] = sanitize_diagnostic_value(thread_rows[0]) if thread_rows else None
+                except sqlite3.Error as exc:
+                    result["warnings"].append(
+                        {"code": "query_failed", "table": "threads", "message": str(exc)}
+                    )
+            else:
+                result["warnings"].append({"code": "missing_columns", "table": "threads"})
 
         if thread_id and table_exists(connection, "thread_context_usage"):
             usage_columns = table_columns(connection, "thread_context_usage")
-            selected_usage_columns = [
+            selected = [
                 column
                 for column in (
-                    "thread_id",
-                    "context_usage_tokens",
-                    "message_count",
-                    "prefix_fingerprint",
-                    "updated_at",
+                    "thread_id", "context_usage_tokens", "message_count", "prefix_fingerprint", "updated_at"
                 )
                 if column in usage_columns
             ]
-            usage_rows = rows(
-                connection,
-                f"""
-                select {", ".join(selected_usage_columns)}
-                from thread_context_usage
-                where thread_id = ?
-                """,
-                (thread_id,),
-            ) if selected_usage_columns else []
-            result["context_usage"] = usage_rows[0] if usage_rows else None
+            if selected and "thread_id" in selected:
+                try:
+                    usage_rows = rows(
+                        connection,
+                        f"select {', '.join(quote_identifier(column) for column in selected)} "
+                        "from \"thread_context_usage\" where \"thread_id\" = ?",
+                        (thread_id,),
+                    )
+                    result["context_usage"] = usage_rows[0] if usage_rows else None
+                except sqlite3.Error as exc:
+                    result["warnings"].append(
+                        {"code": "query_failed", "table": "thread_context_usage", "message": str(exc)}
+                    )
 
         if thread_id and table_exists(connection, "thread_sessions"):
-            session_row = connection.execute(
-                "select updated_at, length(session_json) as session_json_bytes from thread_sessions where thread_id = ?",
-                (thread_id,),
-            ).fetchone()
-            result["legacy_thread_session"] = dict(session_row) if session_row else None
+            try:
+                session_row = connection.execute(
+                    "select updated_at, length(session_json) as session_json_bytes "
+                    "from thread_sessions where thread_id = ?",
+                    (thread_id,),
+                ).fetchone()
+                result["legacy_thread_session"] = dict(session_row) if session_row else None
+            except sqlite3.Error as exc:
+                result["warnings"].append(
+                    {"code": "query_failed", "table": "thread_sessions", "message": str(exc)}
+                )
 
         bound_keys: list[str] = []
         if thread_id and table_exists(connection, "trace_session_bindings"):
-            binding_rows = rows(
-                connection,
-                """
-                select session_key, root_thread_id, parent_session_key, binding_kind, created_at
-                from trace_session_bindings
-                where root_thread_id = ?
-                order by created_at, session_key
-                """,
-                (thread_id,),
-            )
-            result["trace_bindings"] = binding_rows
-            bound_keys = [row["session_key"] for row in binding_rows if row.get("session_key")]
+            try:
+                binding_rows = rows(
+                    connection,
+                    "select session_key, root_thread_id, parent_session_key, binding_kind, created_at "
+                    "from trace_session_bindings where root_thread_id = ? order by created_at, session_key",
+                    (thread_id,),
+                )
+                result["trace_bindings"] = sanitize_diagnostic_value(binding_rows)
+                bound_keys = [row["session_key"] for row in binding_rows if row.get("session_key")]
+            except sqlite3.Error as exc:
+                result["warnings"].append(
+                    {"code": "query_failed", "table": "trace_session_bindings", "message": str(exc)}
+                )
 
         keys = list(dict.fromkeys([*bound_keys, *(session_keys or []), *([thread_id] if thread_id else [])]))
         if keys and table_exists(connection, "trace_sessions"):
-            placeholders = ",".join("?" for _ in keys)
-            result["trace_sessions"] = rows(
-                connection,
-                f"""
-                select session_key, started_at, last_activity_at, request_count, response_count,
-                       tool_call_count, error_count, context_compaction_count, thinking_count,
-                       token_usage_count, total_input_tokens, total_output_tokens,
-                       total_cached_input_tokens, total_cache_write_input_tokens,
-                       total_reasoning_output_tokens, total_tool_duration_ms,
-                       max_tool_duration_ms, last_finish_reason
-                from trace_sessions
-                where session_key in ({placeholders})
-                order by last_activity_at, session_key
-                """,
-                tuple(keys),
-            )
+            columns = table_columns(connection, "trace_sessions")
+            selected = [
+                column
+                for column in (
+                    "session_key", "started_at", "last_activity_at", "request_count", "response_count",
+                    "tool_call_count", "error_count", "context_compaction_count", "thinking_count",
+                    "token_usage_count", "total_input_tokens", "total_output_tokens",
+                    "total_cached_input_tokens", "total_cache_write_input_tokens",
+                    "total_reasoning_output_tokens", "total_tool_duration_ms", "max_tool_duration_ms",
+                    "last_finish_reason",
+                )
+                if column in columns
+            ]
+            if selected and "session_key" in selected:
+                placeholders = ",".join("?" for _ in keys)
+                try:
+                    order_column = "last_activity_at" if "last_activity_at" in selected else "session_key"
+                    result["trace_sessions"] = rows(
+                        connection,
+                        f"select {', '.join(quote_identifier(column) for column in selected)} "
+                        f"from trace_sessions where session_key in ({placeholders}) "
+                        f"order by {quote_identifier(order_column)}, session_key",
+                        tuple(keys),
+                    )
+                except sqlite3.Error as exc:
+                    result["warnings"].append(
+                        {"code": "query_failed", "table": "trace_sessions", "message": str(exc)}
+                    )
 
         if keys and table_exists(connection, "trace_events"):
+            columns = table_columns(connection, "trace_events")
+            safe_event_columns = [
+                column
+                for column in (
+                    "id", "event_id", "timestamp", "type", "tool_name", "call_id", "response_id",
+                    "message_id", "model_id", "finish_reason", "duration_ms",
+                )
+                if column in columns
+            ]
+            has_event_json = "event_json" in columns
             event_summaries: dict[str, Any] = {}
             for key in keys:
-                by_type = rows(
-                    connection,
-                    """
-                    select type, count(*) as count
-                    from trace_events
-                    where session_key = ?
-                    group by type
-                    order by count desc, type
-                    """,
-                    (key,),
-                )
-                errors = []
-                for row in connection.execute(
-                    """
-                    select id, event_id, timestamp, type, tool_name, call_id, response_id,
-                           message_id, model_id, finish_reason, duration_ms, event_json
-                    from trace_events
-                    where session_key = ?
-                      and (type = 'Error'
-                           or lower(event_json) like '%exception%'
-                           or lower(event_json) like '%unsupportedparamserror%'
-                           or lower(event_json) like '%traceback%'
-                           or lower(event_json) like '%http 4%'
-                           or lower(event_json) like '%http 5%'
-                           or lower(event_json) like '%timeout%')
-                    order by case when type = 'Error' then 0 else 1 end, id
-                    limit 20
-                    """,
-                    (key,),
-                ):
-                    event = dict(row)
-                    content_preview = ""
-                    include_event = event.get("type") == "Error"
-                    try:
-                        event_json = json.loads(event.pop("event_json"))
-                        if include_event:
-                            diagnostic_value = event_json.get("Content")
-                        else:
-                            diagnostic_value = (
-                                event_json.get("ToolResult")
-                                or event_json.get("MetadataJson")
-                                or event_json.get("Content")
-                            )
-                            diagnostic_text = preview(diagnostic_value, 4000).lower()
-                            include_event = any(
-                                needle in diagnostic_text
-                                for needle in (
-                                    "badrequesterror",
-                                    "unsupportedparamserror",
-                                    "exception:",
-                                    "traceback",
-                                    "http 4",
-                                    "http 5",
-                                    "exitcode",
-                                    's="error"',
-                                    "rate limit",
-                                    "timeout",
+                try:
+                    by_type = rows(
+                        connection,
+                        "select type, count(*) as count from trace_events where session_key = ? "
+                        "group by type order by count desc, type",
+                        (key,),
+                    )
+                    if not safe_event_columns:
+                        event_summaries[key] = {"type_counts": by_type, "error_like_events": []}
+                        continue
+                    select_columns = ", ".join(quote_identifier(column) for column in safe_event_columns)
+                    if has_event_json:
+                        select_columns += ', "event_json"'
+                    where = "where session_key = ?"
+                    if has_event_json:
+                        where += " and (type = 'Error' or lower(event_json) like '%exception%' " \
+                                 "or lower(event_json) like '%unsupportedparamserror%' " \
+                                 "or lower(event_json) like '%traceback%' or lower(event_json) like '%http 4%' " \
+                                 "or lower(event_json) like '%http 5%' or lower(event_json) like '%timeout%')"
+                    order_column = "id" if "id" in columns else "rowid"
+                    event_rows = rows(
+                        connection,
+                        f"select {select_columns} from trace_events {where} "
+                        f"order by case when type = 'Error' then 0 else 1 end, {quote_identifier(order_column)} limit 20",
+                        (key,),
+                    )
+                    errors = []
+                    for event in event_rows:
+                        raw_event_json = event.pop("event_json", None)
+                        include_event = event.get("type") == "Error"
+                        diagnostic_value: Any = None
+                        if raw_event_json is not None:
+                            try:
+                                event_json = json.loads(raw_event_json)
+                                if isinstance(event_json, dict):
+                                    diagnostic_value = event_json.get("Content")
+                                    if not include_event:
+                                        diagnostic_value = (
+                                            event_json.get("ToolResult")
+                                            or event_json.get("MetadataJson")
+                                            or event_json.get("Content")
+                                        )
+                                        diagnostic_text = preview(diagnostic_value, 4000).lower()
+                                        include_event = any(
+                                            needle in diagnostic_text
+                                            for needle in (
+                                                "badrequesterror", "unsupportedparamserror", "exception:",
+                                                "traceback", "http 4", "http 5", "exitcode", 's="error"',
+                                                "rate limit", "timeout",
+                                            )
+                                        )
+                            except (json.JSONDecodeError, TypeError):
+                                result["warnings"].append(
+                                    {"code": "invalid_event_json", "table": "trace_events", "session_key": key}
                                 )
-                            )
-                        content_preview = preview(diagnostic_value, max_error_preview)
-                    except (json.JSONDecodeError, TypeError):
-                        diagnostic_value = event.get("event_json")
-                        content_preview = preview(diagnostic_value, max_error_preview)
-                    if include_event:
-                        event["content_preview"] = content_preview
-                        errors.append(event)
-                event_summaries[key] = {"type_counts": by_type, "error_like_events": errors}
+                        if include_event:
+                            event["content_preview"] = preview(diagnostic_value, max_error_preview)
+                            errors.append(sanitize_diagnostic_value(event))
+                    event_summaries[key] = {"type_counts": by_type, "error_like_events": errors}
+                except sqlite3.Error as exc:
+                    result["warnings"].append(
+                        {"code": "query_failed", "table": "trace_events", "session_key": key, "message": str(exc)}
+                    )
             result["trace_events"] = event_summaries
+    finally:
+        connection.close()
 
-    connection.close()
     return result
 
 

--- a/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/scripts/analyze_dotcraft_thread.py
+++ b/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/scripts/analyze_dotcraft_thread.py
@@ -29,6 +29,164 @@ ERROR_NEEDLES = (
     "失败",
 )
 
+TOOL_ITEM_TYPES = {
+    "ToolCall",
+    "PluginFunctionCall",
+    "McpToolCall",
+    "DynamicToolCall",
+    "ToolExecution",
+    "ToolResult",
+    "CommandExecution",
+}
+
+MODEL_CONTENT_KINDS = {
+    "text",
+    "reasoning",
+    "data",
+    "function_call",
+    "function_result",
+    "hosted_image_generation",
+    "image_generation_tool_call",
+    "image_generation_tool_result",
+    "tool_call_arguments_delta",
+    "error",
+    "uri",
+    "usage",
+}
+
+SENSITIVE_PROPERTY_KEYS = {
+    "additionalproperties",
+    "protecteddata",
+    "rawrepresentation",
+}
+
+
+def sanitize_diagnostic_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: sanitize_diagnostic_value(nested)
+            for key, nested in value.items()
+            if str(key).replace("_", "").lower() not in SENSITIVE_PROPERTY_KEYS
+        }
+    if isinstance(value, list):
+        return [sanitize_diagnostic_value(nested) for nested in value]
+    return value
+
+
+def get_turn_id(payload: Any, line_number: int) -> str:
+    if not isinstance(payload, dict):
+        return f"line:{line_number}"
+    turn = payload.get("turn")
+    if isinstance(turn, dict) and turn.get("id"):
+        return str(turn["id"])
+    return str(payload.get("turnId") or payload.get("id") or f"line:{line_number}")
+
+
+def summarize_item(
+    item: Any,
+    line_number: int,
+    timestamp: Any,
+    max_error_preview: int,
+) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    summary = {
+        "line": line_number,
+        "timestamp": timestamp,
+        "item_id": item.get("id"),
+        "type": item.get("type") or "(missing)",
+        "status": item.get("status"),
+        "payload_keys": sorted(
+            key
+            for key in item["payload"].keys()
+            if str(key).replace("_", "").lower() not in SENSITIVE_PROPERTY_KEYS
+        )
+        if isinstance(item.get("payload"), dict)
+        else [],
+    }
+    if summary["type"] == "Error":
+        summary["payload_preview"] = preview(item.get("payload"), max_error_preview)
+    return summary
+
+
+def summarize_model_batch(payload: Any, line_number: int, timestamp: Any) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "line": line_number,
+        "timestamp": timestamp,
+        "turn_id": payload.get("turnId") if isinstance(payload, dict) else None,
+        "message_count": 0,
+        "schema_versions": [],
+        "content_kinds": [],
+        "rejected": False,
+    }
+    if not isinstance(payload, dict) or not isinstance(payload.get("messages"), list):
+        summary.update({"rejected": True, "rejection_reason": "malformed model batch"})
+        return summary
+
+    messages = payload["messages"]
+    schemas: set[Any] = set()
+    kinds: set[str] = set()
+    rejected = False
+    for message in messages:
+        if not isinstance(message, dict):
+            rejected = True
+            continue
+        schema = message.get("schemaVersion")
+        schemas.add(schema if isinstance(schema, (str, int)) else "(missing)")
+        if schema != 1:
+            rejected = True
+        contents = message.get("contents")
+        if not isinstance(contents, list):
+            rejected = True
+            continue
+        for content in contents:
+            if not isinstance(content, dict) or not isinstance(content.get("kind"), str):
+                rejected = True
+                kinds.add("(missing)")
+            else:
+                kinds.add(content["kind"])
+                if content["kind"] not in MODEL_CONTENT_KINDS:
+                    rejected = True
+
+    summary["message_count"] = len(messages)
+    summary["schema_versions"] = sorted(schemas, key=str)
+    summary["content_kinds"] = sorted(kinds)
+    summary["rejected"] = rejected
+    if rejected:
+        summary["rejection_reason"] = "unsupported or malformed model history message"
+    return summary
+
+
+def summarize_checkpoint(payload: Any, line_number: int, timestamp: Any) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "line": line_number,
+        "timestamp": timestamp,
+        "covered_through_turn_id": payload.get("coveredThroughTurnId")
+        if isinstance(payload, dict)
+        else None,
+        "checkpoint_id": payload.get("checkpointId") if isinstance(payload, dict) else None,
+        "decoded": True,
+    }
+    if not isinstance(payload, dict) or not isinstance(payload.get("replacementHistory"), list):
+        summary.update({"decoded": False, "decode_error": "malformed checkpoint"})
+        return summary
+
+    replacement = payload["replacementHistory"]
+    summary["replacement_message_count"] = len(replacement)
+    if not payload.get("coveredThroughTurnId") or any(
+        not isinstance(message, dict)
+        or message.get("schemaVersion") != 1
+        or not isinstance(message.get("contents"), list)
+        or any(
+            not isinstance(content, dict)
+            or content.get("kind") not in MODEL_CONTENT_KINDS
+            for content in message.get("contents", [])
+        )
+        for message in replacement
+    ):
+        summary.update({"decoded": False, "decode_error": "unsupported checkpoint history"})
+    return summary
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -46,6 +204,7 @@ def parse_args() -> argparse.Namespace:
 def preview(value: Any, limit: int) -> str:
     if value is None:
         return ""
+    value = sanitize_diagnostic_value(value)
     if not isinstance(value, str):
         try:
             value = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
@@ -69,6 +228,11 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
         "item_type_counts": {},
         "turns": [],
         "errors": [],
+        "tool_items": [],
+        "terminal_items": [],
+        "model_history_batches": [],
+        "checkpoints": [],
+        "rollbacks": [],
         "error_like_lines": [],
         "parse_errors": [],
     }
@@ -78,6 +242,7 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
     kind_counts: collections.Counter[str] = collections.Counter()
     item_type_counts: collections.Counter[str] = collections.Counter()
     active_turns: dict[str, dict[str, Any]] = {}
+    turn_items: dict[str, list[dict[str, Any]]] = {}
 
     with path.open("r", encoding="utf-8-sig") as handle:
         for line_number, raw in enumerate(handle, start=1):
@@ -89,6 +254,11 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
                 record = json.loads(raw)
             except json.JSONDecodeError as exc:
                 result["parse_errors"].append({"line": line_number, "error": str(exc)})
+                continue
+            if not isinstance(record, dict):
+                result["parse_errors"].append(
+                    {"line": line_number, "error": "rollout record is not a JSON object"}
+                )
                 continue
 
             kind = record.get("kind") or "(missing)"
@@ -103,12 +273,12 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
 
             if kind == "turn_started":
                 payload = record.get("turnStarted") or {}
-                turn_id = payload.get("turnId") or payload.get("id") or f"line:{line_number}"
+                turn_id = get_turn_id(payload, line_number)
                 active_turns.setdefault(turn_id, {"turn_id": turn_id})
                 active_turns[turn_id].update({"started_at": timestamp, "start_line": line_number})
             elif kind == "turn_completed":
                 payload = record.get("turnCompleted") or {}
-                turn_id = payload.get("turnId") or payload.get("id") or f"line:{line_number}"
+                turn_id = get_turn_id(payload, line_number)
                 active_turns.setdefault(turn_id, {"turn_id": turn_id})
                 active_turns[turn_id].update(
                     {
@@ -128,23 +298,91 @@ def load_thread(path: pathlib.Path | None, max_error_preview: int) -> dict[str, 
                     turn["last_item_line"] = line_number
                     turn["last_item_type"] = item_type
                     turn["last_item_id"] = item.get("id")
-                if item_type == "Error":
-                    result["errors"].append(
-                        {
-                            "line": line_number,
-                            "timestamp": timestamp,
-                            "turn_id": turn_id,
-                            "item_id": item.get("id"),
-                            "status": item.get("status"),
-                            "payload_keys": sorted((item.get("payload") or {}).keys())
-                            if isinstance(item.get("payload"), dict)
-                            else [],
-                            "payload_preview": preview(item.get("payload"), max_error_preview),
-                        }
-                    )
+                    item_summary = summarize_item(item, line_number, timestamp, max_error_preview)
+                    if item_summary:
+                        turn_items.setdefault(turn_id, []).append(item_summary)
+            elif kind == "turn_state_replaced":
+                payload = record.get("turnStateReplaced") or {}
+                turn = payload.get("turn") if isinstance(payload, dict) else None
+                turn_id = str(turn.get("id")) if isinstance(turn, dict) and turn.get("id") else None
+                if turn_id:
+                    prior = active_turns.get(turn_id, {"turn_id": turn_id})
+                    replacement = {
+                        "turn_id": turn_id,
+                        "start_line": prior.get("start_line", line_number),
+                        "started_at": turn.get("startedAt") or prior.get("started_at"),
+                        "completed_at": turn.get("completedAt"),
+                        "completed_line": line_number,
+                        "status": turn.get("status"),
+                    }
+                    active_turns[turn_id] = replacement
+                    replacement_items = []
+                    for item in turn.get("items") or []:
+                        item_summary = summarize_item(item, line_number, timestamp, max_error_preview)
+                        if item_summary:
+                            replacement_items.append(item_summary)
+                    turn_items[turn_id] = replacement_items
+                    if replacement_items:
+                        replacement["last_item_line"] = line_number
+                        replacement["last_item_type"] = replacement_items[-1]["type"]
+                        replacement["last_item_id"] = replacement_items[-1]["item_id"]
+            elif kind == "thread_rolled_back":
+                payload = record.get("threadRolledBack") or {}
+                count = payload.get("numTurns") if isinstance(payload, dict) else None
+                removed: list[str] = []
+                if isinstance(count, int) and count > 0:
+                    removed = list(active_turns)[-count:]
+                    for turn_id in removed:
+                        active_turns.pop(turn_id, None)
+                        turn_items.pop(turn_id, None)
+                result["rollbacks"].append(
+                    {"line": line_number, "timestamp": timestamp, "num_turns": count, "removed_turn_ids": removed}
+                )
+            elif kind == "model_history_messages_appended":
+                result["model_history_batches"].append(
+                    summarize_model_batch(record.get("modelHistoryMessagesAppended"), line_number, timestamp)
+                )
+            elif kind == "context_compacted":
+                result["checkpoints"].append(
+                    summarize_checkpoint(record.get("contextCompacted"), line_number, timestamp)
+                )
+
+    surviving_turn_ids = set(active_turns)
+    result["model_history_batches"] = [
+        batch
+        for batch in result["model_history_batches"]
+        if batch.get("turn_id") in surviving_turn_ids
+        or (batch.get("turn_id") is None and batch.get("rejected"))
+    ]
+    for checkpoint in result["checkpoints"]:
+        checkpoint["usable"] = bool(
+            checkpoint.get("decoded")
+            and checkpoint.get("covered_through_turn_id") in surviving_turn_ids
+        )
 
     result["kind_counts"] = dict(kind_counts.most_common())
+    surviving_items = [
+        (turn_id, item)
+        for turn_id in active_turns
+        for item in turn_items.get(turn_id, [])
+    ]
+    item_type_counts = collections.Counter(item["type"] for _, item in surviving_items)
     result["item_type_counts"] = dict(item_type_counts.most_common())
+    result["errors"] = [
+        {**item, "turn_id": turn_id}
+        for turn_id, item in surviving_items
+        if item["type"] == "Error"
+    ]
+    result["tool_items"] = [
+        {**item, "turn_id": turn_id}
+        for turn_id, item in surviving_items
+        if item["type"] in TOOL_ITEM_TYPES
+    ]
+    result["terminal_items"] = [
+        {**items[-1], "turn_id": turn_id}
+        for turn_id, items in turn_items.items()
+        if turn_id in active_turns and items
+    ]
     result["turns"] = sorted(
         active_turns.values(), key=lambda row: row.get("start_line") or row.get("completed_line") or 0
     )
@@ -256,7 +494,7 @@ def load_db(
                 "select updated_at, length(session_json) as session_json_bytes from thread_sessions where thread_id = ?",
                 (thread_id,),
             ).fetchone()
-            result["thread_session"] = dict(session_row) if session_row else None
+            result["legacy_thread_session"] = dict(session_row) if session_row else None
 
         bound_keys: list[str] = []
         if thread_id and table_exists(connection, "trace_session_bindings"):
@@ -414,16 +652,26 @@ def emit_markdown(summary: dict[str, Any]) -> None:
                     print(f"    preview: {error['payload_preview']}")
         else:
             print("- No explicit rollout `Error` items found.")
+        if thread.get("tool_items"):
+            print(f"- Surviving tool items: `{thread['tool_items']}`")
+        if thread.get("terminal_items"):
+            print(f"- Terminal items by surviving Turn: `{thread['terminal_items']}`")
+        if thread.get("rollbacks"):
+            print(f"- Rollbacks: `{thread['rollbacks']}`")
+        if thread.get("model_history_batches"):
+            print(f"- Model history batch metadata: `{thread['model_history_batches']}`")
+        if thread.get("checkpoints"):
+            print(f"- Compaction checkpoint metadata: `{thread['checkpoints']}`")
         if thread.get("parse_errors"):
             print(f"- Parse errors: `{thread['parse_errors']}`")
         print()
 
-    if db.get("context_usage") or db.get("thread_session"):
-        print("## Session State")
+    if db.get("context_usage") or db.get("legacy_thread_session"):
+        print("## Runtime And Legacy State")
         if db.get("context_usage"):
             print(f"- thread_context_usage: `{db['context_usage']}`")
-        if db.get("thread_session"):
-            print(f"- thread_sessions: `{db['thread_session']}`")
+        if db.get("legacy_thread_session"):
+            print(f"- optional legacy thread_sessions evidence: `{db['legacy_thread_session']}`")
         print()
 
     if db.get("trace_bindings") or db.get("trace_sessions") or db.get("trace_events"):

--- a/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/tests/test_analyze_dotcraft_thread.py
+++ b/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/tests/test_analyze_dotcraft_thread.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sqlite3
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "scripts" / "analyze_dotcraft_thread.py"
+SPEC = importlib.util.spec_from_file_location("analyze_dotcraft_thread", SCRIPT)
+assert SPEC and SPEC.loader
+ANALYZER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ANALYZER)
+
+
+def record(kind: str, payload_name: str, payload: object) -> str:
+    return json.dumps(
+        {"kind": kind, "timestamp": "2026-07-20T00:00:00Z", payload_name: payload},
+        separators=(",", ":"),
+    )
+
+
+def item(item_id: str, turn_id: str, item_type: str, payload: object) -> dict[str, object]:
+    return {
+        "id": item_id,
+        "turnId": turn_id,
+        "type": item_type,
+        "status": "Completed",
+        "payload": payload,
+    }
+
+
+class ThreadAnalyzerTests(unittest.TestCase):
+    def analyze(self, lines: list[str]) -> dict[str, object]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "thread_fixture.jsonl"
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            return ANALYZER.load_thread(path, 100)
+
+    def test_replacement_discards_incremental_items_and_reports_replacement_terminal_state(self) -> None:
+        result = self.analyze(
+            [
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_1"}}),
+                record(
+                    "item_appended",
+                    "itemAppended",
+                    {"turnId": "turn_1", "item": item("old", "turn_1", "Error", {"message": "old"})},
+                ),
+                record(
+                    "turn_state_replaced",
+                    "turnStateReplaced",
+                    {
+                        "turn": {
+                            "id": "turn_1",
+                            "status": "Completed",
+                            "items": [
+                                item("tool", "turn_1", "ToolCall", {"toolName": "safe"}),
+                                item("error", "turn_1", "Error", {"message": "replacement"}),
+                            ],
+                        }
+                    },
+                ),
+            ]
+        )
+
+        self.assertEqual(["error"], [entry["item_id"] for entry in result["errors"]])
+        self.assertIn("replacement", result["errors"][0]["payload_preview"])
+        self.assertNotIn("old", result["errors"][0]["payload_preview"])
+        self.assertEqual(["tool"], [entry["item_id"] for entry in result["tool_items"]])
+        self.assertEqual("error", result["terminal_items"][0]["item_id"])
+        self.assertEqual({"ToolCall": 1, "Error": 1}, result["item_type_counts"])
+
+    def test_rollback_removes_tail_turn_from_all_current_summaries(self) -> None:
+        result = self.analyze(
+            [
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_1"}}),
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_2"}}),
+                record(
+                    "turn_state_replaced",
+                    "turnStateReplaced",
+                    {"turn": {"id": "turn_2", "items": [item("error", "turn_2", "Error", {})]}},
+                ),
+                record(
+                    "model_history_messages_appended",
+                    "modelHistoryMessagesAppended",
+                    {"turnId": "turn_2", "messages": [{"schemaVersion": 1, "contents": []}]},
+                ),
+                record("thread_rolled_back", "threadRolledBack", {"numTurns": 1}),
+            ]
+        )
+
+        self.assertEqual(["turn_1"], [turn["turn_id"] for turn in result["turns"]])
+        self.assertEqual([], result["errors"])
+        self.assertEqual([], result["model_history_batches"])
+        self.assertEqual(["turn_2"], result["rollbacks"][0]["removed_turn_ids"])
+
+    def test_model_batches_and_checkpoints_never_expose_payloads(self) -> None:
+        secret = "DO_NOT_EXPOSE_MODEL_PAYLOAD"
+        result = self.analyze(
+            [
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_1"}}),
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_2"}}),
+                record(
+                    "item_appended",
+                    "itemAppended",
+                    {
+                        "turnId": "turn_1",
+                        "item": item(
+                            "error",
+                            "turn_1",
+                            "Error",
+                            {
+                                "message": "safe diagnostic",
+                                "ProtectedData": secret,
+                                "AdditionalProperties": {"secret": secret},
+                            },
+                        ),
+                    },
+                ),
+                record(
+                    "model_history_messages_appended",
+                    "modelHistoryMessagesAppended",
+                    {
+                        "turnId": "turn_1",
+                        "messages": [
+                            {
+                                "schemaVersion": 1,
+                                "additionalProperties": {"secret": secret},
+                                "contents": [{"kind": "text", "payload": {"text": secret}}],
+                            }
+                        ],
+                    },
+                ),
+                record(
+                    "model_history_messages_appended",
+                    "modelHistoryMessagesAppended",
+                    {
+                        "turnId": "turn_2",
+                        "messages": [{"schemaVersion": 1, "contents": [{"kind": "future", "payload": secret}]}],
+                    },
+                ),
+                record(
+                    "context_compacted",
+                    "contextCompacted",
+                    {
+                        "checkpointId": "checkpoint_1",
+                        "coveredThroughTurnId": "turn_1",
+                        "replacementHistory": [
+                            {"schemaVersion": 1, "contents": [{"kind": "text", "payload": secret}]}
+                        ],
+                    },
+                ),
+            ]
+        )
+
+        serialized = json.dumps(result)
+        self.assertNotIn(secret, serialized)
+        self.assertFalse(result["model_history_batches"][0]["rejected"])
+        self.assertEqual(["text"], result["model_history_batches"][0]["content_kinds"])
+        self.assertTrue(result["model_history_batches"][1]["rejected"])
+        self.assertTrue(result["checkpoints"][0]["decoded"])
+        self.assertNotIn("replacementHistory", serialized)
+
+    def test_malformed_line_and_checkpoint_are_reported_without_stopping(self) -> None:
+        result = self.analyze(
+            [
+                "{not-json",
+                "[]",
+                record(
+                    "context_compacted",
+                    "contextCompacted",
+                    {"coveredThroughTurnId": "turn_1", "replacementHistory": {"bad": True}},
+                ),
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_1"}}),
+            ]
+        )
+
+        self.assertEqual(2, len(result["parse_errors"]))
+        self.assertFalse(result["checkpoints"][0]["decoded"])
+        self.assertEqual(["turn_1"], [turn["turn_id"] for turn in result["turns"]])
+
+    def test_database_without_legacy_session_table_is_normal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "state.db"
+            connection = sqlite3.connect(path)
+            try:
+                connection.execute("create table marker (id integer)")
+                connection.commit()
+            finally:
+                connection.close()
+
+            result = ANALYZER.load_db(path, "thread_1", [], 100)
+
+        self.assertNotIn("legacy_thread_session", result)
+        self.assertNotIn("open_error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/tests/test_analyze_dotcraft_thread.py
+++ b/desktop/resources/plugins/dotcraft-bundled/plugins/dotcraft-doctor/skills/error-diagnosis/tests/test_analyze_dotcraft_thread.py
@@ -196,6 +196,100 @@ class ThreadAnalyzerTests(unittest.TestCase):
         self.assertNotIn("legacy_thread_session", result)
         self.assertNotIn("open_error", result)
 
+    def test_malformed_payload_types_are_recorded_and_following_records_are_processed(self) -> None:
+        result = self.analyze(
+            [
+                record("turn_completed", "turnCompleted", []),
+                record("item_appended", "itemAppended", {"item": "not-an-object"}),
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_1"}}),
+            ]
+        )
+
+        self.assertEqual(["turn_1"], [turn["turn_id"] for turn in result["turns"]])
+        self.assertGreaterEqual(len(result["parse_errors"]), 2)
+        self.assertNotIn("AttributeError", json.dumps(result))
+
+    def test_invalid_utf8_is_reported_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "thread_fixture.jsonl"
+            path.write_bytes(b'{"kind":"turn_started"}\n' + bytes([0xFF]))
+
+            result = ANALYZER.load_thread(path, 100)
+
+        self.assertIn("read_error", result)
+        self.assertIn("Unicode", result["read_error"])
+
+    def test_sensitive_values_are_redacted_from_diagnostic_result(self) -> None:
+        secret = "sk-test-secret-value"
+        result = self.analyze(
+            [
+                record("turn_started", "turnStarted", {"turn": {"id": "turn_1"}}),
+                record(
+                    "item_appended",
+                    "itemAppended",
+                    {
+                        "turnId": "turn_1",
+                        "item": item(
+                            "error",
+                            "turn_1",
+                            "Error",
+                            {
+                                "token": secret,
+                                "message": f"Authorization: Bearer {secret}",
+                            },
+                        ),
+                    },
+                ),
+            ]
+        )
+
+        serialized = json.dumps(result)
+        self.assertNotIn(secret, serialized)
+        self.assertIn("[REDACTED]", serialized)
+
+    def test_sqlite_missing_columns_degrades_to_safe_partial_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "state.db"
+            connection = sqlite3.connect(path)
+            try:
+                connection.execute("create table trace_events (session_key text, type text)")
+                connection.execute(
+                    "insert into trace_events(session_key, type) values ('session_1', 'Error')"
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            result = ANALYZER.load_db(path, "thread_1", ["session_1"], 100)
+
+        self.assertNotIn("open_error", result)
+        self.assertIn("trace_events", result)
+        self.assertEqual(1, result["trace_events"]["session_1"]["type_counts"][0]["count"])
+        self.assertEqual(1, len(result["trace_events"]["session_1"]["error_like_events"]))
+        self.assertEqual("", result["trace_events"]["session_1"]["error_like_events"][0]["content_preview"])
+
+    def test_invalid_event_json_is_not_echoed(self) -> None:
+        secret = "raw-secret-event-json"
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "state.db"
+            connection = sqlite3.connect(path)
+            try:
+                connection.execute(
+                    "create table trace_events (id integer, session_key text, type text, event_json text)"
+                )
+                connection.execute(
+                    "insert into trace_events values (1, 'session_1', 'Error', ?)",
+                    (secret,),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            result = ANALYZER.load_db(path, "thread_1", ["session_1"], 100)
+
+        self.assertNotIn(secret, json.dumps(result))
+        self.assertTrue(any(w["code"] == "invalid_event_json" for w in result["warnings"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/developing/workflow/workspace-handoff.md
+++ b/docs/developing/workflow/workspace-handoff.md
@@ -81,7 +81,7 @@ The Markdown export includes:
 - Current model-visible context: reconstructed from the latest usable compaction checkpoint plus surviving tail turns.
 - Conversation: surviving turns replayed from canonical rollout JSONL.
 
-Reasoning content is omitted. Tool calls are kept. Tool and command results follow `--tool-results`.
+Reasoning content is omitted. Tool calls are kept. Tool and command results follow `--tool-results`. `RequestUserInput` answer bodies are always omitted, including from full exports; question text and correlation IDs remain.
 
 ## Rollback And Compaction
 

--- a/docs/zh/developing/workflow/workspace-handoff.md
+++ b/docs/zh/developing/workflow/workspace-handoff.md
@@ -81,7 +81,7 @@ Markdown 导出包含：
 - 当前模型可见上下文：从最新可用 compaction checkpoint 加 surviving tail turns 重建。
 - 会话记录：从 canonical rollout JSONL replay 后仍然存活的 turns。
 
-Reasoning content 不会导出。工具调用会保留。工具和命令结果遵循 `--tool-results`。
+Reasoning content 不会导出。工具调用会保留。工具和命令结果遵循 `--tool-results`。`RequestUserInput` 的回答正文始终省略，包括 full 导出；问题文本和关联 ID 仍会保留。
 
 ## Rollback 与 Compaction
 

--- a/specs/architecture/session-core.md
+++ b/specs/architecture/session-core.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |-------|-------|
-| **Version** | 0.3.1 |
+| **Version** | 0.4.0 |
 | **Status** | Living |
-| **Date** | 2026-07-15 |
+| **Date** | 2026-07-20 |
 
 Purpose: Define the current **server-managed** session model (Thread / Turn / Item) used by `DotCraft.Core`, including lifecycle, persistence, event semantics, approval semantics, and adapter boundaries.
 
@@ -28,7 +28,7 @@ The Session Protocol is the active execution model for:
 - QQ
 - WeCom
 
-These channels create and resume server-managed threads whose canonical JSONL history lives under `.craft/threads/active|archived/`, while queryable metadata and agent session blobs live in `.craft/state.db`. They submit turns through Session Core and consume `SessionEvent` streams through thin adapters.
+These channels create and resume server-managed threads whose canonical domain and model-visible history lives under `.craft/threads/active|archived/`, while queryable metadata lives in `.craft/state.db`. They submit turns through Session Core and consume `SessionEvent` streams through thin adapters.
 
 ### 1.2 Design Intent
 
@@ -69,7 +69,7 @@ This boundary is intentional. DotCraft does **not** attempt to force client-owne
    - Owns Thread/Turn/Item lifecycle and state machines.
    - Wraps the agent execution pipeline (`AgentFactory` + `RunStreamingAsync`).
    - Emits a structured event stream consumed by adapters.
-- Persists canonical thread history to JSONL under `.craft/threads/active|archived/` and stores thread metadata plus agent session state in `.craft/state.db`.
+   - Persists canonical domain and model-visible history to JSONL under `.craft/threads/active|archived/`; SQLite contains explicitly classified durable business state, runtime continuity state, diagnostics, and rebuildable projections.
    - Enforces per-thread mutual exclusion.
 
 2. **Channel adapters** (per in-scope channel, in module assemblies)
@@ -79,9 +79,9 @@ This boundary is intentional. DotCraft does **not** attempt to force client-owne
    - Implement approval routing by translating `ApprovalRequest` Items into channel UX.
 
 3. **Persistence Layer** (`DotCraft.Protocol`)
-- Appends thread history to `.craft/threads/{active|archived}/{threadId}.jsonl`.
-- Stores agent history in the SQLite `thread_sessions` table inside `.craft/state.db`.
-   - Provides thread discovery and session reconstruction on resume.
+   - Appends domain transitions and model-history records to `.craft/threads/{active|archived}/{threadId}.jsonl`.
+   - Replays JSONL to reconstruct both `SessionThread` and model-visible history.
+   - Stores queryable projections and explicitly classified non-rollout state in SQLite.
 
 4. **Event stream** (in-process, `DotCraft.Protocol`)
    - Delivers Session Core events to the active channel adapter.
@@ -115,9 +115,9 @@ The server-managed session protocol is organized into five layers, ordered from 
    - Unchanged by this spec. Session Core consumes its output.
 
 5. **Persistence Layer** (`DotCraft.Core`)
-- Thread JSONL storage in `.craft/threads/active|archived/` plus metadata/session storage in `.craft/state.db`
+   - Thread JSONL storage in `.craft/threads/active|archived/` plus metadata projections in `.craft/state.db`
    - SQLite-backed thread discovery
-   - Agent session reconstruction on resume
+   - Rollout-backed model-history reconstruction on resume
 
 ### 3.3 Layer Diagram
 
@@ -198,6 +198,7 @@ Fields:
 - `Source` (ThreadSource)
   - Describes why this thread exists. `kind: "user"` is the default top-level conversation.
   - `kind: "subagent"` marks a child thread spawned from another thread turn and carries parent thread, parent turn, root thread, depth, nickname, role, profile, and runtime metadata.
+  - The complete source and every subagent capability are part of the canonical thread baseline and must survive cold-start replay.
 - `ForkedFromId` (string, nullable)
   - Source thread id when this thread was created by forking another conversation. Null for ordinary starts.
 - `Ephemeral` (boolean)
@@ -236,7 +237,7 @@ Fork contract:
 - Forks do not inherit queued inputs, pending approvals, active user-input requests, app bindings, active goals, or durable plan state. Transcript items already copied remain visible as history.
 - Forks copy thread configuration, then apply request-level overrides.
 - Forked threads include a persisted `SystemNotice` item with `kind = "forked"` and `sourceThreadId` at the boundary between inherited source history and fork-specific work. This marker is client-visible but not model-visible.
-- A persistent fork must materialize its own optimized model-visible session state when source history has already been compacted. If the selected fork prefix fully retains a source compaction checkpoint's covered turn, Session Core rebases that checkpoint into the fork rollout, stores a fork-local `thread_sessions` row from the checkpoint replacement history plus retained later turns, and records an estimated context usage snapshot. If the fork point cuts inside or before the checkpoint-covered turn, that checkpoint is not compatible and an older compatible checkpoint may be used instead.
+- A persistent fork must materialize its own optimized model-visible history when source history has already been compacted. If the selected fork prefix fully retains a source compaction checkpoint's covered turn, Session Core rebases that checkpoint into the fork rollout, appends the retained later model-history messages, and records an estimated context usage snapshot. If the fork point cuts inside or before the checkpoint-covered turn, that checkpoint is not compatible and an older compatible checkpoint may be used instead.
 - Fork rebuilds must prefer fork-local compaction checkpoints and must not expand compacted source history back into the full pre-compaction transcript when a compatible checkpoint exists.
 
 #### 4.1.1.2 Worktree Handoff
@@ -316,7 +317,7 @@ Session Core maintains an internal provider context-window record for each persi
 
 The persisted record is keyed by `thread_id` and stores `first_window_id`, `previous_window_id`, `current_window_id`, `generation`, and `updated_at`. IDs are UUID strings generated by the runtime. A record is created when the first provider request on a thread needs it. `current_window_id` remains stable across normal turns, retries, tool loops, queued inputs, and resume from disk.
 
-When a compaction succeeds and replaces the model-visible history (`micro` or `partial` outcomes from auto, reactive, or manual compaction), Session Core advances the provider context window after the replacement session state is saved. The previous `current_window_id` becomes `previous_window_id`, a new `current_window_id` is generated, and `generation` increments. Skipped, failed, cancelled, or diagnostic-only compaction attempts must not advance the window.
+When a compaction succeeds and replaces the model-visible history (`micro` or `partial` outcomes from auto, reactive, or manual compaction), Session Core advances the provider context window after the replacement checkpoint is durable in rollout. The previous `current_window_id` becomes `previous_window_id`, a new `current_window_id` is generated, and `generation` increments. Skipped, failed, cancelled, or diagnostic-only compaction attempts must not advance the window.
 
 The window record is internal routing metadata. It must not be rendered as conversation content, included in AppServer Thread DTOs, or used as the provider prompt-cache key. `prompt_cache_key`, OAuth `session-id`, and OAuth `thread-id` remain the active Thread id.
 
@@ -841,7 +842,7 @@ must not mutate the source thread.
 
 - `Paused` → `Active` (via `ResumeThread`)
   - Any compatible in-scope adapter can resume a Paused thread by calling `ResumeThread(threadId)`.
-  - Session Core loads the thread state from persistence, reconstructs the agent session, and sets status to Active.
+  - Session Core loads the thread state and model history from rollout, constructs a runtime agent session, and sets status to Active.
   - `LastActiveAt` is updated.
 
 - `Active` → `Archived`
@@ -897,16 +898,16 @@ WaitingApproval/WaitingInput ──────────► Cancelled
 
 - `Running` → `Completed`
   - The agent finishes its response. The final `AgentMessage` Item is marked Completed.
-  - Session Core runs post-turn operations: save session, run Stop hooks, compaction, consolidation.
+  - Session Core commits the terminal rollout batch, runs Stop hooks, and schedules eligible background consolidation.
 
 - `Running` → `Failed`
   - An unrecoverable error occurs: agent exception, tool execution error, timeout.
   - Session Core creates an `Error` Item, sets `Turn.Error`, saves the partial Thread state, and runs cleanup.
-  - For server-managed history, Session Core preserves the current optimized `AgentSession` when it is available, especially after a successful context compaction. Rebuilding from rollout is a recovery fallback only when the current optimized session cannot be saved or deserialized. The next Turn should include the failed Turn's completed user, assistant, and paired tool-call/tool-result Items that were durably recorded before the failure, but must not expand older history that had already been compacted out of the model-visible session.
+  - For server-managed history, Session Core appends completed model messages and any compaction replacement before finishing failure handling. The next Turn includes the failed Turn's completed user, assistant, and paired tool-call/tool-result history, but must not expand older history that a surviving compaction checkpoint replaced.
 
 - `Running`, `WaitingApproval`, or `WaitingInput` → `Cancelled`
 - The adapter requests cancellation (e.g., user sends `/cancel`, channel disconnects).
-- Session Core cancels the agent execution via `CancellationToken`, completes any currently streaming agent/reasoning Items with their accumulated text, saves partial state, and preserves the current optimized `AgentSession` when one exists. Rebuilding from rollout is allowed only as a fallback when the optimized session cannot be saved. A cancellation must not restore pre-compaction tool results or summaries that were no longer model-visible.
+- Session Core cancels the agent execution via `CancellationToken`, completes any currently streaming agent/reasoning Items with their accumulated text, and appends partial domain and model history to rollout. A cancellation must not restore pre-compaction tool results or summaries that were no longer model-visible.
 
 **Terminal states**: `Completed`, `Failed`, `Cancelled`. A Turn in a terminal state cannot transition.
 
@@ -987,7 +988,7 @@ When a channel adapter resumes a Thread that was created by a different channel:
 
 1. The adapter calls `ResumeThread(threadId)`.
 2. Session Core loads the Thread from persistence.
-3. Session Core reconstructs the `AgentSession` (conversation history) by replaying the stored Items into the Microsoft.Agents.AI session format.
+3. Session Core reconstructs the runtime `AgentSession` from the rollout's exact model-history records and latest usable compaction checkpoint. Domain Items are used only as a finite fallback when an exact record is absent.
 4. The Thread's `Status` is set to `Active`, `LastActiveAt` is updated.
 5. The adapter can now call `SubmitInput` to start a new Turn.
 6. The new Turn's Items are attributed to the resuming channel (recorded in Turn metadata).
@@ -1048,7 +1049,7 @@ SessionEvent
   - Hosts that multiplex **multiple Wire clients** onto the same Session Core process (e.g. DotCraft AppServer) **SHOULD** broadcast a `thread/renamed` notification on the AppServer Wire Protocol after the display name is updated, including when the change originates from another channel or from automatic titling, so clients such as DotCraft Desktop can refresh thread titles **without** relying on `turn/completed` (which may not be delivered to connections that did not subscribe to that thread). See [AppServer Protocol §4.11 `thread/rename`](../protocols/appserver-protocol.md#411-threadrename) and [§6.1 `thread/renamed`](../protocols/appserver-protocol.md#61-thread-notifications).
 
 - **`thread/deleted` (Wire Protocol only; not a `SessionEvent`)**
-  - Permanent removal is performed via `ISessionService.DeleteThreadPermanentlyAsync(threadId)`. Session Core removes in-memory state, persisted thread/session data, DB-backed plans, attachment reference rows, all tracing sessions/events bound to that thread, and dashboard usage rows associated with the thread or its bound trace sessions; it also best-effort deletes workspace-managed attachment files that are no longer referenced by any remaining thread. It does **not** enqueue a `SessionEvent` on the turn/event stream (there is no active turn for deletion).
+  - Permanent removal is performed via `ISessionService.DeleteThreadPermanentlyAsync(threadId)`. Session Core first closes the thread recorder, then deletes the canonical rollout, then removes DB-backed state and attachment references, and finally best-effort deletes workspace-managed attachment files that are no longer referenced by any remaining thread. Failure to delete the rollout leaves database state and attachment assets intact. It does **not** enqueue a `SessionEvent` on the turn/event stream (there is no active turn for deletion).
   - Hosts that multiplex **multiple Wire clients** onto the same Session Core process (e.g. DotCraft AppServer) **SHOULD** broadcast a `thread/deleted` notification on the AppServer Wire Protocol after deletion completes, including when deletion is initiated outside Wire (e.g. DashBoard HTTP `DELETE` on `/dashboard/api/sessions/{sessionKey}`), so UIs stay consistent. See [AppServer Protocol §4.9 `thread/delete`](../protocols/appserver-protocol.md#49-threaddelete) and [§6.1 Thread Notifications](../protocols/appserver-protocol.md#61-thread-notifications).
 
 #### Turn Events
@@ -1197,9 +1198,9 @@ SessionEvent
     - The threshold advisory events (`compactWarning`, `compactError`) carry `percentLeft`, `tokenCount`, and `contextUsage` when available so UIs can render the same context-pressure value Session Core used for threshold evaluation.
     - `compacting` start events do not carry `contextUsage`; clients must not update context-window UI from their projected `tokenCount` / `percentLeft`. Successful `compacted` events carry `contextUsage` when available. Clients should prefer this full snapshot over `tokenCount` / `percentLeft` because it includes thresholds and source metadata needed to seed context-window UI after manual compaction timeouts or missed thread snapshots.
     - Auto-compaction events (`compacting`, `compacted`, `compactSkipped`, `compactFailed`) are synchronous within Step 5k and always fire in the order `compacting` -> one terminal event (`compacted` / `compactSkipped` / `compactFailed`). Count-based tool-result clearing is not part of the hot auto-threshold path because it rewrites the prompt prefix and can break prompt-cache reuse. When a prompt request snapshot is available and the cache is not known to be cold, auto-compaction must enter the summary-producing partial/fork path with the original history so snapshot-prefix matching can succeed. A lightweight tool-result clearing pass may run only after a provider-aware idle gap indicates the relevant prompt cache is cold; if that pass does not bring the estimated request below the auto threshold, Session Core must continue to summary compaction using the cleared history.
-    - Manual compaction uses `ISessionService.CompactThreadAsync(threadId)` and is exposed to AppServer clients as `thread/compact/start`. It is allowed only for Active, server-managed threads with existing history and no `Running` / `WaitingApproval` turn or active thread maintenance. It registers thread maintenance with `maintenanceKind = "compacting"`, emits the same `compacting` -> terminal `system/event` sequence through the thread event broker, and prevents new turns from starting until the terminal event. It does not run a microcompact pre-pass; it first tries partial compaction, and if no older prefix exists, or the partial attempt cannot produce a summary, it falls back to full-history compaction. On success, Session Core saves the compacted agent session, updates context usage from the compacted session estimate, clears provider-usage anchors captured before the replacement history boundary, invalidates any prompt request snapshot captured before that boundary, and appends a persisted `SystemNotice` with `kind = "compacted"` and `trigger = "manual"` to the latest completed turn. On cancellation it emits `compactCancelled` and does not append a notice.
+    - Manual compaction uses `ISessionService.CompactThreadAsync(threadId)` and is exposed to AppServer clients as `thread/compact/start`. It is allowed only for Active, server-managed threads with existing history and no `Running` / `WaitingApproval` turn or active thread maintenance. It registers thread maintenance with `maintenanceKind = "compacting"`, emits the same `compacting` -> terminal `system/event` sequence through the thread event broker, and prevents new turns from starting until the terminal event. It does not run a microcompact pre-pass; it first tries partial compaction, and if no older prefix exists, or the partial attempt cannot produce a summary, it falls back to full-history compaction. On success, Session Core appends a compaction replacement checkpoint to rollout, updates context usage from the compacted history estimate, clears provider-usage anchors captured before the replacement history boundary, invalidates any prompt request snapshot captured before that boundary, and appends a persisted `SystemNotice` with `kind = "compacted"` and `trigger = "manual"` to the latest completed turn. On cancellation it emits `compactCancelled` and does not append a notice.
     - The pipeline may also be invoked **reactively** from the Turn's error path when the model rejects a request with `prompt_too_long`, `context_length_exceeded`, or another conservatively classified context-overflow equivalent. In that case the Turn still fails, but `compacting` followed by `compacted` / `compactFailed` is emitted first so UIs know the history was repaired before the user retries.
-    - Automatic memory consolidation is a non-blocking background task scheduled by Session Core after a configured number of successful Turns and after the baseline thread/session persistence attempt for that Turn has finished. It is not spawned by the compaction pipeline, and Turn completion is **not** deferred for consolidation. Its start event (`consolidating`) is emitted through the turn-scoped `SessionEventChannel`; its terminal events (`consolidated` / `consolidationSkipped` / `consolidationFailed` / `consolidationCancelled`) are emitted through the thread event broker with `turnId = null`. Automatic consolidation does not register thread maintenance, does not set `maintenanceKind = "consolidating"`, and does not prevent the next user input from starting a Turn immediately. Session Core serializes automatic consolidation per thread; if another automatic trigger arrives while one is active, at most one follow-up attempt is scheduled after the active attempt completes. On `consolidated`, Session Core persists a `SystemNotice` item with `kind = "memoryConsolidated"` into the completed Turn and broadcasts `item/started` + `item/completed` through the thread event broker. Manual consolidation uses `ISessionService.ConsolidateThreadMemoryAsync(threadId)` and is exposed to AppServer clients as `thread/memory/consolidate/start`. It is allowed only for Active, server-managed, idle threads with at least one completed Turn, no active thread maintenance, and non-empty model-visible history; it bypasses `Memory.AutoConsolidateEnabled`, registers thread maintenance with `maintenanceKind = "consolidating"`, emits thread-scoped `consolidating` → terminal `system/event`, awaits the maintenance result, and appends the same persistent notice on success. See [Memory Consolidation](../features/memory-consolidation.md) for the design contract.
+    - Automatic memory consolidation is a non-blocking background task scheduled by Session Core after a configured number of successful Turns and after the terminal rollout commit for that Turn has finished. It is not spawned by the compaction pipeline, and Turn completion is **not** deferred for consolidation. Its start event (`consolidating`) is emitted through the turn-scoped `SessionEventChannel`; its terminal events (`consolidated` / `consolidationSkipped` / `consolidationFailed` / `consolidationCancelled`) are emitted through the thread event broker with `turnId = null`. Automatic consolidation does not register thread maintenance, does not set `maintenanceKind = "consolidating"`, and does not prevent the next user input from starting a Turn immediately. Session Core serializes automatic consolidation per thread; if another automatic trigger arrives while one is active, at most one follow-up attempt is scheduled after the active attempt completes. On `consolidated`, Session Core persists a `SystemNotice` item with `kind = "memoryConsolidated"` into the completed Turn and broadcasts `item/started` + `item/completed` through the thread event broker. Manual consolidation uses `ISessionService.ConsolidateThreadMemoryAsync(threadId)` and is exposed to AppServer clients as `thread/memory/consolidate/start`. It is allowed only for Active, server-managed, idle threads with at least one completed Turn, no active thread maintenance, and non-empty model-visible history; it bypasses `Memory.AutoConsolidateEnabled`, registers thread maintenance with `maintenanceKind = "consolidating"`, emits thread-scoped `consolidating` → terminal `system/event`, awaits the maintenance result, and appends the same persistent notice on success. See [Memory Consolidation](../features/memory-consolidation.md) for the design contract.
     - `ISessionService.CancelThreadMaintenanceAsync(threadId)` interrupts active thread maintenance. AppServer exposes this as `thread/maintenance/interrupt`.
     - Turn-scoped system events are emitted through the turn-scoped `SessionEventChannel`, so they are guaranteed to arrive before `turn/completed`. Thread-scoped maintenance events may arrive later.
     - The protocol is language-neutral. System events carry `messageKey`, optional `params`, and an English `fallbackText`; `message` is a compatibility alias for `fallbackText`. Clients that support UI localization translate `messageKey` locally and fall back to `fallbackText`. User text, model output, and raw tool output remain original text and are not translated by Session Core.
@@ -1357,10 +1358,10 @@ For each submitted turn, Session Core must:
 
 - validate thread state and mutual exclusion
 - create the Turn and its initial user input item
-- execute the agent against the persisted server-managed session
+- execute the agent against a runtime session hydrated from persisted rollout history
 - translate agent output into typed items and events
 - collect token usage and other turn-level metadata
-- persist updated thread/session state
+- persist updated domain and model history to rollout
 - emit terminal completion or failure events
 
 ### 8.3 Compatibility Boundary
@@ -1384,7 +1385,7 @@ Thread data is stored under the workspace's `.craft/` directory:
 │   ├── archived/
 │   │   ├── {threadId}.jsonl     # Canonical rollout history for archived threads
 │   │   └── ...
-├── state.db                     # SQLite metadata, agent sessions, tracing, token usage
+├── state.db                     # Classified SQLite state, projections, diagnostics, usage
 ├── attachments/images/          # Workspace-managed local image blobs referenced by thread history
 ├── cache/                       # Rebuildable cache files; not part of thread lifecycle
 ```
@@ -1397,38 +1398,118 @@ Each thread is stored as an append-only JSONL rollout. Every line is a `ThreadRo
 { "kind": "thread_opened", "timestamp": "2026-03-15T10:00:00Z", "threadOpened": { ... } }
 { "kind": "turn_started", "timestamp": "2026-03-15T10:00:01Z", "turnStarted": { ... } }
 { "kind": "item_appended", "timestamp": "2026-03-15T10:00:01Z", "itemAppended": { ... } }
+{ "kind": "model_history_messages_appended", "timestamp": "2026-03-15T10:00:02Z", "modelHistoryMessagesAppended": { "turnId": "...", "messages": [ ... ] } }
+{ "kind": "turn_state_replaced", "timestamp": "2026-03-15T10:02:30Z", "turnStateReplaced": { ... } }
 { "kind": "turn_completed", "timestamp": "2026-03-15T10:02:30Z", "turnCompleted": { ... } }
 { "kind": "queued_input_added", "timestamp": "2026-03-15T10:02:31Z", "queuedInputAdded": { ... } }
 { "kind": "queued_input_removed", "timestamp": "2026-03-15T10:02:32Z", "queuedInputRemoved": { ... } }
 { "kind": "queued_input_reordered", "timestamp": "2026-03-15T10:02:33Z", "queuedInputReordered": { ... } }
 ```
 
-Session Core reconstructs a `SessionThread` by replaying the rollout file in order.
-Each Turn writes its initial `turn_started` record once. While the Turn remains active, newly appended Items and updates to an existing Item are persisted as `item_appended`; an update reuses the same Turn-local Item id and replaces that Item during replay. Transitioning the Turn to a terminal state appends one `turn_completed` record instead of rewriting the complete Turn. A full `turn_started` replacement is reserved for incompatible recovery transitions such as Item removal or reordering.
+Session Core reconstructs a `SessionThread` by replaying the rollout file in order. Incremental `turn_started`, `item_appended`, and `turn_completed` records remain readable. The normal terminal write path commits a complete Turn mutation as one `turn_state_replaced` record. Replay replaces the same Turn id atomically, including its ordered Items, terminal state, input, token usage, and error. A Turn writes at most one terminal replacement; streaming deltas and other transient lifecycle updates are not rollout records.
 
-### 9.3 Agent Session Storage
+`thread_opened.source` is a DotCraft-owned versioned union rather than the serialized CLR shape of the public `ThreadSource` type. New records use `schemaVersion = 1`. The user variant stores `kind` and optional `spawnedFromThreadId`. The subagent variant additionally stores parent thread id, root thread id, parent turn id, parent call id, depth, path, task, nickname, role, profile, runtime, and all send, resume, message, follow-up, and close capabilities. A source change is a baseline change and appends a new `thread_opened` record. Replay uses the latest baseline.
 
-Serialized `AgentSession` state is stored in the SQLite `thread_sessions` table inside `.craft/state.db`.
+Rollouts written before source persistence may use the existing limited inference from origin metadata. An unknown source schema version or a structurally invalid canonical source is a thread identity safety error and stops thread replay; it must not be downgraded to an ordinary user thread.
+
+### 9.3 Model-History Storage and Runtime Sessions
+
+The rollout is the sole authority for both the Session Protocol domain model and optimized model-visible history. A persisted Microsoft Agent Framework `AgentSession` is not part of the storage contract. Session Core creates an empty runtime `AgentSession` with `CreateSessionAsync`, replays the rollout into DotCraft-owned model-history messages, converts them to `ChatMessage` values, and injects them with `SetInMemoryChatHistory` before execution.
 
 Per-thread plans are stored in SQLite `thread_plans`. Plans follow the thread lifecycle: archive/unarchive keeps them, and permanent thread deletion cascades through the database. Legacy `.craft/plans/{threadId}.json|md` files are not a runtime plan source.
 
-Workspace-managed local images referenced by persisted `localImage` input parts are indexed in SQLite `thread_attachments`. The image file remains available for history rendering while at least one active or archived thread references it. Permanent thread deletion removes that thread's references and best-effort deletes now-unreferenced managed files. Unsent draft images that never enter thread history are cleaned as unreferenced attachments after the configured TTL.
+Workspace-managed local images referenced by persisted `localImage` input parts are indexed in SQLite `thread_attachments`. The image file is an independent asset: rollout stores its reference but cannot reconstruct its bytes. The file remains available for history rendering while at least one active or archived thread references it. Permanent thread deletion removes that thread's references and best-effort deletes now-unreferenced managed files. Unsent draft images that never enter thread history are cleaned as unreferenced attachments after the configured TTL.
+
+`model_history_messages_appended` atomically stores one Turn-local ordered batch of versioned `ModelHistoryMessage` values. Each message carries `schemaVersion`, `turnId`, role, optional message identity/author/timestamp, and ordered contents. DotCraft's `kind` field is the content discriminator; rollout does not depend on the Framework polymorphic `$type` envelope or on the JSON property shape of any Framework CLR content type. Framework values exist only at the codec boundary: encoding reads their semantic fields into DotCraft-owned DTOs, and decoding explicitly constructs new runtime values from those DTOs.
+
+Every model-history content value has the shape `{ kind, payload }`. The version 1 payload union is owned by DotCraft and contains only the following durable fields, plus content-level `additionalProperties`:
+
+| Kind | Durable fields |
+|---|---|
+| `text` | `text` |
+| `reasoning` | `text`, `protectedData` |
+| `data` | `base64Data`, `mediaType`, `name` |
+| `function_call` | `callId`, `name`, `arguments`, `informationalOnly`, `namespace`, `providerFlatName` |
+| `function_result` | `callId`, versioned result union |
+| `hosted_image_generation` | `id`, `status`, `revisedPrompt`, `imageBase64`, `mediaType`, `errorMessage` |
+| `image_generation_tool_call` | `callId` |
+| `image_generation_tool_result` | `callId`, ordered `outputs` |
+| `error` | `message`, `errorCode`, `details` |
+| `uri` | `uri`, `mediaType` |
+| `usage` | standard token counts and `additionalCounts` |
+
+Function results use a versioned union. A `json` result stores any JSON-compatible scalar, object, array, or null. A `contents` result recursively stores an ordered list from the same DotCraft-owned content union. Image-generation outputs use the same recursive union. Binary data and hosted image bytes are stored once as base64; derived data URIs are not duplicated.
+
+Function-call namespace and provider-flat-name values are persisted as strong fields even when the same values also occur in `AdditionalProperties`. On decode, the strong fields restore the standard runtime metadata keys. A conflict between a strong field and its extension value makes that content invalid; the model-history replayer rejects the containing record and applies its normal whole-Turn fallback rather than choosing one value silently.
+
+Message-level and content-level `AdditionalProperties` are persisted in full using JSON semantics. Arbitrary nested objects, arrays, numbers, booleans, strings, and nulls must round-trip as JSON; runtime CLR object identity is not a persistence guarantee and complex values may hydrate as `JsonElement`. `RawRepresentation` and runtime exception objects on function calls or results are never persisted. Core content fields remain strongly typed even when equivalent provider metadata also exists in `AdditionalProperties`.
+
+Streaming tool-call argument deltas are transient presentation state. They are removed when model history is encoded and never appear in a rollout model-history record. Any other unsupported runtime content fails the write explicitly; the writer must not silently omit an unknown semantic content type. On read, an unknown kind, malformed owned payload, or metadata conflict follows the tolerant replay contract in section 9.3.2.
 
 Session Core manages the mapping:
-- **Save**: After each successful compaction and after each terminal Turn when an optimized session is available, serialize the `AgentSession` and upsert `thread_sessions.session_json`.
-- **Load**: On Thread resume, deserialize `thread_sessions.session_json` via `agent.DeserializeSessionAsync`.
-- **Rebuild**: Rebuild from rollout only when the optimized session row is missing, malformed, or cannot be saved/deserialized. Rebuilds must first apply the newest surviving compaction checkpoint and then replay only later surviving Turns. Full rollout rebuild is a legacy fallback when no usable checkpoint exists. Rebuilds must be treated as recovery and should not overwrite a usable optimized session after compaction.
 
-The separation between rollout history and agent session state is intentional:
-- The rollout JSONL files are the source of truth for the Session Protocol UI/domain model.
-- The `thread_sessions` table is the source of truth for optimized LLM conversation history. It may contain compacted summaries, cleared tool-result markers, or other model-visible projections that intentionally differ from the full UI rollout.
-- Rollout may also contain internal compaction checkpoints. These records store replacement model-visible history for recovery only; they are not Session Items and are not projected to clients.
+- **Append**: Every successful mutation of server-managed model history appends the corresponding model-history records to the same thread rollout before the mutation is considered durable.
+- **Load**: Resume creates an empty Framework session and injects the history produced by rollout replay. It never calls `DeserializeSessionAsync` for persisted state.
+- **Legacy fallback**: A rollout without model-history records may be projected from surviving `SessionItem` records. This compatibility path is intentionally lossy and applies only to histories created before model-history records existed.
+- **Fork**: A persistent fork writes its materialized model history into the fork rollout. It does not create a separate Framework session blob.
+
+The domain history and exact model history are intentionally distinct durable representations. `turn_state_replaced` preserves client-visible Turn and Item lifecycle state. `model_history_messages_appended` preserves the exact provider-facing message sequence. Neither representation is required to losslessly derive the other, and arbitrary model metadata must not be copied into client-visible Items merely to remove duplicate text.
+
+`context_compacted` is an internal model-history replacement record, not a Session Item and not a client event. Its replacement history uses the same versioned DotCraft model-history schema. During replay, the newest checkpoint whose covered turn survives establishes a new history baseline; earlier model-history records are discarded and only later surviving records are appended. Rollback that removes the covered turn invalidates that checkpoint.
+
+Existing installations may still contain a `thread_sessions` table. Runtime code must neither read, update, migrate, nor delete it. New databases do not create the table.
+
+### 9.3.1 Ordered Rollout Writer
+
+All records for a thread pass through one workspace-lifetime recorder keyed by thread id. Each recorder has one bounded queue with capacity 256 and owns its pending suffix and any currently open append stream. Enqueue order is append order. A normal terminal Turn mutation enqueues the Turn replacement, any compaction replacement, and its model-history suffix as one batch, then crosses one flush barrier. The file handle may be released after a barrier so standard filesystem readers can inspect the rollout concurrently; recorder lifetime is independent from file-handle lifetime.
+
+A flush receipt identifies the confirmed byte offset and serialized record sizes. SQLite projections advance only after that barrier succeeds. Normal shutdown flushes and closes every recorder. Writers for different threads may operate concurrently, but one thread has exactly one active append order.
+
+Records leave the pending suffix only after their complete JSONL lines have been written. On I/O failure the recorder drops the stream, retains the unwritten suffix, reopens the file, and retries without rewriting confirmed complete lines. If a failed write leaves a non-newline-terminated tail, reopen terminates that invalid tail before retrying the unconfirmed record so forward readers can skip the damaged line. Exhausted retries block later writes for that thread and fail the affected Turn with a persistence error; a later flush or shutdown may retry the retained suffix.
+
+### 9.3.2 Bounded Model-History Replay
+
+A shared, read-only replayer is the canonical selector for runtime hydration and current-context export. It receives a rollout path, ordered surviving Turns, and an optional excluded current Turn. For ordinary uncompressed JSONL, it scans backward in bounded blocks. It accumulates the surviving suffix and stops at the newest decodable `context_compacted` record whose covered Turn still survives. The reconstructed history is the checkpoint replacement followed by later model-history messages in physical rollout order, including later messages associated with the covered Turn itself.
+
+Ordinary malformed JSONL lines, rollout records, model batches, and model contents are rejected individually. Replay skips them, increments a rejected-record count, emits a structured warning without protected or extension payloads, and continues recovering other Turns. If a rejected record can be associated with a Turn, that Turn is marked exact-history-incomplete and its entire model-visible contribution is rebuilt from Session Items; valid exact batches from the same Turn must not be mixed with that fallback. Other Turns continue using exact history.
+
+An invalid checkpoint is discarded as a whole and scanning continues to an earlier checkpoint. If no usable checkpoint exists, the same reverse scan reaches the beginning and recovers every decodable surviving record; it must not first materialize a second complete domain thread. A surviving tail Turn with no exact records also uses the lossy SessionItem projection. Canonical `thread_opened` source-schema errors remain fail-fast because continuing would change thread identity or authority.
+
+The replay result contains ordered messages, warnings, rejected-record count, fallback Turn ids, bytes read, and decoded-record count. Rollout observability records rejected resume records in `dotcraft.rollout.resume.records.rejected` without thread ids or payload data. Full forward replay remains the domain-history path used by UI, while current-context export consumes the shared model replay result and applies its own presentation redaction.
+
+### 9.3.3 Rollout Observability and Search Safety
+
+Rollout diagnostics measure record count and serialized bytes by record kind, flush duration and outcome, and resume bytes, decoded-record count, and rejected-record count. Metric dimensions must remain low-cardinality and must not contain thread ids, message contents, `ProtectedData`, or arbitrary `AdditionalProperties`.
+
+Context search treats exact model-history and compaction replacement records as internal recovery state. It must not index or preview `model_history_messages_appended`, `context_compacted`, `ProtectedData`, or arbitrary `AdditionalProperties`. Searchable rollout evidence is extracted from explicitly displayable domain fields rather than raw JSONL lines, and a domain value duplicated in model history contributes only one rollout match.
+
+Diagnostic readers apply the same domain replay semantics as Session Core: later `turn_state_replaced` records replace the same Turn, rollback removes the visible tail, and only surviving terminal Items contribute errors and tool summaries. Exact model batches may expose counts, Turn ids, schema versions, content kinds, and rejection status, but never model payloads, `ProtectedData`, or extension properties. Compaction diagnostics expose only checkpoint boundaries and decode status. A legacy `thread_sessions` table is optional evidence and never participates in freshness or persistence-consistency decisions.
+
+Current-context handoff uses the canonical shared model-history replayer. Its Markdown presentation excludes reasoning, `ProtectedData`, `AdditionalProperties`, and internal provider metadata, and propagates sanitized replay warnings through the existing export warning surface.
 
 ### 9.4 Thread Discovery
 
-Thread discovery is implemented by querying the SQLite `threads` metadata table in `.craft/state.db`. Rollout files remain the canonical conversation history, while `ThreadSummary` rows are derived metadata used by `FindThreadsAsync`.
+Thread discovery uses a filesystem-first read-repair pass followed by the SQLite `threads` metadata projection. Rollout files remain the canonical conversation history, while `ThreadSummary` rows are derived metadata used by `FindThreadsAsync`.
 
-This database-backed approach avoids replaying every rollout file during discovery while keeping rollout files as the canonical history.
+Each metadata row records the confirmed rollout byte offset from the flush that produced it. Discovery enumerates active and archived rollout files and compares their paths and lengths with SQLite. Matching rows require no rollout-body read. A missing row, changed path, shortened file, or mismatched offset causes only that rollout to be replayed and its projection rebuilt before the list is returned. Concurrent initial discovery shares one reconciliation operation.
+
+If SQLite listing or repair is unavailable, discovery falls back to summaries derived from filesystem rollouts instead of hiding canonical threads. Rows whose rollout files are absent are omitted but are not destructively deleted by read-repair. SQLite projections never participate in model-history reconstruction.
+
+### 9.4.1 Persistence Authority Classification
+
+| Category | Data | Recovery contract |
+|---|---|---|
+| Rollout session authority | Thread baseline and source, Turns, Items, queued inputs, model history, compaction | Replayed from the thread rollout |
+| SQLite durable business authority | Goals, plans, spawn edges, subagent mailbox | Not rebuilt by rollout read-repair |
+| SQLite runtime continuity state | Context windows | May explicitly degrade to a new transient window when unavailable |
+| SQLite disposable cache and sidecar | Context usage, item widget state | May be discarded and recomputed or restarted |
+| SQLite rebuildable projection | Threads, confirmed rollout offset, attachment references | Rebuilt from readable rollout records |
+| Diagnostics and accounting | Traces, token usage, dashboard usage | Independent diagnostic retention rules apply |
+| Independent file assets | Attachment file bytes | Rollout preserves references only |
+
+Filesystem read-repair updates only thread metadata and attachment references. It must not clear or overwrite durable business authority, runtime continuity, diagnostics, or unrelated sidecar tables. Loss of `state.db` is partial data loss: conversation state remains recoverable from rollout, while goals, plans, graph edges, and mailbox state are not recovered.
+
+A projection repair or terminal Turn commit updates thread metadata, attachment references, and the confirmed rollout offset in one SQLite transaction. The offset is advanced only when every projection update succeeds. Attachment projection uncertainty disables attachment garbage collection until a later successful repair; retaining an orphan is preferable to deleting a referenced asset.
 
 `ThreadSummary` fields returned for each discovered thread:
 - `Id`, `Status`, `OriginChannel`, `ChannelContext`
@@ -1471,7 +1552,7 @@ This opt-in path exists so clients such as **DotCraft Desktop** (which uses a no
 1. **Discovery**: Adapter calls `FindThreadsAsync(identity, includeArchived, crossChannelOrigins)`. Returns threads matching the combined predicate when `crossChannelOrigins` is set, otherwise the default predicate only.
 2. **Selection**: The adapter presents the list to the user, or auto-selects the most recently active thread.
 3. **Resume**: Adapter calls `ResumeThreadAsync(threadId)`. Session Core sets status to `Active` and updates `LastActiveAt`.
-4. **Session Load**: Session Core loads `thread_sessions.session_json`, reconstructing the LLM context.
+4. **Session Load**: Session Core creates an empty runtime `AgentSession`, replays model history from the rollout, and injects it into the configured history provider.
 5. **Ready**: Adapter calls `SubmitInputAsync` to start a new Turn. The Turn's `OriginChannel` records the resuming channel's name.
 
 ### 9.6 Legacy Compatibility Policy
@@ -1481,7 +1562,7 @@ Session Core does not implement compatibility paths for older snapshot layouts s
 The supported persistence contract is:
 
 - Canonical thread history in `.craft/threads/active|archived/*.jsonl`
-- Queryable metadata and serialized agent sessions in `.craft/state.db`
+- Classified durable state, diagnostics, and rebuildable projections in `.craft/state.db`
 
 Dashboard trace-session deletion follows the same persistence contract. Deleting one trace session removes that session's trace rows and associated dashboard usage rows; if the session is bound to a thread, deletion cascades through permanent thread deletion. Clearing all trace sessions deletes the selected trace/thread state and associated usage rows, but preserves global usage rows that have no `thread_id` or `session_key`. Bulk trace clearing may run SQLite maintenance (`wal_checkpoint(TRUNCATE)` and conditional `VACUUM`) after deletion to reclaim WAL/free-page space.
 
@@ -1491,9 +1572,9 @@ Dashboard may also project read-only thread operations from canonical thread JSO
 
 ### 9.7 Persistence Failure Handling
 
-- **Save failure**: If Session Core cannot write to disk after a Turn completes, the Turn's result is still delivered to the adapter (events were already emitted). The error is logged. The in-memory Thread state is preserved. The next save attempt retries.
-- **Load failure**: If Session Core cannot read a Thread file on resume, it returns an error to the adapter. The adapter should inform the user and offer to create a new Thread.
-- **Discovery failure**: If a thread file is unreadable during `FindThreadsAsync`, it is silently skipped. Corrupt files do not prevent other threads from being discovered.
+- **Save failure**: The writer retains the unconfirmed suffix and retries transient failures. If durability cannot be established, the affected Turn ends with a stable persistence error; Session Core must not report a successfully durable terminal Turn or silently discard model history.
+- **Load failure**: Ordinary malformed history records are skipped with structured warnings. If Session Core cannot read the file or cannot safely interpret the canonical thread header or source schema, it returns an error to the adapter. The adapter should inform the user and offer to create a new Thread.
+- **Discovery failure**: If a thread file is unreadable during `FindThreadsAsync`, it is skipped with diagnostic evidence. SQLite failure falls back to readable filesystem rollouts, and one corrupt file does not prevent other threads from being discovered.
 
 ## 10. Approval Flow Integration
 
@@ -1542,7 +1623,7 @@ The Session Protocol is now the active execution path for all **server-managed**
 - QQ
 - WeCom
 
-These channels create threads, submit turns through `ISessionService`, consume `SessionEvent`s, and persist state via rollout files plus `.craft/state.db`.
+These channels create threads, submit turns through `ISessionService`, consume `SessionEvent`s, and persist canonical state via rollout files with rebuildable projections in `.craft/state.db`.
 
 ### 11.2 Cross-Channel Resume Status
 
@@ -1573,15 +1654,15 @@ Cross-channel resume works for channels that share the same identity shape:
 | Failure | Trigger | Behavior |
 |---------|---------|----------|
 | **Resume Failed (file missing)** | Thread file not found on resume | Return error to adapter. Adapter informs user. |
-| **Resume Failed (session corrupt)** | Agent Session file cannot be deserialized | Return error to adapter. Offer to start a new Thread. |
+| **Resume Failed (unsafe header)** | Canonical thread header or source schema cannot be safely interpreted | Return error to adapter. Do not downgrade thread identity or authority. |
 | **Concurrent Turn** | Adapter calls `SubmitInput` while a Turn is Running | Return error to adapter. Adapter should queue or reject the message. |
 
 #### Persistence Failures
 
 | Failure | Trigger | Behavior |
 |---------|---------|----------|
-| **Save Failed** | Disk write error after Turn completes | Log error. In-memory state preserved. Next operation retries save. Turn result is still delivered to adapter (events already emitted). |
-| **Metadata Corrupt** | `threads` metadata table unreadable or inconsistent | Return error for discovery operations and log warning. |
+| **Save Failed** | Rollout writer cannot confirm a terminal Turn batch | Retain the unconfirmed suffix, block later writes for that thread, and end the Turn with a persistence error. A later flush may retry. |
+| **Metadata Corrupt** | `threads` projection is unreadable or inconsistent | Attempt filesystem read-repair; if SQLite remains unavailable, return filesystem-derived summaries with a diagnostic warning. |
 | **Disk Full** | No space for new rollout records or SQLite writes | Return error on CreateThread/SubmitInput. Adapter informs user. |
 
 #### Channel Disconnect Failures
@@ -1671,9 +1752,11 @@ All failures surface as:
 
 - Thread file written after Turn completes
 - Thread file loaded correctly on resume
-- Agent Session file round-trip preserves conversation history
+- Exact model history and supported content round-trip through rollout
+- Malformed ordinary history records are rejected observably without hiding recoverable Turns
+- Unknown canonical source schemas fail explicitly
 - Thread index updated on create, resume, pause, archive
-- Thread index rebuilt from files when missing
+- Thread and attachment projections rebuilt from files when missing without changing SQLite business authority
 
 ### 13.3 Adapter Conformance Tests (Per-Channel)
 
@@ -1745,7 +1828,7 @@ The Session Protocol applies to server-managed channels:
 - QQ
 - WeCom
 
-For these channels, Session Core loads persisted session state, executes the turn, emits `SessionEvent`s, and persists updated thread/session state afterward.
+For these channels, Session Core loads persisted rollout state, constructs a runtime session, executes the turn, emits `SessionEvent`s, and persists updated domain and model history afterward.
 
 ### 15.1 Resume Semantics
 

--- a/specs/architecture/session-core.md
+++ b/specs/architecture/session-core.md
@@ -1380,10 +1380,12 @@ Thread data is stored under the workspace's `.craft/` directory:
 .craft/
 ├── threads/
 │   ├── active/
-│   │   ├── {threadId}.jsonl     # Canonical rollout history for active threads
+│   │   ├── {threadId}.jsonl     # Canonical rollout history when threadId is a safe file name
+│   │   ├── thread-{sha256(threadId)}.jsonl # Canonical name when threadId contains invalid file-name characters
 │   │   └── ...
 │   ├── archived/
-│   │   ├── {threadId}.jsonl     # Canonical rollout history for archived threads
+│   │   ├── {threadId}.jsonl     # Canonical rollout history when threadId is a safe file name
+│   │   ├── thread-{sha256(threadId)}.jsonl # Canonical name when threadId contains invalid file-name characters
 │   │   └── ...
 ├── state.db                     # Classified SQLite state, projections, diagnostics, usage
 ├── attachments/images/          # Workspace-managed local image blobs referenced by thread history
@@ -1410,7 +1412,7 @@ Session Core reconstructs a `SessionThread` by replaying the rollout file in ord
 
 `thread_opened.source` is a DotCraft-owned versioned union rather than the serialized CLR shape of the public `ThreadSource` type. New records use `schemaVersion = 1`. The user variant stores `kind` and optional `spawnedFromThreadId`. The subagent variant additionally stores parent thread id, root thread id, parent turn id, parent call id, depth, path, task, nickname, role, profile, runtime, and all send, resume, message, follow-up, and close capabilities. A source change is a baseline change and appends a new `thread_opened` record. Replay uses the latest baseline.
 
-Rollouts written before source persistence may use the existing limited inference from origin metadata. An unknown source schema version or a structurally invalid canonical source is a thread identity safety error and stops thread replay; it must not be downgraded to an ordinary user thread.
+Every current rollout begins with a canonical `thread_opened` record containing the versioned source union. An unknown source schema version or a structurally invalid canonical source is a thread identity safety error and stops thread replay; it must not be downgraded to an ordinary user thread.
 
 ### 9.3 Model-History Storage and Runtime Sessions
 
@@ -1450,7 +1452,6 @@ Session Core manages the mapping:
 
 - **Append**: Every successful mutation of server-managed model history appends the corresponding model-history records to the same thread rollout before the mutation is considered durable.
 - **Load**: Resume creates an empty Framework session and injects the history produced by rollout replay. It never calls `DeserializeSessionAsync` for persisted state.
-- **Legacy fallback**: A rollout without model-history records may be projected from surviving `SessionItem` records. This compatibility path is intentionally lossy and applies only to histories created before model-history records existed.
 - **Fork**: A persistent fork writes its materialized model history into the fork rollout. It does not create a separate Framework session blob.
 
 The domain history and exact model history are intentionally distinct durable representations. `turn_state_replaced` preserves client-visible Turn and Item lifecycle state. `model_history_messages_appended` preserves the exact provider-facing message sequence. Neither representation is required to losslessly derive the other, and arbitrary model metadata must not be copied into client-visible Items merely to remove duplicate text.
@@ -1469,7 +1470,7 @@ Records leave the pending suffix only after their complete JSONL lines have been
 
 ### 9.3.2 Bounded Model-History Replay
 
-A shared, read-only replayer is the canonical selector for runtime hydration and current-context export. It receives a rollout path, ordered surviving Turns, and an optional excluded current Turn. For ordinary uncompressed JSONL, it scans backward in bounded blocks. It accumulates the surviving suffix and stops at the newest decodable `context_compacted` record whose covered Turn still survives. The reconstructed history is the checkpoint replacement followed by later model-history messages in physical rollout order, including later messages associated with the covered Turn itself.
+A shared, read-only replayer is the canonical selector for runtime hydration and current-context export. It receives a rollout path, ordered surviving Turns, an optional excluded current Turn, and the expected Thread id. The rollout path must resolve under the workspace's `.craft/threads/{active,archived}` roots, and the canonical `thread_opened` identity plus every model-history/checkpoint payload must match the expected Thread id. For ordinary uncompressed JSONL, it scans backward in bounded blocks. It accumulates the surviving suffix and stops at the newest decodable `context_compacted` record whose covered Turn still survives. The reconstructed history is the checkpoint replacement followed by later model-history messages in physical rollout order, including later messages associated with the covered Turn itself.
 
 Ordinary malformed JSONL lines, rollout records, model batches, and model contents are rejected individually. Replay skips them, increments a rejected-record count, emits a structured warning without protected or extension payloads, and continues recovering other Turns. If a rejected record can be associated with a Turn, that Turn is marked exact-history-incomplete and its entire model-visible contribution is rebuilt from Session Items; valid exact batches from the same Turn must not be mixed with that fallback. Other Turns continue using exact history.
 
@@ -1481,9 +1482,9 @@ The replay result contains ordered messages, warnings, rejected-record count, fa
 
 Rollout diagnostics measure record count and serialized bytes by record kind, flush duration and outcome, and resume bytes, decoded-record count, and rejected-record count. Metric dimensions must remain low-cardinality and must not contain thread ids, message contents, `ProtectedData`, or arbitrary `AdditionalProperties`.
 
-Context search treats exact model-history and compaction replacement records as internal recovery state. It must not index or preview `model_history_messages_appended`, `context_compacted`, `ProtectedData`, or arbitrary `AdditionalProperties`. Searchable rollout evidence is extracted from explicitly displayable domain fields rather than raw JSONL lines, and a domain value duplicated in model history contributes only one rollout match.
+Context search treats exact model-history and compaction replacement records as internal recovery state. It must not index or preview `model_history_messages_appended`, `context_compacted`, `ProtectedData`, arbitrary `AdditionalProperties`, system prompts, raw trace event JSON, channel context, or tool arguments/results. Searchable rollout evidence is extracted from explicitly displayable domain fields rather than raw JSONL lines, and a domain value duplicated in model history contributes only one rollout match. Tool arguments and result payloads are omitted or replaced with `[redacted]` at the presentation boundary.
 
-Diagnostic readers apply the same domain replay semantics as Session Core: later `turn_state_replaced` records replace the same Turn, rollback removes the visible tail, and only surviving terminal Items contribute errors and tool summaries. Exact model batches may expose counts, Turn ids, schema versions, content kinds, and rejection status, but never model payloads, `ProtectedData`, or extension properties. Compaction diagnostics expose only checkpoint boundaries and decode status. A legacy `thread_sessions` table is optional evidence and never participates in freshness or persistence-consistency decisions.
+Diagnostic readers apply the same domain replay semantics as Session Core: later `turn_state_replaced` records replace the same Turn, rollback removes the visible tail, and only surviving terminal Items contribute errors and tool summaries. Exact model batches may expose counts, Turn ids, schema versions, content kinds, and rejection status, but never model payloads, `ProtectedData`, or extension properties. Compaction diagnostics expose only checkpoint boundaries and decode status. The current schema has no `thread_sessions` table; diagnostic readers must not read or infer data from that retired shape.
 
 Current-context handoff uses the canonical shared model-history replayer. Its Markdown presentation excludes reasoning, `ProtectedData`, `AdditionalProperties`, and internal provider metadata, and propagates sanitized replay warnings through the existing export warning surface.
 
@@ -1493,7 +1494,7 @@ Thread discovery uses a filesystem-first read-repair pass followed by the SQLite
 
 Each metadata row records the confirmed rollout byte offset from the flush that produced it. Discovery enumerates active and archived rollout files and compares their paths and lengths with SQLite. Matching rows require no rollout-body read. A missing row, changed path, shortened file, or mismatched offset causes only that rollout to be replayed and its projection rebuilt before the list is returned. Concurrent initial discovery shares one reconciliation operation.
 
-If SQLite listing or repair is unavailable, discovery falls back to summaries derived from filesystem rollouts instead of hiding canonical threads. Rows whose rollout files are absent are omitted but are not destructively deleted by read-repair. SQLite projections never participate in model-history reconstruction.
+If SQLite listing or repair is unavailable, discovery reports the metadata read failure; it does not infer or migrate legacy rollout paths. Rows whose current canonical rollout files are absent are omitted but are not destructively deleted by read-repair. SQLite projections never participate in model-history reconstruction.
 
 ### 9.4.1 Persistence Authority Classification
 

--- a/specs/architecture/session-core.md
+++ b/specs/architecture/session-core.md
@@ -860,6 +860,18 @@ must not mutate the source thread.
 - At most one thread maintenance operation may be active on a Thread at any time.
 - A Thread may have Turns from different channels (cross-channel resume). Each Turn records which channel originated it.
 
+### 5.1.1 Thread-Owned Runtime Artifacts
+
+Session Core distinguishes canonical thread history from thread-owned runtime artifacts. Artifacts are not a second source of conversation authority, but their ownership and cleanup are part of the thread lifecycle:
+
+- Background terminal metadata and output logs are owned by the originating Thread. A terminal session is identified by its persisted terminal metadata and remains addressable after process completion until its owner is permanently deleted or retention removes the artifact.
+- Oversized tool-result spill files are owned by the originating Thread. The model-visible message contains a bounded preview and a workspace-relative reference; the complete spill file remains independent of the preview and is not reconstructed from the rollout.
+- Archive is not deletion. `Active → Archived` stops or invalidates active terminal processes for the archived thread, but preserves completed/lost terminal metadata, output logs, and tool-result spill files so historical inspection, context export, and tool-result reads continue to work.
+- Permanent deletion is deletion of the complete owned subtree. It stops or invalidates active terminal processes, removes terminal metadata/output and tool-result spill artifacts for the thread and all descendant SubAgent threads, then removes the thread's durable state. Cleanup is idempotent and may be retried independently when an individual filesystem operation fails.
+- Parent lifecycle operations apply to the complete SubAgent subtree. A child artifact must not survive permanent deletion of its owning parent solely because the child is not visible in the default thread list.
+- Compaction may replace or clear model-visible tool-result content, but must not delete a spill file while a current rollout or retained historical view may reference it. Spill cleanup is a retention/orphan-maintenance concern, not a compaction side effect.
+- Graceful process shutdown stops active terminal processes, flushes terminal metadata/rollout writers, and releases handles. It does not delete archived history or persistent terminal/tool-result artifacts merely because the process exits. A later startup pass marks persisted `running` terminals as `lost` before retention processing.
+
 ### 5.2 Turn Lifecycle
 
 ```
@@ -1422,6 +1434,31 @@ Per-thread plans are stored in SQLite `thread_plans`. Plans follow the thread li
 
 Workspace-managed local images referenced by persisted `localImage` input parts are indexed in SQLite `thread_attachments`. The image file is an independent asset: rollout stores its reference but cannot reconstruct its bytes. The file remains available for history rendering while at least one active or archived thread references it. Permanent thread deletion removes that thread's references and best-effort deletes now-unreferenced managed files. Unsent draft images that never enter thread history are cleaned as unreferenced attachments after the configured TTL.
 
+#### 9.3.0 Thread Artifact Storage and Maintenance
+
+The current artifact layout is workspace-relative and thread-owned:
+
+```text
+.craft/
+├── terminals/{canonicalThreadDirectory}/
+│   ├── {terminalSessionId}.json   # terminal metadata
+│   └── {terminalSessionId}.log    # complete terminal output
+└── tool-results/{canonicalThreadDirectory}/
+    └── {stableToolCallArtifact}.txt
+```
+
+The canonical thread directory name is the same for all thread-owned artifact stores: a safe current Thread ID may remain readable; an ID containing invalid filename characters uses the current `thread-{sha256(threadId)}` form. Runtime code must resolve the final path under the workspace's `.craft/terminals` or `.craft/tool-results` root and must not read or migrate older replacement-based sanitized directories.
+
+Artifact rules:
+
+- A terminal output log is complete persistent output. UI/API previews may impose independent character, line, or width bounds and must not be interpreted as permission to truncate or delete the log.
+- A tool-result spill filename is stable for the originating tool call (prefer the persisted tool call ID; otherwise use a deterministic current-protocol artifact key). Reprocessing or replaying the same call must be idempotent: an existing matching file is a valid result and must not create a second random spill file or overwrite a different call's file.
+- A spill file is referenced from a bounded model-visible preview. The full file is retained through archive and compaction unless permanent deletion or a retention janitor can prove that the owning thread and all current rollout references are gone.
+- The terminal `OutputRetentionDays` setting governs completed and lost terminal artifact retention. Running terminals are never removed by TTL cleanup. Tool-result retention may share the workspace retention policy, but cleanup must be conservative when reference status cannot be established.
+- Startup and long-lived-process maintenance may run a throttled janitor. It must use a workspace/process lock or equivalent coordination, avoid deleting active owners, continue after individual failures, and report a retryable maintenance result. A marker may suppress duplicate scans but must not suppress a later retry after an incomplete scan.
+- Thread deletion is the authoritative synchronous cleanup path; janitor cleanup is best effort and must not be required to make a deleted Thread unavailable. If database deletion succeeds while filesystem cleanup fails, the failure is observable and the orphan remains eligible for a later janitor retry.
+- Normal process shutdown is not an artifact retention boundary. Shutdown cleanup handles active processes and open streams; it does not remove persistent terminal logs or tool-result spill files.
+
 `model_history_messages_appended` atomically stores one Turn-local ordered batch of versioned `ModelHistoryMessage` values. Each message carries `schemaVersion`, `turnId`, role, optional message identity/author/timestamp, and ordered contents. DotCraft's `kind` field is the content discriminator; rollout does not depend on the Framework polymorphic `$type` envelope or on the JSON property shape of any Framework CLR content type. Framework values exist only at the codec boundary: encoding reads their semantic fields into DotCraft-owned DTOs, and decoding explicitly constructs new runtime values from those DTOs.
 
 Every model-history content value has the shape `{ kind, payload }`. The version 1 payload union is owned by DotCraft and contains only the following durable fields, plus content-level `additionalProperties`:
@@ -1633,6 +1670,12 @@ Cross-channel resume works for channels that share the same identity shape:
 - **CLI ↔ ACP** share `UserId = "local"` and `ChannelContext = null`, so they naturally share one thread pool.
 - **QQ**, **WeCom**, and **Feishu** remain isolated by social conversation `ChannelContext`, while multiple users in the same group/chat share that conversation's thread.
 
+### 11.3 Artifact Maintenance Status
+
+The current implementation exposes explicit terminal artifact operations for stop-only thread cleanup, permanent thread-directory deletion, and retention cleanup. Construction of the background terminal service performs a best-effort startup retention pass using `Tools.Shell.Background.OutputRetentionDays`; normal service disposal remains stop-only. The current host registration does not yet provide a separate long-lived periodic janitor for tool-result spill directories, so tool-result permanent deletion and any future TTL/orphan scan must remain explicit maintenance work rather than an assumed background service behavior.
+
+The lifecycle contract in Section 5.1.1 and storage contract in Section 9.3.0 are normative even where a host has not yet wired every maintenance trigger. Implementations must not introduce legacy sanitized-directory discovery or delete tool-result spill files during compaction to compensate for a missing janitor.
+
 ## 12. Failure Model
 
 ### 12.1 Failure Classes
@@ -1724,6 +1767,11 @@ All failures surface as:
 - `ResumeThread` on Archived thread fails
 - `SubmitInput` on Paused thread fails
 - `SubmitInput` on Archived thread fails
+- Archiving a thread stops active terminals but preserves completed/lost terminal artifacts and tool-result spill files
+- Permanent deletion removes terminal and tool-result artifacts for the complete SubAgent subtree
+- Permanent deletion remains successful and retryable when one artifact deletion fails, with an observable cleanup warning
+- Graceful shutdown stops active terminals without deleting persistent artifacts
+- Startup retention marks stale running terminals as lost before removing only eligible completed/lost artifacts
 
 #### Turn Lifecycle
 
@@ -1758,6 +1806,10 @@ All failures surface as:
 - Unknown canonical source schemas fail explicitly
 - Thread index updated on create, resume, pause, archive
 - Thread and attachment projections rebuilt from files when missing without changing SQLite business authority
+- Tool-result spill writes are stable and idempotent for the same tool call identity
+- Canonical artifact directory naming does not collide for distinct invalid Thread IDs and remains contained under the artifact root
+- Terminal retention does not remove running sessions and is safe to repeat after a partial failure
+- Thread artifact deletion is idempotent for terminals and tool-result spill directories
 
 ### 13.3 Adapter Conformance Tests (Per-Channel)
 

--- a/specs/architecture/session-core.md
+++ b/specs/architecture/session-core.md
@@ -1523,7 +1523,7 @@ Context search treats exact model-history and compaction replacement records as 
 
 Diagnostic readers apply the same domain replay semantics as Session Core: later `turn_state_replaced` records replace the same Turn, rollback removes the visible tail, and only surviving terminal Items contribute errors and tool summaries. Exact model batches may expose counts, Turn ids, schema versions, content kinds, and rejection status, but never model payloads, `ProtectedData`, or extension properties. Compaction diagnostics expose only checkpoint boundaries and decode status. The current schema has no `thread_sessions` table; diagnostic readers must not read or infer data from that retired shape.
 
-Current-context handoff uses the canonical shared model-history replayer. Its Markdown presentation excludes reasoning, `ProtectedData`, `AdditionalProperties`, and internal provider metadata, and propagates sanitized replay warnings through the existing export warning surface.
+Current-context handoff uses the canonical shared model-history replayer. Its Markdown presentation excludes reasoning, `ProtectedData`, `AdditionalProperties`, internal provider metadata, and the free-form `SessionThread.Metadata` dictionary. Thread metadata may contain channel credentials, external CLI session identifiers, private paths, or future extension values and therefore is not eligible for blacklist-based redaction. Export uses an explicit allowlist of strong thread fields such as display name, status, timestamps, origin channel, history mode, and Turn count, and propagates sanitized replay warnings through the existing export warning surface.
 
 ### 9.4 Thread Discovery
 

--- a/specs/features/context-export-cli.md
+++ b/specs/features/context-export-cli.md
@@ -96,6 +96,7 @@ Rollout files may be read for top candidates to add short evidence snippets and 
 - `--tool-results none` must omit tool output bodies while preserving tool names, call ids, success flags, and timestamps where available.
 - `--tool-results summary` must produce bounded previews only.
 - Full tool output is opt-in through `--tool-results full`.
+- `RequestUserInput` answer bodies must always be omitted from current model-visible context and conversation output, regardless of `--tool-results`; question text and request or call ids may remain for continuity.
 - Search results must favor evidence metadata and short previews over dumping raw user, assistant, or tool content.
 
 ## 7. Doctor Skill Integration
@@ -114,6 +115,7 @@ The built-in Doctor plugin should provide a skill that teaches agents to:
 - Export includes `MEMORY.md` and HISTORY tail by default.
 - Export applies rollback records and excludes removed turns.
 - Export recognizes surviving compaction checkpoints and later tail turns.
+- Export omits `RequestUserInput` answer bodies from every rendered history projection.
 - Search returns ranked thread hits from DB evidence without a running AppServer.
 - Search JSON output is stable enough for skills and scripts.
 - Missing workspace, missing state DB, missing thread, corrupt rollout lines, and invalid arguments produce clear non-zero CLI failures or warnings.

--- a/src/DotCraft.Core/ContextExport/ContextExportService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextExportService.cs
@@ -32,8 +32,19 @@ public sealed class ContextExportService
             throw new KeyNotFoundException($"Thread '{options.ThreadId}' was not found in the selected workspace.");
 
         var warnings = loaded.Warnings.ToList();
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(
+            loaded.RolloutPath,
+            loaded.Thread.Turns,
+            excludedTurnId: null,
+            ct).ConfigureAwait(false);
+        foreach (var warning in replay.Warnings ?? [])
+        {
+            warnings.Add(string.IsNullOrWhiteSpace(warning.TurnId)
+                ? $"Model history warning ({warning.Code}): {warning.Message}"
+                : $"Model history warning for turn '{warning.TurnId}' ({warning.Code}): {warning.Message}");
+        }
         var memory = _reader.LoadMemory(loaded.Paths, options.History, options.HistoryTailChars);
-        var markdown = BuildMarkdown(loaded, memory, options, warnings);
+        var markdown = BuildMarkdown(loaded, memory, replay, options, warnings);
 
         return new ContextExportResult
         {
@@ -47,6 +58,7 @@ public sealed class ContextExportService
     private static string BuildMarkdown(
         ContextLoadedThread loaded,
         ContextWorkspaceMemory memory,
+        ModelHistoryReplayResult modelHistory,
         ContextExportOptions options,
         List<string> warnings)
     {
@@ -84,7 +96,7 @@ public sealed class ContextExportService
 
         AppendMemory(sb, memory, options);
         AppendContinuity(sb, loaded.ContinuityEvents);
-        AppendCurrentContext(sb, loaded, options, warnings);
+        AppendCurrentContext(sb, modelHistory, options);
         AppendConversation(sb, thread, options);
 
         if (warnings.Count > 0)
@@ -170,90 +182,24 @@ public sealed class ContextExportService
 
     private static void AppendCurrentContext(
         StringBuilder sb,
-        ContextLoadedThread loaded,
-        ContextExportOptions options,
-        List<string> warnings)
+        ModelHistoryReplayResult replay,
+        ContextExportOptions options)
     {
         sb.AppendLine("## Current Model-Visible Context");
-        var history = BuildCurrentContextHistory(loaded, warnings);
-        sb.AppendLine(history.Description);
+        sb.AppendLine(replay.HasModelHistoryRecords
+            ? $"Recovered with canonical model-history replay; {replay.RejectedRecords} record(s) rejected and {(replay.FallbackTurnIds?.Count ?? 0)} turn(s) reconstructed from visible items."
+            : "No exact model-history records were found; reconstructed context from surviving visible turns.");
         sb.AppendLine();
 
-        if (history.Messages.Count == 0)
+        if (replay.Messages.Count == 0)
         {
             sb.AppendLine("(empty)");
             sb.AppendLine();
             return;
         }
 
-        AppendChatMessages(sb, history.Messages, options);
+        AppendChatMessages(sb, replay.Messages, options);
         sb.AppendLine();
-    }
-
-    private static CurrentContextHistory BuildCurrentContextHistory(
-        ContextLoadedThread loaded,
-        List<string> warnings)
-    {
-        var orderedTurns = loaded.Thread.Turns
-            .OrderBy(t => t.StartedAt)
-            .ThenBy(t => t.Id, StringComparer.Ordinal)
-            .ToList();
-
-        var checkpoints = loaded.ContinuityEvents
-            .Where(e => e.Kind == ContextContinuityEventKind.Compaction)
-            .ToList();
-
-        for (var i = checkpoints.Count - 1; i >= 0; i--)
-        {
-            var checkpoint = checkpoints[i];
-            var coveredTurnIndex = orderedTurns.FindIndex(turn =>
-                string.Equals(turn.Id, checkpoint.CoveredThroughTurnId, StringComparison.Ordinal));
-            if (coveredTurnIndex < 0)
-            {
-                warnings.Add($"Ignored compaction checkpoint '{checkpoint.CheckpointId}' because its covered turn is not present in surviving rollout history.");
-                continue;
-            }
-
-            if (!checkpoint.ReplacementHistory.HasValue)
-            {
-                warnings.Add($"Ignored compaction checkpoint '{checkpoint.CheckpointId}' because it has no replacement history.");
-                continue;
-            }
-
-            try
-            {
-                var messages = checkpoint.ReplacementHistory.Value.Deserialize<List<ChatMessage>>(
-                    SessionPersistenceJsonOptions.Default);
-                if (messages == null)
-                {
-                    warnings.Add($"Ignored compaction checkpoint '{checkpoint.CheckpointId}' because replacement history was empty.");
-                    continue;
-                }
-
-                for (var turnIndex = coveredTurnIndex + 1; turnIndex < orderedTurns.Count; turnIndex++)
-                    messages.AddRange(ThreadStore.BuildModelVisibleHistoryFromTurn(orderedTurns[turnIndex]));
-
-                var description =
-                    $"Recovered from latest surviving compaction checkpoint `{checkpoint.CheckpointId}` (covered through `{checkpoint.CoveredThroughTurnId}`), plus {orderedTurns.Count - coveredTurnIndex - 1} later turn(s).";
-                return new CurrentContextHistory(description, messages);
-            }
-            catch (JsonException ex)
-            {
-                warnings.Add($"Ignored compaction checkpoint '{checkpoint.CheckpointId}' because replacement history could not be decoded: {ex.Message}");
-            }
-            catch (NotSupportedException ex)
-            {
-                warnings.Add($"Ignored compaction checkpoint '{checkpoint.CheckpointId}' because replacement history could not be decoded: {ex.Message}");
-            }
-        }
-
-        var fallback = new List<ChatMessage>();
-        foreach (var turn in orderedTurns)
-            fallback.AddRange(ThreadStore.BuildModelVisibleHistoryFromTurn(turn));
-
-        return new CurrentContextHistory(
-            "No usable compaction checkpoint survived; reconstructed context from surviving rollout turns.",
-            fallback);
     }
 
     private static void AppendConversation(
@@ -530,7 +476,7 @@ public sealed class ContextExportService
                     continue;
                 }
 
-                AppendJsonPayload(sb, content);
+                sb.AppendLine($"[{content.GetType().Name} payload omitted]");
             }
 
             sb.AppendLine();
@@ -615,5 +561,4 @@ public sealed class ContextExportService
         sb.AppendLine(fence);
     }
 
-    private sealed record CurrentContextHistory(string Description, List<ChatMessage> Messages);
 }

--- a/src/DotCraft.Core/ContextExport/ContextExportService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextExportService.cs
@@ -10,6 +10,7 @@ namespace DotCraft.ContextExport;
 /// </summary>
 public sealed class ContextExportService
 {
+    private const string RequestUserInputToolName = "RequestUserInput";
     private readonly ContextWorkspaceReader _reader = new();
 
     /// <summary>
@@ -224,8 +225,13 @@ public sealed class ContextExportService
                 AppendMetadata(sb, "Tokens", $"{turn.TokenUsage.InputTokens} input, {turn.TokenUsage.OutputTokens} output, {turn.TokenUsage.TotalTokens} total");
             sb.AppendLine();
 
+            var requestUserInputCallIds = turn.Items
+                .Select(item => item.AsToolCall)
+                .Where(toolCall => toolCall != null && IsRequestUserInput(toolCall.ToolName))
+                .Select(toolCall => toolCall!.CallId)
+                .ToHashSet(StringComparer.Ordinal);
             foreach (var item in turn.Items.OrderBy(i => i.CreatedAt).ThenBy(i => i.Id, StringComparer.Ordinal))
-                AppendItem(sb, item, options);
+                AppendItem(sb, item, options, requestUserInputCallIds);
 
             sb.AppendLine();
         }
@@ -234,7 +240,8 @@ public sealed class ContextExportService
     private static void AppendItem(
         StringBuilder sb,
         SessionItem item,
-        ContextExportOptions options)
+        ContextExportOptions options,
+        IReadOnlySet<string> requestUserInputCallIds)
     {
         var timestamp = item.CompletedAt ?? item.CreatedAt;
         sb.AppendLine($"#### {FormatItemType(item.Type)} `{item.Id}` ({item.Status}, {timestamp:O})");
@@ -271,7 +278,12 @@ public sealed class ContextExportService
                 if (!string.IsNullOrWhiteSpace(toolExecution.ErrorMessage))
                     AppendMetadata(sb, "Error", toolExecution.ErrorMessage!);
                 if (!string.IsNullOrWhiteSpace(toolExecution.ResultPreview))
-                    AppendResult(sb, toolExecution.ResultPreview!, options.ToolResults, options.ToolResultPreviewChars, "Tool execution preview");
+                {
+                    if (IsRequestUserInput(toolExecution.ToolName))
+                        AppendUserInputResponseOmitted(sb, "Tool execution preview");
+                    else
+                        AppendResult(sb, toolExecution.ResultPreview!, options.ToolResults, options.ToolResultPreviewChars, "Tool execution preview");
+                }
                 break;
 
             case ItemType.ImageGeneration when item.AsImageGeneration is { } imageGeneration:
@@ -333,7 +345,10 @@ public sealed class ContextExportService
             case ItemType.ToolResult when item.AsToolResult is { } toolResult:
                 AppendMetadata(sb, "Call Id", toolResult.CallId);
                 AppendMetadata(sb, "Success", toolResult.Success.ToString());
-                AppendResult(sb, toolResult.Result, options.ToolResults, options.ToolResultPreviewChars, "Tool result");
+                if (IsRequestUserInput(toolResult.ToolName) || requestUserInputCallIds.Contains(toolResult.CallId))
+                    AppendUserInputResponseOmitted(sb, "Tool result");
+                else
+                    AppendResult(sb, toolResult.Result, options.ToolResults, options.ToolResultPreviewChars, "Tool result");
                 break;
 
             case ItemType.ApprovalRequest when item.AsApprovalRequest is { } approvalRequest:
@@ -358,7 +373,7 @@ public sealed class ContextExportService
 
             case ItemType.UserInputResponse when item.AsUserInputResponse is { } inputResponse:
                 AppendMetadata(sb, "Request Id", inputResponse.RequestId);
-                AppendJsonPayload(sb, inputResponse.Response);
+                AppendUserInputResponseOmitted(sb, "Response");
                 break;
 
             case ItemType.SystemNotice when item.AsSystemNotice is { } notice:
@@ -448,6 +463,14 @@ public sealed class ContextExportService
         IReadOnlyList<ChatMessage> messages,
         ContextExportOptions options)
     {
+        var requestUserInputCallIds = messages
+            .SelectMany(message => message.Contents)
+            .OfType<FunctionCallContent>()
+            .Where(content => IsRequestUserInput(GetPropertyValue(content, "Name")))
+            .Select(content => GetPropertyValue(content, "CallId"))
+            .Where(callId => !string.IsNullOrWhiteSpace(callId))
+            .ToHashSet(StringComparer.Ordinal);
+
         for (var i = 0; i < messages.Count; i++)
         {
             var message = messages[i];
@@ -483,13 +506,21 @@ public sealed class ContextExportService
 
                 if (content is FunctionResultContent)
                 {
-                    sb.AppendLine($"Tool result (`{GetPropertyValue(content, "CallId") ?? "unknown"}`):");
-                    AppendResult(
-                        sb,
-                        SerializeProperty(content, "Result"),
-                        options.ToolResults,
-                        options.ToolResultPreviewChars,
-                        "Tool result");
+                    var callId = GetPropertyValue(content, "CallId");
+                    sb.AppendLine($"Tool result (`{callId ?? "unknown"}`):");
+                    if (callId != null && requestUserInputCallIds.Contains(callId))
+                    {
+                        AppendUserInputResponseOmitted(sb, "Tool result");
+                    }
+                    else
+                    {
+                        AppendResult(
+                            sb,
+                            SerializeProperty(content, "Result"),
+                            options.ToolResults,
+                            options.ToolResultPreviewChars,
+                            "Tool result");
+                    }
                     continue;
                 }
 
@@ -499,6 +530,12 @@ public sealed class ContextExportService
             sb.AppendLine();
         }
     }
+
+    private static bool IsRequestUserInput(string? toolName) =>
+        string.Equals(toolName, RequestUserInputToolName, StringComparison.Ordinal);
+
+    private static void AppendUserInputResponseOmitted(StringBuilder sb, string label) =>
+        sb.AppendLine($"{label}: omitted because user-input answers may contain secrets.");
 
     private static string SerializeProperty(object value, string propertyName)
     {

--- a/src/DotCraft.Core/ContextExport/ContextExportService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextExportService.cs
@@ -36,7 +36,8 @@ public sealed class ContextExportService
             loaded.RolloutPath,
             loaded.Thread.Turns,
             excludedTurnId: null,
-            ct).ConfigureAwait(false);
+            ct,
+            options.ThreadId.Trim()).ConfigureAwait(false);
         foreach (var warning in replay.Warnings ?? [])
         {
             warnings.Add(string.IsNullOrWhiteSpace(warning.TurnId)
@@ -83,7 +84,8 @@ public sealed class ContextExportService
         AppendMetadata(sb, "Created At", thread.CreatedAt.ToString("O"));
         AppendMetadata(sb, "Last Active At", thread.LastActiveAt.ToString("O"));
         AppendMetadata(sb, "Origin Channel", thread.OriginChannel);
-        AppendMetadata(sb, "Channel Context", thread.ChannelContext ?? "(none)");
+        if (options.Profile == ContextExportProfile.Transcript)
+            AppendMetadata(sb, "Channel Context", SafeContextProjection.RedactText(thread.ChannelContext ?? "(none)"));
         AppendMetadata(sb, "History Mode", thread.HistoryMode.ToString());
         AppendMetadata(sb, "Turn Count", thread.Turns.Count.ToString());
         if (thread.Metadata.Count > 0)
@@ -293,7 +295,12 @@ public sealed class ContextExportService
                 AppendMetadata(sb, "Tool", toolCall.ToolName);
                 AppendMetadata(sb, "Call Id", toolCall.CallId);
                 if (toolCall.Arguments != null)
-                    AppendCodeBlock(sb, "json", toolCall.Arguments.ToJsonString(new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
+                {
+                    var arguments = options.ToolResults == ContextExportToolResultMode.None
+                        ? "[redacted]"
+                        : SafeContextProjection.RedactJson(toolCall.Arguments.ToJsonString(new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
+                    AppendCodeBlock(sb, "json", arguments);
+                }
                 break;
 
             case ItemType.PluginFunctionCall when item.AsPluginFunctionCall is { } pluginCall:
@@ -303,7 +310,12 @@ public sealed class ContextExportService
                 AppendMetadata(sb, "Call Id", pluginCall.CallId);
                 AppendMetadata(sb, "Success", pluginCall.Success.ToString());
                 if (pluginCall.Arguments != null)
-                    AppendCodeBlock(sb, "json", pluginCall.Arguments.ToJsonString(new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
+                {
+                    var arguments = options.ToolResults == ContextExportToolResultMode.None
+                        ? "[redacted]"
+                        : SafeContextProjection.RedactJson(pluginCall.Arguments.ToJsonString(new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
+                    AppendCodeBlock(sb, "json", arguments);
+                }
                 AppendStructuredResult(sb, pluginCall.StructuredResult, pluginCall.ErrorCode, pluginCall.ErrorMessage, options);
                 break;
 
@@ -315,7 +327,12 @@ public sealed class ContextExportService
                 if (dynamicCall.Success.HasValue)
                     AppendMetadata(sb, "Success", dynamicCall.Success.Value.ToString());
                 if (dynamicCall.Arguments != null)
-                    AppendCodeBlock(sb, "json", dynamicCall.Arguments.ToJsonString(new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
+                {
+                    var arguments = options.ToolResults == ContextExportToolResultMode.None
+                        ? "[redacted]"
+                        : SafeContextProjection.RedactJson(dynamicCall.Arguments.ToJsonString(new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
+                    AppendCodeBlock(sb, "json", arguments);
+                }
                 AppendStructuredResult(sb, dynamicCall.StructuredContent, dynamicCall.ErrorCode, dynamicCall.ErrorMessage, options);
                 break;
 
@@ -490,12 +507,12 @@ public sealed class ContextExportService
             return "{}";
 
         if (propertyValue is string text)
-            return text;
+            return SafeContextProjection.RedactText(text);
 
-        return JsonSerializer.Serialize(
+        return SafeContextProjection.RedactJson(JsonSerializer.Serialize(
             propertyValue,
             propertyValue.GetType(),
-            new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true });
+            new JsonSerializerOptions(JsonSerializerOptions.Web) { WriteIndented = true }));
     }
 
     private static string? GetPropertyValue(object value, string propertyName)

--- a/src/DotCraft.Core/ContextExport/ContextExportService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextExportService.cs
@@ -88,12 +88,6 @@ public sealed class ContextExportService
             AppendMetadata(sb, "Channel Context", SafeContextProjection.RedactText(thread.ChannelContext ?? "(none)"));
         AppendMetadata(sb, "History Mode", thread.HistoryMode.ToString());
         AppendMetadata(sb, "Turn Count", thread.Turns.Count.ToString());
-        if (thread.Metadata.Count > 0)
-        {
-            sb.AppendLine("- Metadata:");
-            foreach (var (key, value) in thread.Metadata.OrderBy(kv => kv.Key, StringComparer.Ordinal))
-                sb.AppendLine($"  - `{EscapeInline(key)}`: {EscapeInline(value)}");
-        }
         sb.AppendLine();
 
         AppendMemory(sb, memory, options);

--- a/src/DotCraft.Core/ContextExport/ContextExportService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextExportService.cs
@@ -421,18 +421,24 @@ public sealed class ContextExportService
             return;
         }
 
+        if (mode == ContextExportToolResultMode.None)
+        {
+            sb.AppendLine($"{label}: omitted by `--tool-results none`.");
+            return;
+        }
+
+        // Redact before bounding so previews cannot retain a truncated fragment of a secret
+        // or destroy the JSON structure needed for sensitive-key detection.
+        var redacted = SafeContextProjection.RedactJson(value);
         switch (mode)
         {
-            case ContextExportToolResultMode.None:
-                sb.AppendLine($"{label}: omitted by `--tool-results none`.");
-                break;
             case ContextExportToolResultMode.Summary:
                 sb.AppendLine($"{label} preview:");
-                AppendCodeBlock(sb, string.Empty, ContextWorkspaceReader.Bound(value, Math.Max(1, previewChars)));
+                AppendCodeBlock(sb, string.Empty, ContextWorkspaceReader.Bound(redacted, Math.Max(1, previewChars)));
                 break;
             case ContextExportToolResultMode.Full:
                 sb.AppendLine($"{label}:");
-                AppendCodeBlock(sb, string.Empty, value.TrimEnd());
+                AppendCodeBlock(sb, string.Empty, redacted.TrimEnd());
                 break;
         }
     }

--- a/src/DotCraft.Core/ContextExport/ContextSearchService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextSearchService.cs
@@ -78,9 +78,7 @@ public sealed class ContextSearchService
                 row.ThreadId,
                 row.DisplayName,
                 row.FirstUserMessage,
-                row.OriginChannel,
-                row.ChannelContext,
-                row.MetadataJson);
+                 row.OriginChannel);
             var score = ScoreText(haystack, terms);
             if (row.ThreadId.Contains(string.Join(' ', terms), StringComparison.OrdinalIgnoreCase))
                 score += 80;
@@ -116,7 +114,6 @@ public sealed class ContextSearchService
             var expression = """
                 lower(coalesce(session_key, '') || ' ' ||
                       coalesce(last_finish_reason, '') || ' ' ||
-                      coalesce(final_system_prompt, '') || ' ' ||
                       coalesce(tool_names_json, ''))
                 """;
             AddTermParameters(command, terms);
@@ -147,7 +144,7 @@ public sealed class ContextSearchService
                 var preview = BuildTraceSessionPreview(
                     sessionKey,
                     reader.IsDBNull(2) ? null : reader.GetString(2),
-                    reader.IsDBNull(3) ? null : reader.GetString(3),
+                    null,
                     reader.IsDBNull(4) ? null : reader.GetString(4),
                     reader.GetInt32(5),
                     reader.GetInt32(6),
@@ -465,7 +462,7 @@ public sealed class ContextSearchService
 
         if (builder.Length > 0)
             builder.Append(' ');
-        builder.Append(name).Append('=').Append(value);
+        builder.Append(name).Append('=').Append(SafeContextProjection.RedactText(value));
     }
 
     private static IReadOnlyDictionary<string, string?> LoadTraceBindings(
@@ -504,9 +501,7 @@ public sealed class ContextSearchService
             builder.Append($" finish={finishReason}");
         builder.Append($" errors={errorCount} tools={toolCallCount} compactions={compactionCount}");
         if (!string.IsNullOrWhiteSpace(toolNamesJson))
-            builder.Append($" tools_json={toolNamesJson}");
-        if (!string.IsNullOrWhiteSpace(finalSystemPrompt))
-            builder.Append($" prompt={finalSystemPrompt}");
+            builder.Append($" tools={SafeContextProjection.RedactText(toolNamesJson)}");
         return builder.ToString();
     }
 
@@ -525,8 +520,6 @@ public sealed class ContextSearchService
             builder.Append($" model={modelId}");
         if (!string.IsNullOrWhiteSpace(finishReason))
             builder.Append($" finish={finishReason}");
-        builder.Append(' ');
-        builder.Append(eventJson);
         return builder.ToString();
     }
 

--- a/src/DotCraft.Core/ContextExport/ContextSearchService.cs
+++ b/src/DotCraft.Core/ContextExport/ContextSearchService.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Text.Json;
+using DotCraft.Protocol;
 using Microsoft.Data.Sqlite;
 
 namespace DotCraft.ContextExport;
@@ -261,32 +263,209 @@ public sealed class ContextSearchService
             if (!File.Exists(path))
                 continue;
 
+            var snippetsByItem = new Dictionary<string, RolloutItemSnippet>(StringComparer.Ordinal);
             var lineNumber = 0;
             await foreach (var line in File.ReadLinesAsync(path, ct))
             {
                 lineNumber++;
-                if (line.Contains("\"kind\":\"context_compacted\"", StringComparison.OrdinalIgnoreCase) ||
-                    line.Contains("\"kind\": \"context_compacted\"", StringComparison.OrdinalIgnoreCase))
+                ThreadRolloutRecord? record;
+                try
+                {
+                    using var document = JsonDocument.Parse(line);
+                    if (!document.RootElement.TryGetProperty("kind", out var kindElement))
+                        continue;
+
+                    var kind = kindElement.GetString();
+                    if (string.Equals(kind, "model_history_messages_appended", StringComparison.Ordinal) ||
+                        string.Equals(kind, "context_compacted", StringComparison.Ordinal) ||
+                        kind is not ("item_appended" or "turn_state_replaced"))
+                    {
+                        continue;
+                    }
+
+                    record = document.RootElement.Deserialize<ThreadRolloutRecord>(SessionJsonOptions.Default);
+                }
+                catch (Exception ex) when (ex is JsonException or NotSupportedException)
                 {
                     continue;
                 }
 
-                if (!ContainsAllTerms(line, terms))
+                if (record is null)
+                    continue;
+
+                if (record is { Kind: "item_appended", ItemAppended: { } appended })
+                {
+                    AddOrReplaceRolloutItemSnippet(
+                        snippetsByItem,
+                        appended.TurnId,
+                        appended.Item,
+                        lineNumber,
+                        record.Timestamp);
+                }
+                else if (record is { Kind: "turn_state_replaced", TurnStateReplaced: { } replacement })
+                {
+                    foreach (var item in replacement.Turn.Items)
+                    {
+                        AddOrReplaceRolloutItemSnippet(
+                            snippetsByItem,
+                            replacement.Turn.Id,
+                            item,
+                            lineNumber,
+                            record.Timestamp);
+                    }
+                }
+            }
+
+            foreach (var snippet in snippetsByItem.Values.OrderBy(static snippet => snippet.LineNumber))
+            {
+                if (!ContainsAllTerms(snippet.Text, terms))
                     continue;
 
                 var hit = GetHit(hits, threadId, rowByThreadId, null, null);
                 hit.RolloutPath ??= path;
-                hit.Score += 8 + ScoreText(line, terms);
+                hit.Score += 8 + ScoreText(snippet.Text, terms);
                 hit.AddEvidence(new ContextSearchEvidence
                 {
                     Source = "rollout",
-                    SourceId = $"{Path.GetFileName(path)}:{lineNumber}",
+                    SourceId = $"{Path.GetFileName(path)}:{snippet.LineNumber}",
+                    Timestamp = snippet.Timestamp,
                     Preview = ContextWorkspaceReader.Bound(
-                        ContextWorkspaceReader.NormalizeWhitespace(line),
+                        ContextWorkspaceReader.NormalizeWhitespace(snippet.Text),
                         Math.Max(1, options.PreviewChars))
                 });
             }
         }
+    }
+
+    private static void AddOrReplaceRolloutItemSnippet(
+        Dictionary<string, RolloutItemSnippet> snippetsByItem,
+        string turnId,
+        SessionItem item,
+        int lineNumber,
+        DateTimeOffset timestamp)
+    {
+        var text = BuildDisplayableItemText(item);
+        if (string.IsNullOrWhiteSpace(text))
+            return;
+
+        var key = $"{turnId}\0{item.Id}";
+        snippetsByItem[key] = new RolloutItemSnippet(lineNumber, timestamp, text);
+    }
+
+    private static string BuildDisplayableItemText(SessionItem item)
+    {
+        var builder = new StringBuilder();
+        AppendSearchField(builder, "type", item.Type.ToString());
+        AppendSearchField(builder, "status", item.Status.ToString());
+
+        switch (item.Type)
+        {
+            case ItemType.UserMessage when item.AsUserMessage is { } user:
+                AppendSearchField(builder, "text", user.Text);
+                AppendSearchField(builder, "sender", user.SenderName);
+                AppendSearchField(builder, "channel", user.ChannelName);
+                break;
+            case ItemType.AgentMessage when item.AsAgentMessage is { } agent:
+                AppendSearchField(builder, "text", agent.Text);
+                break;
+            case ItemType.ReasoningContent:
+                // Reasoning is intentionally omitted from searchable/exportable handoff content.
+                return string.Empty;
+            case ItemType.CommandExecution when item.AsCommandExecution is { } command:
+                AppendSearchField(builder, "command", command.Command);
+                AppendSearchField(builder, "working_directory", command.WorkingDirectory);
+                AppendSearchField(builder, "execution_status", command.Status);
+                AppendSearchField(builder, "output", command.AggregatedOutput);
+                break;
+            case ItemType.ToolExecution when item.AsToolExecution is { } execution:
+                AppendSearchField(builder, "tool", execution.ToolName);
+                AppendSearchField(builder, "execution_status", execution.Status);
+                AppendSearchField(builder, "result", execution.ResultPreview);
+                AppendSearchField(builder, "error", execution.ErrorMessage);
+                break;
+            case ItemType.ImageGeneration when item.AsImageGeneration is { } image:
+                AppendSearchField(builder, "generation_status", image.Status);
+                AppendSearchField(builder, "prompt", image.RevisedPrompt);
+                break;
+            case ItemType.ToolCall when item.AsToolCall is { } toolCall:
+                AppendSearchField(builder, "namespace", toolCall.Namespace);
+                AppendSearchField(builder, "tool", toolCall.ToolName);
+                break;
+            case ItemType.PluginFunctionCall when item.AsPluginFunctionCall is { } pluginCall:
+                AppendSearchField(builder, "plugin", pluginCall.PluginId);
+                AppendSearchField(builder, "namespace", pluginCall.Namespace);
+                AppendSearchField(builder, "function", pluginCall.FunctionName);
+                AppendSearchField(builder, "error_code", pluginCall.ErrorCode);
+                AppendSearchField(builder, "error", pluginCall.ErrorMessage);
+                break;
+            case ItemType.McpToolCall when item.AsMcpToolCall is { } mcpCall:
+                AppendSearchField(builder, "server", mcpCall.Server);
+                AppendSearchField(builder, "namespace", mcpCall.Namespace);
+                AppendSearchField(builder, "tool", mcpCall.ToolName);
+                AppendSearchField(builder, "execution_status", mcpCall.Status);
+                AppendSearchField(builder, "error_code", mcpCall.ErrorCode);
+                AppendSearchField(builder, "error", mcpCall.ErrorMessage);
+                break;
+            case ItemType.DynamicToolCall when item.AsDynamicToolCall is { } dynamicCall:
+                AppendSearchField(builder, "namespace", dynamicCall.Namespace);
+                AppendSearchField(builder, "tool", dynamicCall.ToolName);
+                AppendSearchField(builder, "execution_status", dynamicCall.Status);
+                AppendSearchField(builder, "error_code", dynamicCall.ErrorCode);
+                AppendSearchField(builder, "error", dynamicCall.ErrorMessage);
+                break;
+            case ItemType.ToolResult when item.AsToolResult is { } result:
+                AppendSearchField(builder, "namespace", result.Namespace);
+                AppendSearchField(builder, "tool", result.ToolName);
+                AppendSearchField(builder, "result", result.Result);
+                AppendSearchField(builder, "error_code", result.ErrorCode);
+                AppendSearchField(builder, "error", result.ErrorMessage);
+                break;
+            case ItemType.ApprovalRequest when item.AsApprovalRequest is { } approval:
+                AppendSearchField(builder, "approval_type", approval.ApprovalType);
+                AppendSearchField(builder, "operation", approval.Operation);
+                AppendSearchField(builder, "target", approval.Target);
+                AppendSearchField(builder, "reason", approval.Reason);
+                break;
+            case ItemType.ApprovalResponse when item.AsApprovalResponse is { } response:
+                AppendSearchField(builder, "decision", response.Decision.ToString());
+                break;
+            case ItemType.UserInputRequest when item.AsUserInputRequest is { } request:
+                foreach (var question in request.Questions)
+                {
+                    AppendSearchField(builder, "question_header", question.Header);
+                    AppendSearchField(builder, "question", question.Question);
+                    foreach (var option in question.Options)
+                    {
+                        AppendSearchField(builder, "option", option.Label);
+                        AppendSearchField(builder, "option_description", option.Description);
+                    }
+                }
+                break;
+            case ItemType.UserInputResponse:
+                // Responses may contain answers to secret questions.
+                return string.Empty;
+            case ItemType.Error when item.AsError is { } error:
+                AppendSearchField(builder, "error_code", error.Code);
+                AppendSearchField(builder, "error", error.Message);
+                break;
+            case ItemType.SystemNotice when item.AsSystemNotice is { } notice:
+                AppendSearchField(builder, "notice", notice.Kind);
+                AppendSearchField(builder, "trigger", notice.Trigger);
+                AppendSearchField(builder, "mode", notice.Mode);
+                break;
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendSearchField(StringBuilder builder, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        if (builder.Length > 0)
+            builder.Append(' ');
+        builder.Append(name).Append('=').Append(value);
     }
 
     private static IReadOnlyDictionary<string, string?> LoadTraceBindings(
@@ -512,6 +691,11 @@ public sealed class ContextSearchService
                 yield return (Path.GetFileNameWithoutExtension(file), file);
         }
     }
+
+    private sealed record RolloutItemSnippet(
+        int LineNumber,
+        DateTimeOffset Timestamp,
+        string Text);
 
     private sealed class HitBuilder
     {

--- a/src/DotCraft.Core/ContextExport/ContextWorkspaceReader.cs
+++ b/src/DotCraft.Core/ContextExport/ContextWorkspaceReader.cs
@@ -51,6 +51,11 @@ internal sealed class ContextWorkspaceReader
         var thread = replay.Build();
         if (thread == null)
             return null;
+        if (!string.Equals(thread.Id, threadId, StringComparison.Ordinal))
+        {
+            warnings.Add($"Rollout header thread id does not match requested thread '{threadId}'.");
+            return null;
+        }
 
         return new ContextLoadedThread(
             paths,
@@ -126,9 +131,16 @@ internal sealed class ContextWorkspaceReader
                 if (!MatchesStatusFilter(storedStatus, status))
                     continue;
 
+                var storedRolloutPath = ResolveStoredPath(paths.CraftPath, reader.GetString(1));
+                if (storedRolloutPath == null)
+                {
+                    warnings.Add($"Ignoring rollout path outside craft directory for thread '{reader.GetString(0)}'.");
+                    continue;
+                }
+
                 rows.Add(new ContextThreadIndexRow(
                     ThreadId: reader.GetString(0),
-                    RolloutPath: ResolveStoredPath(paths.CraftPath, reader.GetString(1)),
+                    RolloutPath: storedRolloutPath,
                     WorkspacePath: reader.GetString(2),
                     OriginChannel: reader.GetString(3),
                     ChannelContext: reader.IsDBNull(4) ? null : reader.GetString(4),
@@ -173,7 +185,9 @@ internal sealed class ContextWorkspaceReader
 
     public static string TakeTail(string value, int maxChars)
     {
-        if (maxChars <= 0 || string.IsNullOrEmpty(value) || value.Length <= maxChars)
+        if (maxChars <= 0 || string.IsNullOrEmpty(value))
+            return string.Empty;
+        if (value.Length <= maxChars)
             return value;
 
         return value[^maxChars..].TrimStart();
@@ -212,8 +226,6 @@ internal sealed class ContextWorkspaceReader
         return value[..maxChars].TrimEnd() + " ...";
     }
 
-    public static string MakeSafe(string key) => string.Concat(key.Split(Path.GetInvalidFileNameChars()));
-
     private string? TryResolveRolloutPath(
         ContextWorkspacePaths paths,
         string threadId,
@@ -234,7 +246,9 @@ internal sealed class ContextWorkspaceReader
                     if (File.Exists(resolved))
                         return resolved;
 
-                    warnings.Add($"Thread metadata points to a missing rollout file: {resolved}");
+                    warnings.Add(resolved == null
+                        ? "Thread metadata points to a rollout path outside the craft directory."
+                        : $"Thread metadata points to a missing rollout file: {resolved}");
                 }
             }
             catch (Exception ex) when (ex is SqliteException or InvalidOperationException)
@@ -243,13 +257,7 @@ internal sealed class ContextWorkspaceReader
             }
         }
 
-        var safe = MakeSafe(threadId);
-        var active = Path.Combine(paths.CraftPath, "threads", "active", $"{safe}.jsonl");
-        if (File.Exists(active))
-            return active;
-
-        var archived = Path.Combine(paths.CraftPath, "threads", "archived", $"{safe}.jsonl");
-        return File.Exists(archived) ? archived : null;
+        return null;
     }
 
     private static SqliteConnection OpenReadOnlyConnection(string dbPath)
@@ -271,12 +279,35 @@ internal sealed class ContextWorkspaceReader
         return connection;
     }
 
-    private static string ResolveStoredPath(string craftPath, string storedPath)
+    private static string? ResolveStoredPath(string craftPath, string storedPath)
     {
-        if (Path.IsPathRooted(storedPath))
-            return Path.GetFullPath(storedPath);
+        if (string.IsNullOrWhiteSpace(storedPath))
+            return null;
 
-        return Path.GetFullPath(Path.Combine(craftPath, storedPath));
+        string resolved;
+        try
+        {
+            resolved = Path.GetFullPath(
+                Path.IsPathRooted(storedPath)
+                    ? storedPath
+                    : Path.Combine(craftPath, storedPath));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+
+        var root = Path.GetFullPath(craftPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return resolved.StartsWith(root, comparison) ? resolved : null;
     }
 
     private static bool MatchesStatusFilter(string storedStatus, ContextSearchStatusFilter filter)

--- a/src/DotCraft.Core/ContextExport/ContextWorkspaceReader.cs
+++ b/src/DotCraft.Core/ContextExport/ContextWorkspaceReader.cs
@@ -315,6 +315,7 @@ internal sealed class ContextWorkspaceReader
     {
         private readonly Dictionary<string, SessionTurn> _turns = new(StringComparer.Ordinal);
         private SessionThread? _thread;
+        private bool _hasCanonicalHeader;
 
         public List<ContextContinuityEvent> ContinuityEvents { get; } = [];
 
@@ -330,12 +331,27 @@ internal sealed class ContextWorkspaceReader
             }
             catch (JsonException ex)
             {
+                if (!_hasCanonicalHeader)
+                    throw new InvalidDataException("The canonical thread header is unreadable.", ex);
                 warnings.Add($"Skipped corrupt rollout line {lineNumber}: {ex.Message}");
                 return;
             }
 
             if (record == null)
+            {
+                if (!_hasCanonicalHeader)
+                    throw new InvalidDataException("The canonical thread header is empty.");
                 return;
+            }
+
+            if (record.Kind == "thread_opened" && record.ThreadOpened == null)
+                throw new InvalidDataException("A canonical thread baseline record is incomplete.");
+
+            if (!_hasCanonicalHeader
+                && (record.Kind != "thread_opened" || record.ThreadOpened == null))
+            {
+                throw new InvalidDataException("The rollout does not begin with a canonical thread header.");
+            }
 
             switch (record.Kind)
             {
@@ -346,11 +362,20 @@ internal sealed class ContextWorkspaceReader
                     _thread.UserId = record.ThreadOpened.UserId;
                     _thread.OriginChannel = record.ThreadOpened.OriginChannel;
                     _thread.ChannelContext = record.ThreadOpened.ChannelContext;
+                    _thread.Source = record.ThreadOpened.Source == null
+                        ? PersistedThreadSourceCodec.InferLegacy(
+                            record.ThreadOpened.OriginChannel,
+                            record.ThreadOpened.Metadata)
+                        : PersistedThreadSourceCodec.Decode(record.ThreadOpened.Source);
+                    _thread.ForkedFromId = record.ThreadOpened.ForkedFromId;
+                    _thread.Ephemeral = record.ThreadOpened.Ephemeral;
+                    _thread.Worktree = record.ThreadOpened.Worktree;
                     _thread.CreatedAt = record.ThreadOpened.CreatedAt;
                     _thread.LastActiveAt = record.ThreadOpened.LastActiveAt;
                     _thread.Metadata = new Dictionary<string, string>(record.ThreadOpened.Metadata);
                     _thread.HistoryMode = record.ThreadOpened.HistoryMode;
                     _thread.Configuration = record.ThreadOpened.Configuration;
+                    _hasCanonicalHeader = true;
                     break;
 
                 case "thread_name_updated" when _thread != null && record.ThreadNameUpdated != null:
@@ -360,6 +385,17 @@ internal sealed class ContextWorkspaceReader
                 case "thread_status_changed" when _thread != null && record.ThreadStatusChanged != null:
                     _thread.Status = record.ThreadStatusChanged.Status;
                     _thread.LastActiveAt = record.ThreadStatusChanged.LastActiveAt;
+                    break;
+
+                case "turn_state_replaced" when _thread != null && record.TurnStateReplaced != null:
+                    var replacement = record.TurnStateReplaced;
+                    var replacementTurn = replacement.Turn;
+                    replacementTurn.Input ??= replacementTurn.Items.FirstOrDefault(static item =>
+                        item.Type == ItemType.UserMessage);
+                    _turns[replacementTurn.Id] = replacementTurn;
+                    _thread.Status = replacement.ThreadStatus;
+                    _thread.LastActiveAt = replacement.LastActiveAt;
+                    _thread.DisplayName = replacement.DisplayName;
                     break;
 
                 case "turn_started" when _thread != null && record.TurnStarted != null:
@@ -424,8 +460,7 @@ internal sealed class ContextWorkspaceReader
                         record.ContextCompacted.Mode,
                         record.ContextCompacted.TokensBefore,
                         record.ContextCompacted.TokensAfter,
-                        record.ContextCompacted.CreatedAt,
-                        record.ContextCompacted.ReplacementHistory.Clone()));
+                        record.ContextCompacted.CreatedAt));
                     break;
 
                 case "queued_input_added" when _thread != null && record.QueuedInputAdded != null:
@@ -527,8 +562,7 @@ internal sealed record ContextContinuityEvent(
     string? Mode,
     long? TokensBefore,
     long? TokensAfter,
-    DateTimeOffset? CreatedAt,
-    JsonElement? ReplacementHistory)
+    DateTimeOffset? CreatedAt)
 {
     public static ContextContinuityEvent FromRollback(
         int lineNumber,
@@ -547,7 +581,6 @@ internal sealed record ContextContinuityEvent(
             null,
             null,
             null,
-            null,
             null);
 
     public static ContextContinuityEvent FromCompaction(
@@ -560,8 +593,7 @@ internal sealed record ContextContinuityEvent(
         string mode,
         long tokensBefore,
         long tokensAfter,
-        DateTimeOffset createdAt,
-        JsonElement replacementHistory) =>
+        DateTimeOffset createdAt) =>
         new(
             ContextContinuityEventKind.Compaction,
             lineNumber,
@@ -574,8 +606,7 @@ internal sealed record ContextContinuityEvent(
             mode,
             tokensBefore,
             tokensAfter,
-            createdAt,
-            replacementHistory);
+            createdAt);
 }
 
 internal sealed record ContextThreadIndexRow(

--- a/src/DotCraft.Core/ContextExport/SafeContextProjection.cs
+++ b/src/DotCraft.Core/ContextExport/SafeContextProjection.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace DotCraft.ContextExport;
+
+internal static partial class SafeContextProjection
+{
+    private static readonly string[] SensitiveKeyFragments =
+    [
+        "token", "secret", "password", "passwd", "credential", "authorization", "cookie",
+        "private_key", "privatekey", "apikey", "api_key", "access_key", "refresh_token"
+    ];
+
+    public static string RedactJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return json;
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            using var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+            {
+                WriteElement(writer, document.RootElement, null);
+            }
+
+            return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        }
+        catch (JsonException)
+        {
+            return RedactText(json);
+        }
+    }
+
+    public static string RedactText(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        var redacted = BearerTokenRegex().Replace(value, "$1[redacted]");
+        redacted = SecretAssignmentRegex().Replace(redacted, "$1[redacted]");
+        return redacted;
+    }
+
+    public static string RedactOrOmit(string value, ContextExportToolResultMode mode)
+    {
+        return mode == ContextExportToolResultMode.None ? "[redacted]" : RedactText(value);
+    }
+
+    private static void WriteElement(Utf8JsonWriter writer, JsonElement element, string? propertyName)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                foreach (var property in element.EnumerateObject())
+                {
+                    writer.WritePropertyName(property.Name);
+                    if (IsSensitiveKey(property.Name))
+                        writer.WriteStringValue("[redacted]");
+                    else
+                        WriteElement(writer, property.Value, property.Name);
+                }
+                writer.WriteEndObject();
+                break;
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                    WriteElement(writer, item, propertyName);
+                writer.WriteEndArray();
+                break;
+            default:
+                element.WriteTo(writer);
+                break;
+        }
+    }
+
+    private static bool IsSensitiveKey(string key)
+    {
+        var normalized = key.Replace("-", "_", StringComparison.Ordinal).ToLowerInvariant();
+        return SensitiveKeyFragments.Any(normalized.Contains);
+    }
+
+    [GeneratedRegex(@"(?i)(\bBearer\s+)[^\s,;]+")]
+    private static partial Regex BearerTokenRegex();
+
+    [GeneratedRegex(@"(?i)(\b(?:token|secret|password|passwd|api[_-]?key|authorization|cookie)\s*[=:]\s*)[^\s,;]+")]
+    private static partial Regex SecretAssignmentRegex();
+}

--- a/src/DotCraft.Core/Hosting/WorkspaceRuntime.cs
+++ b/src/DotCraft.Core/Hosting/WorkspaceRuntime.cs
@@ -32,6 +32,7 @@ public sealed class WorkspaceRuntime : IAsyncDisposable
         WireAcpExtensionProxy wireAcpExtensionProxy,
         WireNodeReplProxy wireNodeReplProxy,
         WireDynamicToolProxy wireDynamicToolProxy,
+        ThreadStore threadStore,
         ISessionService sessionService,
         ICommitMessageSuggestService commitMessageSuggestService,
         WelcomeSuggestionService welcomeSuggestionService,
@@ -52,6 +53,8 @@ public sealed class WorkspaceRuntime : IAsyncDisposable
         public WireNodeReplProxy WireNodeReplProxy { get; } = wireNodeReplProxy;
 
         public WireDynamicToolProxy WireDynamicToolProxy { get; } = wireDynamicToolProxy;
+
+        public ThreadStore ThreadStore { get; } = threadStore;
 
         public ISessionService SessionService { get; } = sessionService;
 
@@ -409,6 +412,7 @@ public sealed class WorkspaceRuntime : IAsyncDisposable
                     wireAcpExtensionProxy,
                     wireNodeReplProxy,
                     wireDynamicToolProxy,
+                    Services.GetRequiredService<ThreadStore>(),
                     sessionService,
                     commitMessageSuggestService,
                     welcomeSuggestionService,
@@ -610,6 +614,15 @@ public sealed class WorkspaceRuntime : IAsyncDisposable
                 started.SessionService.ThreadRuntimeSignalForBroadcast = null;
                 if (started.SessionService is SessionService sessionService)
                     sessionService.SubAgentGraphChangedForBroadcast = null;
+            }
+            catch (Exception ex)
+            {
+                (errors ??= []).Add(ex);
+            }
+
+            try
+            {
+                await started.ThreadStore.FlushAndCloseAsync(ct);
             }
             catch (Exception ex)
             {

--- a/src/DotCraft.Core/Protocol/ISessionService.cs
+++ b/src/DotCraft.Core/Protocol/ISessionService.cs
@@ -130,7 +130,7 @@ public interface ISessionService
 
     /// <summary>
     /// Resumes a Paused or previously inactive Thread.
-    /// Loads Thread state and reconstructs agent session from persistence.
+    /// Loads Thread state and reconstructs a runtime agent session from canonical rollout history.
     /// </summary>
     Task<SessionThread> ResumeThreadAsync(string threadId, CancellationToken ct = default);
 

--- a/src/DotCraft.Core/Protocol/ModelHistory.cs
+++ b/src/DotCraft.Core/Protocol/ModelHistory.cs
@@ -1,0 +1,697 @@
+using System.Text.Json;
+using DotCraft.Agents;
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Protocol;
+
+internal interface IModelHistoryCodec
+{
+    ModelHistoryMessage Encode(ChatMessage message, string? turnId = null);
+
+    ChatMessage Decode(ModelHistoryMessage message);
+}
+
+internal interface IRolloutReplayer
+{
+    Task<ModelHistoryReplayResult> ReplayModelHistoryAsync(
+        string rolloutPath,
+        IReadOnlyList<SessionTurn> survivingTurns,
+        string? excludedTurnId = null,
+        CancellationToken ct = default);
+}
+
+#pragma warning disable MEAI001 // Persist the complete runtime usage contract, including preview counters.
+internal sealed class ModelHistoryCodec : IModelHistoryCodec
+{
+    public const int CurrentSchemaVersion = 1;
+
+    private const int CurrentResultSchemaVersion = 1;
+    private const string ProviderFlatNameMetadataKey = "dotcraft.tool.provider_flat_name";
+    private const string FunctionNamespaceMetadataKey = "openai.responses.function_call.namespace";
+    private const string FunctionNamespaceAliasKey = "namespace";
+
+    private static readonly JsonSerializerOptions JsonOptions = SessionPersistenceJsonOptions.Default;
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new(JsonSerializerOptions.Web);
+
+    public ModelHistoryMessage Encode(ChatMessage message, string? turnId = null)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        return new ModelHistoryMessage
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            TurnId = turnId,
+            Role = message.Role.Value,
+            MessageId = message.MessageId,
+            AuthorName = message.AuthorName,
+            CreatedAt = message.CreatedAt,
+            AdditionalProperties = SerializeAdditionalProperties(message.AdditionalProperties),
+            Contents = message.Contents
+                .Where(static content => content is not ToolCallArgumentsDeltaContent)
+                .Select(EncodeContent)
+                .ToList()
+        };
+    }
+
+    public ChatMessage Decode(ModelHistoryMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (message.SchemaVersion != CurrentSchemaVersion)
+            throw new NotSupportedException($"Unsupported model history schema version '{message.SchemaVersion}'.");
+
+        var decoded = new ChatMessage(new ChatRole(message.Role), message.Contents.Select(DecodeContent).ToList())
+        {
+            MessageId = message.MessageId,
+            AuthorName = message.AuthorName,
+            CreatedAt = message.CreatedAt,
+            AdditionalProperties = DeserializeAdditionalProperties(message.AdditionalProperties)
+        };
+        return decoded;
+    }
+
+    private static ModelHistoryContent EncodeContent(AIContent content)
+    {
+        return content switch
+        {
+            TextContent value => CreateContent("text", new PersistedTextContent
+            {
+                Text = value.Text,
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            TextReasoningContent value => CreateContent("reasoning", new PersistedReasoningContent
+            {
+                Text = value.Text,
+                ProtectedData = value.ProtectedData,
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            DataContent value => CreateContent("data", new PersistedDataContent
+            {
+                Base64Data = value.Base64Data.ToString(),
+                MediaType = value.MediaType,
+                Name = value.Name,
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            FunctionCallContent value => EncodeFunctionCall(value),
+            FunctionResultContent value => CreateContent("function_result", new PersistedFunctionResultContent
+            {
+                CallId = value.CallId,
+                Result = EncodeFunctionResult(value.Result),
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            HostedImageGenerationContent value => CreateContent(
+                "hosted_image_generation",
+                new PersistedHostedImageGenerationContent
+                {
+                    Id = value.Id,
+                    Status = value.Status,
+                    RevisedPrompt = value.RevisedPrompt,
+                    ImageBase64 = value.ImageBytes is null ? null : Convert.ToBase64String(value.ImageBytes),
+                    MediaType = value.MediaType,
+                    ErrorMessage = value.ErrorMessage,
+                    AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+                }),
+            ImageGenerationToolCallContent value => CreateContent(
+                "image_generation_tool_call",
+                new PersistedImageGenerationToolCallContent
+                {
+                    CallId = value.CallId,
+                    AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+                }),
+            ImageGenerationToolResultContent value => CreateContent(
+                "image_generation_tool_result",
+                new PersistedImageGenerationToolResultContent
+                {
+                    CallId = value.CallId,
+                    Outputs = value.Outputs?.Select(EncodeContent).ToList(),
+                    AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+                }),
+            ErrorContent value => CreateContent("error", new PersistedErrorContent
+            {
+                Message = value.Message,
+                ErrorCode = value.ErrorCode,
+                Details = value.Details,
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            UriContent value => CreateContent("uri", new PersistedUriContent
+            {
+                Uri = value.Uri.ToString(),
+                MediaType = value.MediaType,
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            UsageContent value => CreateContent("usage", new PersistedUsageContent
+            {
+                InputTokenCount = value.Details.InputTokenCount,
+                OutputTokenCount = value.Details.OutputTokenCount,
+                TotalTokenCount = value.Details.TotalTokenCount,
+                CachedInputTokenCount = value.Details.CachedInputTokenCount,
+                ReasoningTokenCount = value.Details.ReasoningTokenCount,
+                InputAudioTokenCount = value.Details.InputAudioTokenCount,
+                InputTextTokenCount = value.Details.InputTextTokenCount,
+                OutputAudioTokenCount = value.Details.OutputAudioTokenCount,
+                OutputTextTokenCount = value.Details.OutputTextTokenCount,
+                AdditionalCounts = value.Details.AdditionalCounts is null
+                    ? null
+                    : new Dictionary<string, long>(value.Details.AdditionalCounts, StringComparer.Ordinal),
+                AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+            }),
+            _ => throw new NotSupportedException(
+                $"AI content type '{content.GetType().FullName}' is not supported by model history schema v{CurrentSchemaVersion}.")
+        };
+    }
+
+    private static ModelHistoryContent EncodeFunctionCall(FunctionCallContent value)
+    {
+        var functionNamespace = ReadConsistentMetadataValue(
+            value.AdditionalProperties,
+            FunctionNamespaceMetadataKey,
+            FunctionNamespaceAliasKey);
+        var providerFlatName = ReadConsistentMetadataValue(
+            value.AdditionalProperties,
+            ProviderFlatNameMetadataKey);
+        return CreateContent("function_call", new PersistedFunctionCallContent
+        {
+            CallId = value.CallId,
+            Name = value.Name,
+            Arguments = SerializeJsonValue(value.Arguments),
+            InformationalOnly = value.InformationalOnly,
+            Namespace = functionNamespace,
+            ProviderFlatName = providerFlatName,
+            AdditionalProperties = SerializeAdditionalProperties(value.AdditionalProperties)
+        });
+    }
+
+    private static AIContent DecodeContent(ModelHistoryContent content)
+    {
+        return content.Kind switch
+        {
+            "text" => DecodeText(content),
+            "reasoning" => DecodeReasoning(content),
+            "data" => DecodeData(content),
+            "function_call" => DecodeFunctionCall(content),
+            "function_result" => DecodeFunctionResult(content),
+            "hosted_image_generation" => DecodeHostedImageGeneration(content),
+            "image_generation_tool_call" => DecodeImageGenerationToolCall(content),
+            "image_generation_tool_result" => DecodeImageGenerationToolResult(content),
+            "error" => DecodeError(content),
+            "uri" => DecodeUri(content),
+            "usage" => DecodeUsage(content),
+            _ => throw new NotSupportedException($"Unsupported model history content kind '{content.Kind}'.")
+        };
+    }
+
+    private static AIContent DecodeText(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedTextContent>(content);
+        return ApplyAdditionalProperties(new TextContent(payload.Text), payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeReasoning(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedReasoningContent>(content);
+        return ApplyAdditionalProperties(
+            new TextReasoningContent(payload.Text) { ProtectedData = payload.ProtectedData },
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeData(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedDataContent>(content);
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(payload.Base64Data);
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException("Model history data content has invalid base64 data.", ex);
+        }
+
+        return ApplyAdditionalProperties(
+            new DataContent(bytes, payload.MediaType) { Name = payload.Name },
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeFunctionCall(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedFunctionCallContent>(content);
+        var properties = DeserializeAdditionalProperties(payload.AdditionalProperties);
+        ValidateAndRestoreToolIdentity(
+            properties,
+            payload.Namespace,
+            payload.ProviderFlatName,
+            out properties);
+        var arguments = DeserializeDictionary(payload.Arguments);
+        return new FunctionCallContent(payload.CallId, payload.Name, arguments)
+        {
+            InformationalOnly = payload.InformationalOnly,
+            AdditionalProperties = properties
+        };
+    }
+
+    private static AIContent DecodeFunctionResult(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedFunctionResultContent>(content);
+        return ApplyAdditionalProperties(
+            new FunctionResultContent(payload.CallId, DecodeFunctionResult(payload.Result)),
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeHostedImageGeneration(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedHostedImageGenerationContent>(content);
+        byte[]? imageBytes = null;
+        if (payload.ImageBase64 is not null)
+        {
+            try
+            {
+                imageBytes = Convert.FromBase64String(payload.ImageBase64);
+            }
+            catch (FormatException ex)
+            {
+                throw new JsonException("Model history hosted image content has invalid base64 data.", ex);
+            }
+        }
+
+        return ApplyAdditionalProperties(
+            new HostedImageGenerationContent
+            {
+                Id = payload.Id,
+                Status = payload.Status,
+                RevisedPrompt = payload.RevisedPrompt,
+                ImageBytes = imageBytes,
+                MediaType = payload.MediaType,
+                ErrorMessage = payload.ErrorMessage
+            },
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeImageGenerationToolCall(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedImageGenerationToolCallContent>(content);
+        return ApplyAdditionalProperties(
+            new ImageGenerationToolCallContent(payload.CallId),
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeImageGenerationToolResult(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedImageGenerationToolResultContent>(content);
+        return ApplyAdditionalProperties(
+            new ImageGenerationToolResultContent(payload.CallId)
+            {
+                Outputs = payload.Outputs?.Select(DecodeContent).ToList()
+            },
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeError(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedErrorContent>(content);
+        return ApplyAdditionalProperties(
+            new ErrorContent(payload.Message)
+            {
+                ErrorCode = payload.ErrorCode,
+                Details = payload.Details
+            },
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeUri(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedUriContent>(content);
+        return ApplyAdditionalProperties(
+            new UriContent(payload.Uri, payload.MediaType),
+            payload.AdditionalProperties);
+    }
+
+    private static AIContent DecodeUsage(ModelHistoryContent content)
+    {
+        var payload = DeserializePayload<PersistedUsageContent>(content);
+        return ApplyAdditionalProperties(
+            new UsageContent(new UsageDetails
+            {
+                InputTokenCount = payload.InputTokenCount,
+                OutputTokenCount = payload.OutputTokenCount,
+                TotalTokenCount = payload.TotalTokenCount,
+                CachedInputTokenCount = payload.CachedInputTokenCount,
+                ReasoningTokenCount = payload.ReasoningTokenCount,
+                InputAudioTokenCount = payload.InputAudioTokenCount,
+                InputTextTokenCount = payload.InputTextTokenCount,
+                OutputAudioTokenCount = payload.OutputAudioTokenCount,
+                OutputTextTokenCount = payload.OutputTextTokenCount,
+                AdditionalCounts = DecodeAdditionalCounts(payload.AdditionalCounts)
+            }),
+            payload.AdditionalProperties);
+    }
+
+    private static ModelHistoryContent CreateContent<TPayload>(string kind, TPayload payload) where TPayload : notnull =>
+        new()
+        {
+            Kind = kind,
+            Payload = JsonSerializer.SerializeToElement(payload, PayloadJsonOptions)
+        };
+
+    private static TPayload DeserializePayload<TPayload>(ModelHistoryContent content) where TPayload : class =>
+        content.Payload.Deserialize<TPayload>(PayloadJsonOptions)
+        ?? throw new JsonException($"Model history content '{content.Kind}' deserialized to null.");
+
+    private static PersistedFunctionResult EncodeFunctionResult(object? result)
+    {
+        if (result is IEnumerable<AIContent> contents)
+        {
+            return new PersistedFunctionResult
+            {
+                SchemaVersion = CurrentResultSchemaVersion,
+                Kind = "contents",
+                Json = null,
+                Contents = contents.Select(EncodeContent).ToList()
+            };
+        }
+
+        return new PersistedFunctionResult
+        {
+            SchemaVersion = CurrentResultSchemaVersion,
+            Kind = "json",
+            Json = SerializeJsonValue(result),
+            Contents = null
+        };
+    }
+
+    private static object? DecodeFunctionResult(PersistedFunctionResult result)
+    {
+        if (result.SchemaVersion != CurrentResultSchemaVersion)
+            throw new NotSupportedException($"Unsupported function result schema version '{result.SchemaVersion}'.");
+
+        return result.Kind switch
+        {
+            "json" when result.Json is { } json => DeserializeJsonValue(json),
+            "json" => throw new JsonException("Model history JSON result is missing its value."),
+            "contents" when result.Contents is not null => result.Contents.Select(DecodeContent).ToList(),
+            "contents" => throw new JsonException("Model history content result is missing contents."),
+            _ => throw new NotSupportedException($"Unsupported function result kind '{result.Kind}'.")
+        };
+    }
+
+    private static JsonElement SerializeJsonValue(object? value) => value switch
+    {
+        JsonElement element => element.Clone(),
+        null => JsonSerializer.SerializeToElement<object?>(null, JsonOptions),
+        _ => JsonSerializer.SerializeToElement(value, value.GetType(), JsonOptions)
+    };
+
+    private static object? DeserializeJsonValue(JsonElement value) => NormalizeJsonValue(value);
+
+    private static AdditionalPropertiesDictionary<long>? DecodeAdditionalCounts(
+        Dictionary<string, long>? counts)
+    {
+        if (counts is null)
+            return null;
+
+        var result = new AdditionalPropertiesDictionary<long>();
+        foreach (var (key, value) in counts)
+            result[key] = value;
+        return result;
+    }
+
+    private static IDictionary<string, object?>? DeserializeDictionary(JsonElement value)
+    {
+        if (value.ValueKind == JsonValueKind.Null)
+            return null;
+        if (value.ValueKind != JsonValueKind.Object)
+            throw new JsonException("Model history function arguments must be a JSON object or null.");
+
+        var dictionary = value.Deserialize<Dictionary<string, object?>>(JsonOptions)
+            ?? throw new JsonException("Model history function arguments deserialized to null.");
+        return dictionary.ToDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value is JsonElement element ? NormalizeJsonValue(element) : pair.Value,
+            StringComparer.Ordinal);
+    }
+
+    private static TContent ApplyAdditionalProperties<TContent>(TContent content, JsonElement? properties)
+        where TContent : AIContent
+    {
+        content.AdditionalProperties = DeserializeAdditionalProperties(properties);
+        return content;
+    }
+
+    private static string? ReadConsistentMetadataValue(
+        AdditionalPropertiesDictionary? properties,
+        params string[] keys)
+    {
+        string? result = null;
+        foreach (var key in keys)
+        {
+            if (properties is null || !properties.TryGetValue(key, out var value))
+                continue;
+            if (value is not string text || string.IsNullOrWhiteSpace(text))
+                throw new JsonException($"Tool identity metadata '{key}' must be a non-empty string.");
+            if (result is not null && !string.Equals(result, text, StringComparison.Ordinal))
+                throw new JsonException("Tool identity metadata fields conflict.");
+            result = text;
+        }
+
+        return result;
+    }
+
+    private static void ValidateAndRestoreToolIdentity(
+        AdditionalPropertiesDictionary? properties,
+        string? functionNamespace,
+        string? providerFlatName,
+        out AdditionalPropertiesDictionary? restored)
+    {
+        ValidateMetadataValue(properties, providerFlatName, ProviderFlatNameMetadataKey);
+        ValidateMetadataValue(
+            properties,
+            functionNamespace,
+            FunctionNamespaceMetadataKey,
+            FunctionNamespaceAliasKey);
+
+        restored = properties;
+        if (providerFlatName is not null && !ContainsAny(properties, ProviderFlatNameMetadataKey))
+        {
+            restored ??= new AdditionalPropertiesDictionary();
+            restored[ProviderFlatNameMetadataKey] = providerFlatName;
+        }
+        if (functionNamespace is not null &&
+            !ContainsAny(properties, FunctionNamespaceMetadataKey, FunctionNamespaceAliasKey))
+        {
+            restored ??= new AdditionalPropertiesDictionary();
+            restored[FunctionNamespaceMetadataKey] = functionNamespace;
+            restored[FunctionNamespaceAliasKey] = functionNamespace;
+        }
+    }
+
+    private static void ValidateMetadataValue(
+        AdditionalPropertiesDictionary? properties,
+        string? expected,
+        params string[] keys)
+    {
+        var actual = ReadConsistentMetadataValue(properties, keys);
+        if (actual is not null && !string.Equals(actual, expected, StringComparison.Ordinal))
+            throw new JsonException("Tool identity strong fields conflict with additional properties.");
+    }
+
+    private static bool ContainsAny(AdditionalPropertiesDictionary? properties, params string[] keys) =>
+        properties is not null && keys.Any(properties.ContainsKey);
+
+    private static JsonElement? SerializeAdditionalProperties(AdditionalPropertiesDictionary? properties) =>
+        properties == null
+            ? null
+            : JsonSerializer.SerializeToElement(properties, JsonOptions);
+
+    private static AdditionalPropertiesDictionary? DeserializeAdditionalProperties(JsonElement? properties) =>
+        properties is null
+            ? null
+            : NormalizeAdditionalProperties(properties.Value.Deserialize<AdditionalPropertiesDictionary>(JsonOptions));
+
+    private static AdditionalPropertiesDictionary? NormalizeAdditionalProperties(
+        AdditionalPropertiesDictionary? properties)
+    {
+        if (properties == null)
+            return null;
+
+        var normalized = new AdditionalPropertiesDictionary();
+        foreach (var (key, value) in properties)
+            normalized[key] = value is JsonElement element ? NormalizeJsonValue(element) : value;
+        return normalized;
+    }
+
+    private static object? NormalizeJsonValue(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null => null,
+        JsonValueKind.Number when element.TryGetInt64(out var integer) => integer,
+        JsonValueKind.Number when element.TryGetDecimal(out var number) => number,
+        JsonValueKind.Number => element.GetDouble(),
+        _ => element.Clone()
+    };
+}
+#pragma warning restore MEAI001
+
+internal abstract class PersistedModelContentPayload
+{
+    public required JsonElement? AdditionalProperties { get; init; }
+}
+
+internal sealed class PersistedTextContent : PersistedModelContentPayload
+{
+    public required string Text { get; init; }
+}
+
+internal sealed class PersistedReasoningContent : PersistedModelContentPayload
+{
+    public required string Text { get; init; }
+
+    public required string? ProtectedData { get; init; }
+}
+
+internal sealed class PersistedDataContent : PersistedModelContentPayload
+{
+    public required string Base64Data { get; init; }
+
+    public required string MediaType { get; init; }
+
+    public required string? Name { get; init; }
+}
+
+internal sealed class PersistedFunctionCallContent : PersistedModelContentPayload
+{
+    public required string CallId { get; init; }
+
+    public required string Name { get; init; }
+
+    public required JsonElement Arguments { get; init; }
+
+    public required bool InformationalOnly { get; init; }
+
+    public required string? Namespace { get; init; }
+
+    public required string? ProviderFlatName { get; init; }
+}
+
+internal sealed class PersistedFunctionResultContent : PersistedModelContentPayload
+{
+    public required string CallId { get; init; }
+
+    public required PersistedFunctionResult Result { get; init; }
+}
+
+internal sealed class PersistedFunctionResult
+{
+    public required int SchemaVersion { get; init; }
+
+    public required string Kind { get; init; }
+
+    public required JsonElement? Json { get; init; }
+
+    public required List<ModelHistoryContent>? Contents { get; init; }
+}
+
+internal sealed class PersistedHostedImageGenerationContent : PersistedModelContentPayload
+{
+    public required string Id { get; init; }
+
+    public required string Status { get; init; }
+
+    public required string? RevisedPrompt { get; init; }
+
+    public required string? ImageBase64 { get; init; }
+
+    public required string MediaType { get; init; }
+
+    public required string? ErrorMessage { get; init; }
+}
+
+internal sealed class PersistedImageGenerationToolCallContent : PersistedModelContentPayload
+{
+    public required string CallId { get; init; }
+}
+
+internal sealed class PersistedImageGenerationToolResultContent : PersistedModelContentPayload
+{
+    public required string CallId { get; init; }
+
+    public required List<ModelHistoryContent>? Outputs { get; init; }
+}
+
+internal sealed class PersistedErrorContent : PersistedModelContentPayload
+{
+    public required string Message { get; init; }
+
+    public required string? ErrorCode { get; init; }
+
+    public required string? Details { get; init; }
+}
+
+internal sealed class PersistedUriContent : PersistedModelContentPayload
+{
+    public required string Uri { get; init; }
+
+    public required string MediaType { get; init; }
+}
+
+internal sealed class PersistedUsageContent : PersistedModelContentPayload
+{
+    public required long? InputTokenCount { get; init; }
+
+    public required long? OutputTokenCount { get; init; }
+
+    public required long? TotalTokenCount { get; init; }
+
+    public required long? CachedInputTokenCount { get; init; }
+
+    public required long? ReasoningTokenCount { get; init; }
+
+    public required long? InputAudioTokenCount { get; init; }
+
+    public required long? InputTextTokenCount { get; init; }
+
+    public required long? OutputAudioTokenCount { get; init; }
+
+    public required long? OutputTextTokenCount { get; init; }
+
+    public required Dictionary<string, long>? AdditionalCounts { get; init; }
+}
+
+internal sealed class ModelHistoryMessage
+{
+    public int SchemaVersion { get; init; } = ModelHistoryCodec.CurrentSchemaVersion;
+
+    public string? TurnId { get; init; }
+
+    public string Role { get; init; } = ChatRole.User.Value;
+
+    public string? MessageId { get; init; }
+
+    public string? AuthorName { get; init; }
+
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    public JsonElement? AdditionalProperties { get; init; }
+
+    public List<ModelHistoryContent> Contents { get; init; } = [];
+}
+
+internal sealed class ModelHistoryContent
+{
+    public string Kind { get; init; } = string.Empty;
+
+    public JsonElement Payload { get; init; }
+}
+
+internal sealed record ModelHistoryReplayResult(
+    IReadOnlyList<ChatMessage> Messages,
+    bool HasModelHistoryRecords,
+    IReadOnlyList<ModelHistoryReplayWarning>? Warnings = null,
+    int RejectedRecords = 0,
+    IReadOnlySet<string>? FallbackTurnIds = null,
+    long BytesRead = 0,
+    int RecordsDecoded = 0);
+
+internal sealed record ModelHistoryReplayWarning(
+    string Code,
+    string Message,
+    string? TurnId = null);

--- a/src/DotCraft.Core/Protocol/ModelHistory.cs
+++ b/src/DotCraft.Core/Protocol/ModelHistory.cs
@@ -17,7 +17,8 @@ internal interface IRolloutReplayer
         string rolloutPath,
         IReadOnlyList<SessionTurn> survivingTurns,
         string? excludedTurnId = null,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        string? expectedThreadId = null);
 }
 
 #pragma warning disable MEAI001 // Persist the complete runtime usage contract, including preview counters.
@@ -56,17 +57,40 @@ internal sealed class ModelHistoryCodec : IModelHistoryCodec
     public ChatMessage Decode(ModelHistoryMessage message)
     {
         ArgumentNullException.ThrowIfNull(message);
-        if (message.SchemaVersion != CurrentSchemaVersion)
-            throw new NotSupportedException($"Unsupported model history schema version '{message.SchemaVersion}'.");
 
-        var decoded = new ChatMessage(new ChatRole(message.Role), message.Contents.Select(DecodeContent).ToList())
+        try
         {
-            MessageId = message.MessageId,
-            AuthorName = message.AuthorName,
-            CreatedAt = message.CreatedAt,
-            AdditionalProperties = DeserializeAdditionalProperties(message.AdditionalProperties)
-        };
-        return decoded;
+            ValidateMessage(message);
+            if (message.SchemaVersion != CurrentSchemaVersion)
+                throw new NotSupportedException($"Unsupported model history schema version '{message.SchemaVersion}'.");
+
+            var decoded = new ChatMessage(new ChatRole(message.Role), message.Contents!.Select(DecodeContent).ToList())
+            {
+                MessageId = message.MessageId,
+                AuthorName = message.AuthorName,
+                CreatedAt = message.CreatedAt,
+                AdditionalProperties = DeserializeAdditionalProperties(message.AdditionalProperties)
+            };
+            return decoded;
+        }
+        catch (JsonException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is FormatException or NotSupportedException or ArgumentException or InvalidOperationException or NullReferenceException)
+        {
+            throw new JsonException("Model history message contains invalid persisted content.", ex);
+        }
+    }
+
+    private static void ValidateMessage(ModelHistoryMessage message)
+    {
+        if (string.IsNullOrWhiteSpace(message.Role))
+            throw new JsonException("Model history message is missing its role.");
+        if (message.Contents is null)
+            throw new JsonException("Model history message is missing its contents.");
+        if (message.Contents.Any(static content => content is null))
+            throw new JsonException("Model history message contains a null content entry.");
     }
 
     private static ModelHistoryContent EncodeContent(AIContent content)
@@ -182,6 +206,14 @@ internal sealed class ModelHistoryCodec : IModelHistoryCodec
 
     private static AIContent DecodeContent(ModelHistoryContent content)
     {
+        ArgumentNullException.ThrowIfNull(content);
+        if (string.IsNullOrWhiteSpace(content.Kind))
+            throw new JsonException("Model history content is missing its kind.");
+        if (content.Payload.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            throw new JsonException($"Model history content '{content.Kind}' is missing its payload.");
+        if (content.Payload.ValueKind != JsonValueKind.Object)
+            throw new JsonException($"Model history content '{content.Kind}' payload must be an object.");
+
         return content.Kind switch
         {
             "text" => DecodeText(content),
@@ -379,6 +411,7 @@ internal sealed class ModelHistoryCodec : IModelHistoryCodec
 
     private static object? DecodeFunctionResult(PersistedFunctionResult result)
     {
+        ArgumentNullException.ThrowIfNull(result);
         if (result.SchemaVersion != CurrentResultSchemaVersion)
             throw new NotSupportedException($"Unsupported function result schema version '{result.SchemaVersion}'.");
 
@@ -386,7 +419,10 @@ internal sealed class ModelHistoryCodec : IModelHistoryCodec
         {
             "json" when result.Json is { } json => DeserializeJsonValue(json),
             "json" => throw new JsonException("Model history JSON result is missing its value."),
-            "contents" when result.Contents is not null => result.Contents.Select(DecodeContent).ToList(),
+            "contents" when result.Contents is not null && !result.Contents.Any(static content => content is null)
+                => result.Contents.Select(DecodeContent).ToList(),
+            "contents" when result.Contents is not null
+                => throw new JsonException("Model history content result contains a null content entry."),
             "contents" => throw new JsonException("Model history content result is missing contents."),
             _ => throw new NotSupportedException($"Unsupported function result kind '{result.Kind}'.")
         };

--- a/src/DotCraft.Core/Protocol/ReverseJsonlReader.cs
+++ b/src/DotCraft.Core/Protocol/ReverseJsonlReader.cs
@@ -1,0 +1,86 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace DotCraft.Protocol;
+
+internal sealed class ReverseJsonlReader(string path, int blockSize = 64 * 1024)
+{
+    public long BytesRead { get; private set; }
+
+    public async IAsyncEnumerable<string> ReadLinesAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite,
+            bufferSize: 1,
+            FileOptions.Asynchronous | FileOptions.RandomAccess);
+        var position = stream.Length;
+        byte[] carry = [];
+        var firstBlock = true;
+
+        while (position > 0)
+        {
+            ct.ThrowIfCancellationRequested();
+            var count = (int)Math.Min(blockSize, position);
+            var start = position - count;
+            var rented = ArrayPool<byte>.Shared.Rent(count);
+            try
+            {
+                stream.Seek(start, SeekOrigin.Begin);
+                var read = 0;
+                while (read < count)
+                {
+                    var current = await stream.ReadAsync(rented.AsMemory(read, count - read), ct);
+                    if (current == 0)
+                        break;
+                    read += current;
+                }
+
+                BytesRead += read;
+                var data = new byte[read + carry.Length];
+                Buffer.BlockCopy(rented, 0, data, 0, read);
+                if (carry.Length > 0)
+                    Buffer.BlockCopy(carry, 0, data, read, carry.Length);
+
+                var end = data.Length;
+                if (firstBlock && end > 0 && data[end - 1] == (byte)'\n')
+                    end--;
+                firstBlock = false;
+
+                for (var index = end - 1; index >= 0; index--)
+                {
+                    if (data[index] != (byte)'\n')
+                        continue;
+
+                    var lineStart = index + 1;
+                    var lineLength = end - lineStart;
+                    if (lineLength > 0 && data[end - 1] == (byte)'\r')
+                        lineLength--;
+                    if (lineLength > 0)
+                        yield return Encoding.UTF8.GetString(data, lineStart, lineLength);
+                    end = index;
+                }
+
+                carry = data.AsSpan(0, end).ToArray();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+            position = start;
+        }
+
+        if (carry.Length > 0)
+        {
+            var length = carry.Length;
+            if (carry[length - 1] == (byte)'\r')
+                length--;
+            if (length > 0)
+                yield return Encoding.UTF8.GetString(carry, 0, length);
+        }
+    }
+}

--- a/src/DotCraft.Core/Protocol/RolloutReplayer.cs
+++ b/src/DotCraft.Core/Protocol/RolloutReplayer.cs
@@ -11,7 +11,8 @@ internal sealed class RolloutReplayer : IRolloutReplayer
         string rolloutPath,
         IReadOnlyList<SessionTurn> survivingTurns,
         string? excludedTurnId = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? expectedThreadId = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(rolloutPath);
         ArgumentNullException.ThrowIfNull(survivingTurns);
@@ -55,12 +56,24 @@ internal sealed class RolloutReplayer : IRolloutReplayer
                 var root = document.RootElement;
                 var kind = TryGetString(root, "kind");
                 var envelopeTurnId = TryGetEnvelopeTurnId(root, kind);
+                if (!TryValidateTargetEnvelope(root, kind, out var envelopeError))
+                {
+                    Reject(
+                        string.Equals(kind, "context_compacted", StringComparison.Ordinal)
+                            ? "invalid_checkpoint"
+                            : "malformed_record",
+                        envelopeError!,
+                        envelopeTurnId,
+                        markFallback: !string.Equals(kind, "context_compacted", StringComparison.Ordinal));
+                    continue;
+                }
+
                 ThreadRolloutRecord? record;
                 try
                 {
                     record = root.Deserialize<ThreadRolloutRecord>(JsonOptions);
                 }
-                catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+                catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException or InvalidOperationException)
                 {
                     var checkpointRecord = string.Equals(kind, "context_compacted", StringComparison.Ordinal);
                     Reject(
@@ -84,58 +97,76 @@ internal sealed class RolloutReplayer : IRolloutReplayer
                 {
                     hasRecords = true;
                     var batch = record.ModelHistoryMessagesAppended;
-                    if (batch == null || string.IsNullOrWhiteSpace(batch.TurnId))
+                    if (!TryValidateModelBatch(batch, out var batchError))
                     {
-                        Reject("invalid_model_batch", "Skipped an invalid model-history batch.", envelopeTurnId);
+                        Reject("invalid_model_batch", batchError!, envelopeTurnId);
                         continue;
                     }
-                    if (!survivingTurnIds.Contains(batch.TurnId))
+                    var validBatch = batch!;
+                    if (expectedThreadId != null
+                        && !string.Equals(validBatch.ThreadId, expectedThreadId, StringComparison.Ordinal))
+                    {
+                        Reject("cross_thread_record", "Skipped a model-history batch belonging to another thread.", validBatch.TurnId);
+                        continue;
+                    }
+                    if (!survivingTurnIds.Contains(validBatch.TurnId))
                         continue;
 
                     try
                     {
-                        var decodedMessages = batch.Messages
-                            .Select(message => codec.Decode(WithTurnId(message, batch.TurnId)))
+                        var decodedMessages = validBatch.Messages
+                            .Select(message => codec.Decode(WithTurnId(message, validBatch.TurnId)))
                             .ToList();
-                        reverseBatches.Add(new DecodedModelBatch(batch.TurnId, decodedMessages));
+                        reverseBatches.Add(new DecodedModelBatch(validBatch.TurnId, decodedMessages));
                     }
-                    catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+                    catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException or InvalidOperationException)
                     {
-                        Reject("invalid_model_batch", "Skipped an undecodable model-history batch.", batch.TurnId);
+                        Reject("invalid_model_batch", "Skipped an undecodable model-history batch.", validBatch.TurnId);
                     }
                 }
                 else if (string.Equals(kind, "context_compacted", StringComparison.Ordinal))
                 {
                     hasRecords = true;
                     var checkpoint = record.ContextCompacted;
-                    if (checkpoint == null || string.IsNullOrWhiteSpace(checkpoint.CoveredThroughTurnId))
+                    if (!TryValidateCheckpoint(checkpoint, out var checkpointError))
                     {
                         Reject(
                             "invalid_checkpoint",
-                            "Skipped an invalid compaction checkpoint.",
+                            checkpointError!,
                             envelopeTurnId,
                             markFallback: false);
                         continue;
                     }
-                    if (!survivingTurnIds.Contains(checkpoint.CoveredThroughTurnId)
-                        || fallbackTurnIds.Contains(checkpoint.CoveredThroughTurnId))
+                    var validCheckpoint = checkpoint!;
+                    if (expectedThreadId != null
+                        && !string.Equals(validCheckpoint.ThreadId, expectedThreadId, StringComparison.Ordinal))
+                    {
+                        Reject(
+                            "cross_thread_record",
+                            "Skipped a compaction checkpoint belonging to another thread.",
+                            validCheckpoint.CoveredThroughTurnId,
+                            markFallback: false);
+                        continue;
+                    }
+                    if (!survivingTurnIds.Contains(validCheckpoint.CoveredThroughTurnId)
+                        || fallbackTurnIds.Contains(validCheckpoint.CoveredThroughTurnId))
                     {
                         continue;
                     }
 
                     try
                     {
-                        replacement = checkpoint.ReplacementHistory.Select(codec.Decode).ToList();
-                        selectedCheckpoint = checkpoint;
+                        replacement = validCheckpoint.ReplacementHistory.Select(codec.Decode).ToList();
+                        selectedCheckpoint = validCheckpoint;
                         break;
                     }
-                    catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+                    catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException or InvalidOperationException)
                     {
                         replacement = null;
                         Reject(
                             "invalid_checkpoint",
                             "Skipped an undecodable compaction checkpoint.",
-                            checkpoint.CoveredThroughTurnId,
+                            validCheckpoint.CoveredThroughTurnId,
                             markFallback: false);
                     }
                 }
@@ -198,8 +229,92 @@ internal sealed class RolloutReplayer : IRolloutReplayer
         }
     }
 
+    private static bool TryValidateTargetEnvelope(
+        JsonElement root,
+        string? kind,
+        out string? error)
+    {
+        error = null;
+        var payloadNames = new[] { "contextCompacted", "modelHistoryMessagesAppended" };
+        var populatedPayloads = payloadNames
+            .Where(name => root.TryGetProperty(name, out var payload)
+                && payload.ValueKind != JsonValueKind.Null)
+            .ToList();
+
+        if (kind is not ("context_compacted" or "model_history_messages_appended"))
+            return true;
+
+        var expectedPayload = kind == "context_compacted"
+            ? "contextCompacted"
+            : "modelHistoryMessagesAppended";
+        if (!root.TryGetProperty(expectedPayload, out var payload)
+            || payload.ValueKind != JsonValueKind.Object)
+        {
+            error = $"Rollout record '{kind}' is missing its object payload.";
+            return false;
+        }
+
+        if (populatedPayloads.Count != 1)
+        {
+            error = $"Rollout record '{kind}' contains inconsistent payload fields.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateModelBatch(
+        ModelHistoryMessagesAppendedPayload? batch,
+        out string? error)
+    {
+        error = null;
+        if (batch is null || string.IsNullOrWhiteSpace(batch.ThreadId) || string.IsNullOrWhiteSpace(batch.TurnId))
+        {
+            error = "Skipped an invalid model-history batch with missing identity fields.";
+            return false;
+        }
+        if (batch.Messages is null)
+        {
+            error = "Skipped an invalid model-history batch with missing messages.";
+            return false;
+        }
+        if (batch.Messages.Any(static message => message is null))
+        {
+            error = "Skipped an invalid model-history batch containing a null message.";
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TryValidateCheckpoint(
+        ContextCompactedPayload? checkpoint,
+        out string? error)
+    {
+        error = null;
+        if (checkpoint is null
+            || string.IsNullOrWhiteSpace(checkpoint.ThreadId)
+            || string.IsNullOrWhiteSpace(checkpoint.CoveredThroughTurnId))
+        {
+            error = "Skipped an invalid compaction checkpoint with missing identity fields.";
+            return false;
+        }
+        if (checkpoint.ReplacementHistory is null)
+        {
+            error = "Skipped an invalid compaction checkpoint with missing replacement history.";
+            return false;
+        }
+        if (checkpoint.ReplacementHistory.Any(static message => message is null))
+        {
+            error = "Skipped an invalid compaction checkpoint containing a null message.";
+            return false;
+        }
+        return true;
+    }
+
     private static string? TryGetString(JsonElement value, string propertyName) =>
-        value.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+        value.ValueKind == JsonValueKind.Object
+        && value.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.String
             ? property.GetString()
             : null;
 

--- a/src/DotCraft.Core/Protocol/RolloutReplayer.cs
+++ b/src/DotCraft.Core/Protocol/RolloutReplayer.cs
@@ -1,0 +1,242 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Protocol;
+
+internal sealed class RolloutReplayer : IRolloutReplayer
+{
+    private static readonly JsonSerializerOptions JsonOptions = SessionJsonOptions.Default;
+
+    public async Task<ModelHistoryReplayResult> ReplayModelHistoryAsync(
+        string rolloutPath,
+        IReadOnlyList<SessionTurn> survivingTurns,
+        string? excludedTurnId = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rolloutPath);
+        ArgumentNullException.ThrowIfNull(survivingTurns);
+
+        if (!File.Exists(rolloutPath))
+            return new ModelHistoryReplayResult([], HasModelHistoryRecords: false);
+
+        var orderedTurns = survivingTurns
+            .Where(turn => !string.Equals(turn.Id, excludedTurnId, StringComparison.Ordinal))
+            .ToList();
+        var survivingTurnIds = orderedTurns.Select(static turn => turn.Id).ToHashSet(StringComparer.Ordinal);
+        var reverseBatches = new List<DecodedModelBatch>();
+        var fallbackTurnIds = new HashSet<string>(StringComparer.Ordinal);
+        var warnings = new List<ModelHistoryReplayWarning>();
+        var codec = new ModelHistoryCodec();
+        var hasRecords = false;
+        var recordsDecoded = 0;
+        var rejectedRecords = 0;
+        List<ChatMessage>? replacement = null;
+        ContextCompactedPayload? selectedCheckpoint = null;
+        var reader = new ReverseJsonlReader(rolloutPath);
+
+        await foreach (var line in reader.ReadLinesAsync(ct))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(line);
+            }
+            catch (JsonException)
+            {
+                Reject("malformed_json", "Skipped a malformed rollout record.", null);
+                continue;
+            }
+
+            using (document)
+            {
+                var root = document.RootElement;
+                var kind = TryGetString(root, "kind");
+                var envelopeTurnId = TryGetEnvelopeTurnId(root, kind);
+                ThreadRolloutRecord? record;
+                try
+                {
+                    record = root.Deserialize<ThreadRolloutRecord>(JsonOptions);
+                }
+                catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+                {
+                    var checkpointRecord = string.Equals(kind, "context_compacted", StringComparison.Ordinal);
+                    Reject(
+                        checkpointRecord ? "invalid_checkpoint" : "malformed_record",
+                        checkpointRecord
+                            ? "Skipped an unreadable compaction checkpoint."
+                            : "Skipped an unreadable rollout record.",
+                        envelopeTurnId,
+                        markFallback: !checkpointRecord);
+                    continue;
+                }
+
+                if (record == null)
+                {
+                    Reject("empty_record", "Skipped an empty rollout record.", envelopeTurnId);
+                    continue;
+                }
+
+                recordsDecoded++;
+                if (string.Equals(kind, "model_history_messages_appended", StringComparison.Ordinal))
+                {
+                    hasRecords = true;
+                    var batch = record.ModelHistoryMessagesAppended;
+                    if (batch == null || string.IsNullOrWhiteSpace(batch.TurnId))
+                    {
+                        Reject("invalid_model_batch", "Skipped an invalid model-history batch.", envelopeTurnId);
+                        continue;
+                    }
+                    if (!survivingTurnIds.Contains(batch.TurnId))
+                        continue;
+
+                    try
+                    {
+                        var decodedMessages = batch.Messages
+                            .Select(message => codec.Decode(WithTurnId(message, batch.TurnId)))
+                            .ToList();
+                        reverseBatches.Add(new DecodedModelBatch(batch.TurnId, decodedMessages));
+                    }
+                    catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+                    {
+                        Reject("invalid_model_batch", "Skipped an undecodable model-history batch.", batch.TurnId);
+                    }
+                }
+                else if (string.Equals(kind, "context_compacted", StringComparison.Ordinal))
+                {
+                    hasRecords = true;
+                    var checkpoint = record.ContextCompacted;
+                    if (checkpoint == null || string.IsNullOrWhiteSpace(checkpoint.CoveredThroughTurnId))
+                    {
+                        Reject(
+                            "invalid_checkpoint",
+                            "Skipped an invalid compaction checkpoint.",
+                            envelopeTurnId,
+                            markFallback: false);
+                        continue;
+                    }
+                    if (!survivingTurnIds.Contains(checkpoint.CoveredThroughTurnId)
+                        || fallbackTurnIds.Contains(checkpoint.CoveredThroughTurnId))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        replacement = checkpoint.ReplacementHistory.Select(codec.Decode).ToList();
+                        selectedCheckpoint = checkpoint;
+                        break;
+                    }
+                    catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+                    {
+                        replacement = null;
+                        Reject(
+                            "invalid_checkpoint",
+                            "Skipped an undecodable compaction checkpoint.",
+                            checkpoint.CoveredThroughTurnId,
+                            markFallback: false);
+                    }
+                }
+            }
+        }
+
+        reverseBatches.Reverse();
+        var messages = replacement ?? [];
+        var firstTailTurnIndex = 0;
+        if (selectedCheckpoint != null)
+        {
+            firstTailTurnIndex = orderedTurns.FindIndex(turn =>
+                string.Equals(turn.Id, selectedCheckpoint.CoveredThroughTurnId, StringComparison.Ordinal));
+        }
+
+        for (var turnIndex = Math.Max(0, firstTailTurnIndex); turnIndex < orderedTurns.Count; turnIndex++)
+        {
+            var turn = orderedTurns[turnIndex];
+            var turnBatches = reverseBatches
+                .Where(batch => string.Equals(batch.TurnId, turn.Id, StringComparison.Ordinal))
+                .ToList();
+            if (fallbackTurnIds.Contains(turn.Id))
+            {
+                messages.AddRange(ThreadStore.BuildModelVisibleHistoryFromTurn(turn));
+                continue;
+            }
+            if (turnBatches.Count == 0)
+            {
+                if (selectedCheckpoint != null && turnIndex == firstTailTurnIndex)
+                    continue;
+                fallbackTurnIds.Add(turn.Id);
+                messages.AddRange(ThreadStore.BuildModelVisibleHistoryFromTurn(turn));
+                continue;
+            }
+
+            foreach (var batch in turnBatches)
+                messages.AddRange(batch.Messages);
+        }
+
+        RolloutTelemetry.RecordResume(reader.BytesRead, recordsDecoded, rejectedRecords);
+        return new ModelHistoryReplayResult(
+            messages,
+            hasRecords,
+            warnings,
+            rejectedRecords,
+            fallbackTurnIds,
+            reader.BytesRead,
+            recordsDecoded);
+
+        void Reject(
+            string code,
+            string message,
+            string? turnId,
+            bool markFallback = true)
+        {
+            rejectedRecords++;
+            if (markFallback && !string.IsNullOrWhiteSpace(turnId) && survivingTurnIds.Contains(turnId))
+                fallbackTurnIds.Add(turnId);
+            warnings.Add(new ModelHistoryReplayWarning(code, message, turnId));
+        }
+    }
+
+    private static string? TryGetString(JsonElement value, string propertyName) =>
+        value.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static string? TryGetEnvelopeTurnId(JsonElement root, string? kind)
+    {
+        var payloadName = kind switch
+        {
+            "model_history_messages_appended" => "modelHistoryMessagesAppended",
+            "context_compacted" => "contextCompacted",
+            _ => null
+        };
+        if (payloadName == null
+            || !root.TryGetProperty(payloadName, out var payload)
+            || payload.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        return TryGetString(payload, kind == "context_compacted" ? "coveredThroughTurnId" : "turnId");
+    }
+
+    private static ModelHistoryMessage WithTurnId(ModelHistoryMessage message, string turnId)
+    {
+        if (!string.IsNullOrWhiteSpace(message.TurnId))
+            return message;
+
+        return new ModelHistoryMessage
+        {
+            SchemaVersion = message.SchemaVersion,
+            TurnId = turnId,
+            Role = message.Role,
+            MessageId = message.MessageId,
+            AuthorName = message.AuthorName,
+            CreatedAt = message.CreatedAt,
+            AdditionalProperties = message.AdditionalProperties,
+            Contents = message.Contents
+        };
+    }
+
+    private sealed record DecodedModelBatch(string TurnId, IReadOnlyList<ChatMessage> Messages);
+}

--- a/src/DotCraft.Core/Protocol/RolloutWriter.cs
+++ b/src/DotCraft.Core/Protocol/RolloutWriter.cs
@@ -1,0 +1,456 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+
+namespace DotCraft.Protocol;
+
+internal sealed record RolloutWriteReceipt(
+    long ConfirmedOffset,
+    int RecordCount,
+    IReadOnlyDictionary<string, long> BytesByKind);
+
+internal sealed class RolloutPersistenceException(string message, Exception innerException)
+    : IOException(message, innerException);
+
+internal interface IRolloutWriter
+{
+    Task AddBatchAsync(
+        string threadId,
+        string path,
+        IReadOnlyList<ThreadRolloutRecord> records,
+        CancellationToken ct = default);
+
+    Task<RolloutWriteReceipt> FlushAsync(string threadId, CancellationToken ct = default);
+
+    Task CloseAsync(string threadId, CancellationToken ct = default);
+
+    Task ShutdownAllAsync(CancellationToken ct = default);
+}
+
+internal sealed class OrderedRolloutWriter : IRolloutWriter
+{
+    internal const int Capacity = 256;
+    private const int WriteRetryCount = 5;
+
+    private static readonly Meter Meter = new("DotCraft.Protocol.Rollout");
+    private static readonly Counter<long> RecordsWritten = Meter.CreateCounter<long>("dotcraft.rollout.records.written");
+    private static readonly Counter<long> BytesWritten = Meter.CreateCounter<long>("dotcraft.rollout.bytes.written");
+    private static readonly Histogram<double> FlushDuration = Meter.CreateHistogram<double>("dotcraft.rollout.flush.duration", "ms");
+
+    private readonly ConcurrentDictionary<string, ThreadWriter> _writers = new(StringComparer.Ordinal);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly Func<string, IReadOnlyList<ThreadRolloutRecord>, CancellationToken, Task<RolloutWriteReceipt>>? _testFlush;
+
+    public OrderedRolloutWriter(JsonSerializerOptions? jsonOptions = null)
+    {
+        _jsonOptions = jsonOptions ?? SessionJsonOptions.Default;
+    }
+
+    internal OrderedRolloutWriter(
+        Func<string, IReadOnlyList<ThreadRolloutRecord>, CancellationToken, Task<RolloutWriteReceipt>> testFlush)
+        : this()
+    {
+        _testFlush = testFlush;
+    }
+
+    public async Task AddBatchAsync(
+        string threadId,
+        string path,
+        IReadOnlyList<ThreadRolloutRecord> records,
+        CancellationToken ct = default)
+    {
+        if (records.Count == 0)
+            return;
+
+        var writer = _writers.GetOrAdd(threadId, _ => new ThreadWriter(_jsonOptions, _testFlush));
+        await writer.AddBatchAsync(path, records, ct);
+    }
+
+    public async Task<RolloutWriteReceipt> FlushAsync(string threadId, CancellationToken ct = default)
+    {
+        if (!_writers.TryGetValue(threadId, out var writer))
+            return new RolloutWriteReceipt(0, 0, new Dictionary<string, long>(StringComparer.Ordinal));
+
+        var started = Stopwatch.GetTimestamp();
+        try
+        {
+            var receipt = await writer.FlushAsync(ct);
+            FlushDuration.Record(Stopwatch.GetElapsedTime(started).TotalMilliseconds, new KeyValuePair<string, object?>("outcome", "success"));
+            foreach (var (kind, bytes) in receipt.BytesByKind)
+            {
+                RecordsWritten.Add(writer.LastFlushedRecordCounts.GetValueOrDefault(kind), new KeyValuePair<string, object?>("record.kind", kind));
+                BytesWritten.Add(bytes, new KeyValuePair<string, object?>("record.kind", kind));
+            }
+            return receipt;
+        }
+        catch
+        {
+            FlushDuration.Record(Stopwatch.GetElapsedTime(started).TotalMilliseconds, new KeyValuePair<string, object?>("outcome", "failure"));
+            throw;
+        }
+    }
+
+    public async Task CloseAsync(string threadId, CancellationToken ct = default)
+    {
+        if (!_writers.TryGetValue(threadId, out var writer))
+            return;
+
+        await writer.CloseAsync(ct);
+        _writers.TryRemove(new KeyValuePair<string, ThreadWriter>(threadId, writer));
+    }
+
+    public async Task ShutdownAllAsync(CancellationToken ct = default)
+    {
+        List<Exception>? errors = null;
+        foreach (var (threadId, writer) in _writers.ToArray())
+        {
+            try
+            {
+                await writer.CloseAsync(ct);
+                _writers.TryRemove(new KeyValuePair<string, ThreadWriter>(threadId, writer));
+            }
+            catch (Exception ex)
+            {
+                (errors ??= []).Add(ex);
+            }
+        }
+
+        if (errors is { Count: 1 })
+            throw errors[0];
+        if (errors is { Count: > 1 })
+            throw new AggregateException(errors);
+    }
+
+    private sealed class ThreadWriter
+    {
+        private readonly Channel<WriterCommand> _channel = Channel.CreateBounded<WriterCommand>(
+            new BoundedChannelOptions(Capacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false
+            });
+        private readonly SemaphoreSlim _enqueueGate = new(1, 1);
+        private readonly JsonSerializerOptions _jsonOptions;
+        private readonly Func<string, IReadOnlyList<ThreadRolloutRecord>, CancellationToken, Task<RolloutWriteReceipt>>? _testFlush;
+        private readonly Task _pump;
+        private readonly List<PendingRecord> _pending = [];
+        private FileStream? _stream;
+        private string? _path;
+        private long? _pendingStartOffset;
+        private int _writtenPendingCount;
+
+        public ThreadWriter(
+            JsonSerializerOptions jsonOptions,
+            Func<string, IReadOnlyList<ThreadRolloutRecord>, CancellationToken, Task<RolloutWriteReceipt>>? testFlush)
+        {
+            _jsonOptions = jsonOptions;
+            _testFlush = testFlush;
+            _pump = Task.Run(PumpAsync);
+        }
+
+        public IReadOnlyDictionary<string, long> LastFlushedRecordCounts { get; private set; } =
+            new Dictionary<string, long>(StringComparer.Ordinal);
+
+        public async Task AddBatchAsync(
+            string path,
+            IReadOnlyList<ThreadRolloutRecord> records,
+            CancellationToken ct)
+        {
+            await _enqueueGate.WaitAsync(ct);
+            try
+            {
+                foreach (var record in records)
+                    await _channel.Writer.WriteAsync(new AddRecordCommand(path, record), CancellationToken.None);
+            }
+            finally
+            {
+                _enqueueGate.Release();
+            }
+        }
+
+        public async Task<RolloutWriteReceipt> FlushAsync(CancellationToken ct)
+        {
+            await _enqueueGate.WaitAsync(ct);
+            try
+            {
+                var completion = new TaskCompletionSource<RolloutWriteReceipt>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await _channel.Writer.WriteAsync(new FlushCommand(completion), CancellationToken.None);
+                return await completion.Task.WaitAsync(ct);
+            }
+            finally
+            {
+                _enqueueGate.Release();
+            }
+        }
+
+        public async Task CloseAsync(CancellationToken ct)
+        {
+            await _enqueueGate.WaitAsync(ct);
+            var closed = false;
+            try
+            {
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                await _channel.Writer.WriteAsync(new CloseCommand(completion), CancellationToken.None);
+                await completion.Task.WaitAsync(ct);
+                await _pump.WaitAsync(ct);
+                closed = true;
+            }
+            finally
+            {
+                _enqueueGate.Release();
+                if (closed)
+                    _enqueueGate.Dispose();
+            }
+        }
+
+        private async Task PumpAsync()
+        {
+            await foreach (var command in _channel.Reader.ReadAllAsync())
+            {
+                switch (command)
+                {
+                    case AddRecordCommand add:
+                        if (_path != null && !string.Equals(_path, add.Path, StringComparison.OrdinalIgnoreCase))
+                        {
+                            _pending.Add(new PendingRecord(
+                                add.Record,
+                                [],
+                                new InvalidOperationException("A live rollout recorder cannot change paths before it is closed.")));
+                            break;
+                        }
+
+                        _path ??= add.Path;
+                        _pending.Add(new PendingRecord(add.Record, SerializeRecord(add.Record), null));
+                        break;
+
+                    case FlushCommand flush:
+                        try
+                        {
+                            flush.Completion.TrySetResult(await WritePendingWithRecoveryAsync());
+                        }
+                        catch (Exception ex)
+                        {
+                            flush.Completion.TrySetException(ex);
+                        }
+                        break;
+
+                    case CloseCommand close:
+                        try
+                        {
+                            await WritePendingWithRecoveryAsync();
+                            await DisposeStreamAsync();
+                            close.Completion.TrySetResult();
+                            _channel.Writer.TryComplete();
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            close.Completion.TrySetException(ex);
+                        }
+                        break;
+                }
+            }
+        }
+
+        private byte[] SerializeRecord(ThreadRolloutRecord record) =>
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(record, _jsonOptions) + "\n");
+
+        private async Task<RolloutWriteReceipt> WritePendingWithRecoveryAsync()
+        {
+            if (_pending.FirstOrDefault(static record => record.Error != null) is { Error: { } pendingError })
+                throw pendingError;
+
+            IOException? lastError = null;
+            for (var attempt = 0; attempt <= WriteRetryCount; attempt++)
+            {
+                try
+                {
+                    return await WritePendingOnceAsync();
+                }
+                catch (IOException ex)
+                {
+                    lastError = ex;
+                    await DisposeStreamAsync();
+                    if (attempt == WriteRetryCount)
+                        break;
+                    await Task.Delay(TimeSpan.FromMilliseconds(20 << Math.Min(attempt, 4)));
+                }
+            }
+
+            throw new RolloutPersistenceException(
+                $"Rollout flush failed after {WriteRetryCount + 1} attempts.",
+                lastError ?? new IOException("Rollout flush failed."));
+        }
+
+        private async Task<RolloutWriteReceipt> WritePendingOnceAsync()
+        {
+            if (_path == null)
+                return new RolloutWriteReceipt(0, 0, new Dictionary<string, long>(StringComparer.Ordinal));
+            if (_pending.Count == 0)
+            {
+                LastFlushedRecordCounts = new Dictionary<string, long>(StringComparer.Ordinal);
+                var offset = _testFlush == null && File.Exists(_path)
+                    ? new FileInfo(_path).Length
+                    : 0;
+                return new RolloutWriteReceipt(offset, 0, new Dictionary<string, long>(StringComparer.Ordinal));
+            }
+
+            if (_testFlush != null)
+            {
+                var records = _pending.Select(static pending => pending.Record).ToList();
+                var receipt = await _testFlush(_path, records, CancellationToken.None);
+                _pending.Clear();
+                LastFlushedRecordCounts = records
+                    .GroupBy(static record => record.Kind, StringComparer.Ordinal)
+                    .ToDictionary(static group => group.Key, static group => (long)group.Count(), StringComparer.Ordinal);
+                return receipt;
+            }
+
+            await EnsureStreamOpenAsync(_path);
+            await RecoverWrittenPrefixAsync();
+            var bytesByKind = new Dictionary<string, long>(StringComparer.Ordinal);
+            var countsByKind = new Dictionary<string, long>(StringComparer.Ordinal);
+            for (var i = _writtenPendingCount; i < _pending.Count; i++)
+            {
+                var record = _pending[i];
+                _stream!.Seek(0, SeekOrigin.End);
+                await _stream!.WriteAsync(record.Bytes);
+                _writtenPendingCount = i + 1;
+            }
+
+            await _stream!.FlushAsync();
+            _stream.Flush(flushToDisk: true);
+            var confirmedOffset = _stream.Position;
+            foreach (var record in _pending)
+            {
+                var kind = record.Record.Kind;
+                bytesByKind[kind] = bytesByKind.GetValueOrDefault(kind) + record.Bytes.Length;
+                countsByKind[kind] = countsByKind.GetValueOrDefault(kind) + 1;
+            }
+            var written = _pending.Count;
+            _pending.Clear();
+            _pendingStartOffset = null;
+            _writtenPendingCount = 0;
+            await DisposeStreamAsync();
+            LastFlushedRecordCounts = countsByKind;
+            return new RolloutWriteReceipt(confirmedOffset, written, bytesByKind);
+        }
+
+        private async Task RecoverWrittenPrefixAsync()
+        {
+            if (_pending.Count == 0)
+            {
+                _pendingStartOffset = null;
+                _writtenPendingCount = 0;
+                return;
+            }
+
+            _pendingStartOffset ??= _stream!.Length;
+            var position = _pendingStartOffset.Value;
+            var matched = 0;
+            foreach (var pending in _pending)
+            {
+                if (position + pending.Bytes.Length > _stream!.Length)
+                    break;
+
+                var actual = new byte[pending.Bytes.Length];
+                _stream.Seek(position, SeekOrigin.Begin);
+                var read = 0;
+                while (read < actual.Length)
+                {
+                    var count = await _stream.ReadAsync(actual.AsMemory(read));
+                    if (count == 0)
+                        break;
+                    read += count;
+                }
+
+                if (read != actual.Length || !actual.AsSpan().SequenceEqual(pending.Bytes))
+                    break;
+
+                position += pending.Bytes.Length;
+                matched++;
+            }
+
+            // Any bytes after the last complete, matching record are an unconfirmed
+            // partial suffix from this recorder and can be replaced safely.
+            if (_stream!.Length != position)
+            {
+                _stream.SetLength(position);
+                await _stream.FlushAsync();
+            }
+
+            _stream.Seek(0, SeekOrigin.End);
+            _writtenPendingCount = matched;
+        }
+
+        private async Task EnsureStreamOpenAsync(string path)
+        {
+            if (_stream != null)
+                return;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var stream = new FileStream(
+                path,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.ReadWrite | FileShare.Delete,
+                bufferSize: 16 * 1024,
+                FileOptions.Asynchronous);
+            if (_pendingStartOffset == null && stream.Length > 0)
+            {
+                stream.Seek(-1, SeekOrigin.End);
+                var last = stream.ReadByte();
+                stream.Seek(0, SeekOrigin.End);
+                if (last != (byte)'\n')
+                {
+                    await stream.WriteAsync("\n"u8.ToArray());
+                    await stream.FlushAsync();
+                }
+            }
+            else
+            {
+                stream.Seek(0, SeekOrigin.End);
+            }
+
+            _stream = stream;
+        }
+
+        private async Task DisposeStreamAsync()
+        {
+            if (_stream == null)
+                return;
+            await _stream.DisposeAsync();
+            _stream = null;
+        }
+    }
+
+    private abstract record WriterCommand;
+
+    private sealed record AddRecordCommand(string Path, ThreadRolloutRecord Record) : WriterCommand;
+
+    private sealed record FlushCommand(TaskCompletionSource<RolloutWriteReceipt> Completion) : WriterCommand;
+
+    private sealed record CloseCommand(TaskCompletionSource Completion) : WriterCommand;
+
+    private sealed record PendingRecord(ThreadRolloutRecord Record, byte[] Bytes, Exception? Error);
+}
+
+internal static class RolloutTelemetry
+{
+    private static readonly Meter Meter = new("DotCraft.Protocol.Rollout.Resume");
+    private static readonly Histogram<long> ResumeBytesRead = Meter.CreateHistogram<long>("dotcraft.rollout.resume.bytes_read", "By");
+    private static readonly Histogram<long> ResumeRecordsDecoded = Meter.CreateHistogram<long>("dotcraft.rollout.resume.records.decoded");
+    private static readonly Histogram<long> ResumeRecordsRejected = Meter.CreateHistogram<long>("dotcraft.rollout.resume.records.rejected");
+
+    public static void RecordResume(long bytesRead, int recordsDecoded, int recordsRejected = 0)
+    {
+        ResumeBytesRead.Record(bytesRead);
+        ResumeRecordsDecoded.Record(recordsDecoded);
+        ResumeRecordsRejected.Record(recordsRejected);
+    }
+}

--- a/src/DotCraft.Core/Protocol/RolloutWriter.cs
+++ b/src/DotCraft.Core/Protocol/RolloutWriter.cs
@@ -165,7 +165,7 @@ internal sealed class OrderedRolloutWriter : IRolloutWriter
             try
             {
                 foreach (var record in records)
-                    await _channel.Writer.WriteAsync(new AddRecordCommand(path, record), CancellationToken.None);
+                    await _channel.Writer.WriteAsync(new AddRecordCommand(path, record), ct);
             }
             finally
             {

--- a/src/DotCraft.Core/Protocol/SessionPersistenceJsonOptions.cs
+++ b/src/DotCraft.Core/Protocol/SessionPersistenceJsonOptions.cs
@@ -7,12 +7,12 @@ using Microsoft.Extensions.AI;
 namespace DotCraft.Protocol;
 
 /// <summary>
-/// JSON serialization options used for persisting agent session files.
+/// JSON serialization options shared by model-history persistence and runtime history injection.
 /// </summary>
 public static class SessionPersistenceJsonOptions
 {
     /// <summary>
-    /// Canonical options for thread session save/load paths.
+    /// Canonical options for model-history codec and Framework StateBag history values.
     /// </summary>
     public static readonly JsonSerializerOptions Default = BuildOptions();
 

--- a/src/DotCraft.Core/Protocol/SessionPersistenceService.cs
+++ b/src/DotCraft.Core/Protocol/SessionPersistenceService.cs
@@ -36,6 +36,12 @@ public sealed class SessionPersistenceService(
     public Task SaveThreadAsync(SessionThread thread, CancellationToken ct = default)
         => threadStore.SaveThreadAsync(thread, ct);
 
+    internal Task SaveTurnAsync(SessionThread thread, SessionTurn turn, CancellationToken ct = default)
+        => threadStore.SaveTurnAsync(thread, turn, ct);
+
+    internal Task CommitTurnAsync(TurnPersistenceCommit commit, CancellationToken ct = default)
+        => threadStore.CommitTurnAsync(commit, ct);
+
     internal StateRuntime StateRuntime => _stateRuntime;
 
     public Task<SessionThread?> LoadThreadAsync(string threadId, CancellationToken ct = default)
@@ -47,19 +53,20 @@ public sealed class SessionPersistenceService(
     public Task<List<ThreadSummary>> LoadIndexAsync(CancellationToken ct = default)
         => threadStore.LoadIndexAsync(ct);
 
-    public Task SaveSessionAsync(
-        AIAgent agent,
+    internal Task PersistModelHistoryAsync(
         AgentSession session,
         string threadId,
+        string turnId,
+        int persistedPrefixLength,
         CancellationToken ct = default)
-        => threadStore.SaveSessionAsync(agent, session, threadId, ct);
+        => threadStore.PersistModelHistoryAsync(session, threadId, turnId, persistedPrefixLength, ct);
 
-    internal Task<AgentSession> SaveSessionFromHistoryAsync(
-        AIAgent agent,
+    internal Task AppendModelHistoryAsync(
         string threadId,
         IReadOnlyList<ChatMessage> history,
+        string turnId,
         CancellationToken ct = default)
-        => threadStore.SaveSessionFromHistoryAsync(agent, threadId, history, ct);
+        => threadStore.AppendModelHistoryAsync(threadId, history, turnId, ct);
 
     internal Task<ForkModelHistoryMaterialization> BuildForkModelHistoryMaterializationAsync(
         SessionThread source,
@@ -67,17 +74,18 @@ public sealed class SessionPersistenceService(
         CancellationToken ct = default)
         => threadStore.BuildForkModelHistoryMaterializationAsync(source, forked, ct);
 
-    public Task RebuildAndSaveSessionFromThreadAsync(
-        AIAgent agent,
-        string threadId,
-        CancellationToken ct = default)
-        => threadStore.RebuildAndSaveSessionFromThreadAsync(agent, threadId, ct);
-
     public Task<AgentSession> LoadOrCreateSessionAsync(
         AIAgent agent,
         string threadId,
         CancellationToken ct = default)
         => threadStore.LoadOrCreateSessionAsync(agent, threadId, ct);
+
+    internal Task<AgentSession> LoadOrCreateSessionAsync(
+        AIAgent agent,
+        SessionThread thread,
+        string? excludedTurnId,
+        CancellationToken ct = default)
+        => threadStore.LoadOrCreateSessionAsync(agent, thread, excludedTurnId, ct);
 
     public Task RollbackThreadAsync(SessionThread thread, int numTurns, CancellationToken ct = default)
         => threadStore.RollbackThreadAsync(thread, numTurns, ct);
@@ -103,12 +111,6 @@ public sealed class SessionPersistenceService(
             tokensBefore,
             tokensAfter,
             ct);
-
-    public void DeleteSessionFile(string threadId)
-        => threadStore.DeleteSessionFile(threadId);
-
-    public bool SessionFileExists(string threadId)
-        => threadStore.SessionFileExists(threadId);
 
     public long? LoadContextUsageTokens(string threadId)
         => threadStore.LoadContextUsageTokens(threadId);
@@ -236,7 +238,6 @@ public sealed class SessionPersistenceService(
             _traceStore.ClearSession(sessionKey);
 
         threadStore.DeleteThread(threadId);
-        threadStore.DeleteSessionFile(threadId);
         DeleteUsageRecords([threadId], sessionKeys);
         return Task.CompletedTask;
     }

--- a/src/DotCraft.Core/Protocol/SessionService.MaintenanceCoordinator.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.MaintenanceCoordinator.cs
@@ -176,7 +176,6 @@ public sealed partial class SessionService
                     case CompactionOutcome.Partial:
                     {
                         tokenTracker.Reset();
-                        await owner.Persistence.SaveSessionAsync(agent, session, threadId, maintenanceCt);
                         var contextUsage = await owner.SaveReplacementContextUsageSnapshotAsync(
                             threadId,
                             status.ThresholdAfter.Tokens,
@@ -470,6 +469,7 @@ public sealed partial class SessionService
             catch (Exception ex)
             {
                 owner.Logger?.LogWarning(ex, "Failed to append compaction checkpoint for thread {ThreadId}", threadId);
+                throw;
             }
         }
 

--- a/src/DotCraft.Core/Protocol/SessionService.ThreadCreationCoordinator.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.ThreadCreationCoordinator.cs
@@ -178,11 +178,21 @@ public sealed partial class SessionService
                     ct);
             }
 
-            if (forked.HistoryMode == HistoryMode.Server && materialization.History.Count > 0)
+            if (forked.HistoryMode == HistoryMode.Server
+                && materialization.History.Count > 0
+                && forked.Turns.Count > 0)
             {
-                await owner.EnsurePerThreadAgentIfMissingAsync(forked.Id, forked, ct);
-                var agent = owner.GetThreadAgentOrDefault(forked.Id);
-                await owner.Persistence.SaveSessionFromHistoryAsync(agent, forked.Id, materialization.History, ct);
+                if (!materialization.HasCompatibleCheckpoint)
+                {
+                    foreach (var forkTurn in forked.Turns)
+                    {
+                        await owner.Persistence.AppendModelHistoryAsync(
+                            forked.Id,
+                            ThreadStore.BuildModelVisibleHistoryFromTurn(forkTurn),
+                            forkTurn.Id,
+                            ct);
+                    }
+                }
             }
 
             await owner.SaveContextUsageSnapshotAsync(

--- a/src/DotCraft.Core/Protocol/SessionService.ThreadLifecycleCoordinator.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.ThreadLifecycleCoordinator.cs
@@ -1,4 +1,6 @@
 using DotCraft.Abstractions;
+using DotCraft.Tools;
+using Microsoft.Extensions.Logging;
 
 namespace DotCraft.Protocol;
 
@@ -218,10 +220,12 @@ public sealed partial class SessionService
         private async Task DeleteCoreAsync(string threadId, CancellationToken ct)
         {
             var ephemeral = false;
+            string? workspacePath = null;
             if (owner._runtimeRegistry.TryGetRuntime(threadId, out var runtime))
             {
                 var thread = runtime.Thread;
                 ephemeral = thread.Ephemeral;
+                workspacePath = thread.WorkspacePath;
                 foreach (var turn in thread.Turns.Where(t => t.Status is TurnStatus.Running or TurnStatus.WaitingApproval or TurnStatus.WaitingInput))
                 {
                     if (runtime.TryRemoveTurn(turn.Id, out var turnRuntime))
@@ -230,6 +234,31 @@ public sealed partial class SessionService
                             await turnRuntime.Cancellation.CancelAsync();
                         turnRuntime.Dispose();
                     }
+                }
+            }
+
+            if (workspacePath is null)
+            {
+                var persisted = await owner.Persistence.LoadThreadAsync(threadId, ct);
+                if (persisted is not null)
+                {
+                    ephemeral = persisted.Ephemeral;
+                    workspacePath = persisted.WorkspacePath;
+                }
+            }
+
+            if (owner.BackgroundTerminalService != null)
+                await owner.BackgroundTerminalService.DeleteThreadArtifactsAsync(threadId, ct);
+
+            if (!string.IsNullOrWhiteSpace(workspacePath))
+            {
+                var cleanup = ToolResultProcessor.CleanupThreadArtifacts(workspacePath, threadId);
+                if (cleanup.Errors > 0)
+                {
+                    owner.Logger?.LogWarning(
+                        "Failed to delete {Count} tool-result artifact directories for thread {ThreadId}; cleanup will be retried.",
+                        cleanup.Errors,
+                        threadId);
                 }
             }
 
@@ -243,8 +272,6 @@ public sealed partial class SessionService
             owner.InvalidatePromptRequestSnapshot(threadId, "thread_deleted");
             owner.ClearContextUsageAnchor(threadId);
             owner.ForgetContextPages(threadId);
-            if (owner.BackgroundTerminalService != null)
-                await owner.BackgroundTerminalService.CleanThreadAsync(threadId, ct);
 
             owner.ThreadDeletedForBroadcast?.Invoke(threadId);
         }

--- a/src/DotCraft.Core/Protocol/SessionService.cs
+++ b/src/DotCraft.Core/Protocol/SessionService.cs
@@ -1382,6 +1382,7 @@ public sealed partial class SessionService(
             Dictionary<int, string>? streamingToolNameByIndex = null;
             Dictionary<string, SessionItem>? streamingToolCallItemsByCallId = null;
             PendingCompactionCheckpoint? pendingCompactionCheckpoint = null;
+            var persistedModelHistoryCount = 0;
 
             void FinalizeStreamingAgentMessage()
             {
@@ -1413,31 +1414,40 @@ public sealed partial class SessionService(
 
             async Task PersistCancelledTurnAsync()
             {
-                await TrySaveThreadAsync(thread);
-                if (session is not null)
-                {
-                    await TrySaveSessionAsync(agent, session, threadId);
-                    await TryAppendPendingCompactionCheckpointAsync();
-                    return;
-                }
-
-                if (!persistence.SessionFileExists(threadId))
-                    await TryRebuildAndSaveSessionAsync(agent, threadId);
+                await PersistCurrentTurnCommitAsync();
             }
 
-            async Task TryAppendPendingCompactionCheckpointAsync()
+            async Task PersistCurrentTurnCommitAsync()
             {
-                if (pendingCompactionCheckpoint is null || session is null)
-                    return;
+                IReadOnlyList<ChatMessage> modelHistory;
+                if (session != null && TrySnapshotInMemoryHistory(session, out var currentHistory))
+                {
+                    if (persistedModelHistoryCount < 0 || persistedModelHistoryCount > currentHistory.Count)
+                        throw new InvalidOperationException($"Invalid model-history prefix length for thread '{threadId}'.");
+                    modelHistory = currentHistory.Skip(persistedModelHistoryCount).ToList();
+                }
+                else
+                {
+                    modelHistory = ThreadStore.BuildModelVisibleHistoryFromTurn(turn);
+                }
 
                 var checkpoint = pendingCompactionCheckpoint;
-                pendingCompactionCheckpoint = null;
-                await TryAppendCompactionCheckpointAsync(
-                    threadId,
-                    turn.Id,
-                    session,
-                    checkpoint,
+                var compaction = checkpoint == null
+                    ? null
+                    : new TurnCompactionHistory(
+                        checkpoint.Trigger,
+                        checkpoint.Mode,
+                        checkpoint.TokensBefore,
+                        checkpoint.TokensAfter,
+                        checkpoint.ReplacementHistory ?? []);
+                await PersistTurnCommitWithMaterializationAsync(
+                    thread,
+                    turn,
+                    modelHistory,
+                    compaction,
                     CancellationToken.None);
+                pendingCompactionCheckpoint = null;
+                persistedModelHistoryCount += modelHistory.Count;
             }
 
             async Task<ChatMessage?> TryDrainTurnContextMessageAsync(CancellationToken drainCt)
@@ -1771,13 +1781,16 @@ public sealed partial class SessionService(
                         session.SetInMemoryChatHistory(
                             [.. result.Messages],
                             jsonSerializerOptions: SessionPersistenceJsonOptions.Default);
+                        if (!TrySnapshotInMemoryHistory(session, out var compactedHistory))
+                            throw new InvalidOperationException("Unable to snapshot compacted model history.");
                         pendingCompactionCheckpoint = new PendingCompactionCheckpoint(
                             "auto",
                             CompactionOutcomeToWire(status.Outcome),
                             status.ThresholdBefore.Tokens,
-                            status.ThresholdAfter.Tokens);
+                            status.ThresholdAfter.Tokens,
+                            compactedHistory);
+                        persistedModelHistoryCount = compactedHistory.Count;
                         InvalidatePromptRequestSnapshot(threadId, "auto_compaction");
-                        await TrySaveSessionAsync(agent, session, threadId);
                         var contextUsage = await SaveReplacementContextUsageSnapshotAsync(
                             threadId,
                             status.ThresholdAfter.Tokens,
@@ -1882,22 +1895,9 @@ public sealed partial class SessionService(
                     CancellationToken.None);
                 await MarkActiveGoalBlockedForTurnErrorAsync(turnKey, CancellationToken.None);
                 ThreadRuntimeSignalForBroadcast?.Invoke(threadId, SessionThreadRuntimeSignal.TurnFailed);
-                await TrySaveThreadAsync(thread);
                 if (session is not null)
-                {
-                    if (TryAppendFailedTurnTailToSession(session, turn))
-                    {
-                        await TrySaveSessionAsync(agent, session, threadId);
-                        await TryAppendPendingCompactionCheckpointAsync();
-                        return;
-                    }
-                }
-                else if (persistence.SessionFileExists(threadId))
-                {
-                    return;
-                }
-
-                await TryRebuildAndSaveSessionAsync(agent, threadId);
+                    TryAppendFailedTurnTailToSession(session, turn);
+                await PersistCurrentTurnCommitAsync();
             }
 
             try
@@ -1942,8 +1942,10 @@ public sealed partial class SessionService(
                 }
                 else
                 {
-                    session = await persistence.LoadOrCreateSessionAsync(agent, threadId, executionCt);
+                    session = await persistence.LoadOrCreateSessionAsync(agent, thread, turn.Id, executionCt);
                 }
+                if (TrySnapshotInMemoryHistory(session, out var persistedHistory))
+                    persistedModelHistoryCount = persistedHistory.Count;
 
                 // Step 5c: Append runtime context to the multimodal content list
                 var turnMode = thread.Configuration?.Mode?.Equals("plan", StringComparison.OrdinalIgnoreCase) == true
@@ -2863,18 +2865,8 @@ public sealed partial class SessionService(
                 thread.LastActiveAt = DateTimeOffset.UtcNow;
                 RecordTurnTokenUsage(thread, turn);
                 RecordTurnDurationTrace(threadId, turn);
+                await PersistCurrentTurnCommitAsync();
                 eventChannel.EmitTurnCompleted(turn);
-
-                try
-                {
-                    await PersistThreadWithMaterializationAsync(thread, CancellationToken.None);
-                    await TrySaveSessionAsync(agent, session, threadId);
-                    await TryAppendPendingCompactionCheckpointAsync();
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogError(ex, "Failed to persist thread state after turn completion for thread {ThreadId}", threadId);
-                }
 
                 _ = TryScheduleMemoryConsolidation(
                     threadId,
@@ -2964,6 +2956,23 @@ public sealed partial class SessionService(
                     BuildEmptyProviderResponseMessage(threadId, session, tokenTracker, ex.Message),
                     "agent_empty_response");
             }
+            catch (RolloutPersistenceException ex)
+            {
+                logger?.LogError(ex, "Turn persistence failed for thread {ThreadId}", threadId);
+                FinalizeStreamingAgentMessage();
+                FinalizeStreamingReasoning();
+                var errorItem = CreateErrorItem(
+                    turn,
+                    NextItemSeq(),
+                    ex.Message,
+                    "persistence_error",
+                    fatal: true);
+                turn.Items.Add(errorItem);
+                eventChannel.EmitItemStarted(errorItem);
+                eventChannel.EmitItemCompleted(errorItem);
+                FailTurn(turn, eventChannel, ex.Message);
+                ThreadRuntimeSignalForBroadcast?.Invoke(threadId, SessionThreadRuntimeSignal.TurnFailed);
+            }
             catch (Exception ex)
             {
                 logger?.LogError(ex, "Turn execution failed for thread {ThreadId}", threadId);
@@ -3024,11 +3033,15 @@ public sealed partial class SessionService(
                             if (status.Success)
                             {
                                 tokenTracker?.Reset();
+                                if (!TrySnapshotInMemoryHistory(session, out var compactedHistory))
+                                    throw new InvalidOperationException("Unable to snapshot compacted model history.");
                                 pendingCompactionCheckpoint = new PendingCompactionCheckpoint(
                                     "reactive",
                                     CompactionOutcomeToWire(status.Outcome),
                                     status.ThresholdBefore.Tokens,
-                                    status.ThresholdAfter.Tokens);
+                                    status.ThresholdAfter.Tokens,
+                                    compactedHistory);
+                                persistedModelHistoryCount = compactedHistory.Count;
                                 InvalidatePromptRequestSnapshot(threadId, "reactive_compaction");
                                 var contextUsage = await SaveReplacementContextUsageSnapshotAsync(
                                     threadId,
@@ -4574,21 +4587,6 @@ public sealed partial class SessionService(
         }
     }
 
-    private async Task TrySaveThreadAsync(SessionThread thread)
-    {
-        if (IsPendingPermanentDeletion(thread.Id))
-            return;
-
-        try
-        {
-            await PersistThreadWithMaterializationAsync(thread, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            logger?.LogError(ex, "Failed to persist thread state for thread {ThreadId}", thread.Id);
-        }
-    }
-
     private static bool TryAppendFailedTurnTailToSession(AgentSession session, SessionTurn turn)
     {
         if (!session.TryGetInMemoryChatHistory(
@@ -4623,12 +4621,7 @@ public sealed partial class SessionService(
     {
         try
         {
-            var session = await persistence.LoadOrCreateSessionAsync(agent, threadId, ct);
-            if (TryTrimRolledBackTailFromSession(session, removedTurns))
-            {
-                await TrySaveSessionAsync(agent, session, threadId);
-                return session;
-            }
+            return await persistence.LoadOrCreateSessionAsync(agent, threadId, ct);
         }
         catch (OperationCanceledException)
         {
@@ -4639,21 +4632,7 @@ public sealed partial class SessionService(
             logger?.LogWarning(ex, "Failed to trim agent session after rollback for thread {ThreadId}", threadId);
         }
 
-        await TryRebuildAndSaveSessionAsync(agent, threadId);
-
-        try
-        {
-            return await persistence.LoadOrCreateSessionAsync(agent, threadId, ct);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            logger?.LogWarning(ex, "Failed to load rebuilt agent session after rollback for thread {ThreadId}", threadId);
-            return null;
-        }
+        return null;
     }
 
     private async Task SaveContextUsageFromSessionAsync(
@@ -4866,52 +4845,6 @@ public sealed partial class SessionService(
         return result;
     }
 
-    private async Task<bool> TrySaveSessionAsync(AIAgent agent, AgentSession session, string threadId)
-    {
-        if (IsPendingPermanentDeletion(threadId))
-            return false;
-
-        if (!_runtimeRegistry.TryGetThread(threadId, out var thread) || thread.HistoryMode != HistoryMode.Server)
-            return false;
-
-        try
-        {
-            await persistence.SaveSessionAsync(agent, session, threadId, ct: CancellationToken.None);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            logger?.LogError(ex, "Failed to save agent session for thread {ThreadId}", threadId);
-            return false;
-        }
-    }
-
-    private async Task TryRebuildAndSaveSessionAsync(AIAgent agent, string threadId)
-    {
-        if (IsPendingPermanentDeletion(threadId))
-            return;
-
-        if (!_runtimeRegistry.TryGetThread(threadId, out var thread) || thread.HistoryMode != HistoryMode.Server)
-            return;
-
-        try
-        {
-            await persistence.RebuildAndSaveSessionFromThreadAsync(agent, threadId, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            logger?.LogError(ex, "Failed to rebuild agent session for thread {ThreadId}; clearing stale session.", threadId);
-            try
-            {
-                persistence.DeleteSessionFile(threadId);
-            }
-            catch (Exception deleteEx)
-            {
-                logger?.LogWarning(deleteEx, "Failed to clear stale agent session for thread {ThreadId}", threadId);
-            }
-        }
-    }
-
     private bool IsMaterialized(string threadId) =>
         _runtimeRegistry.TryGetRuntime(threadId, out var runtime) && runtime.Materialized;
 
@@ -4929,6 +4862,27 @@ public sealed partial class SessionService(
         }
 
         await persistence.SaveThreadAsync(thread, ct);
+        _runtimeRegistry.SetThread(thread).Materialized = true;
+    }
+
+    private async Task PersistTurnCommitWithMaterializationAsync(
+        SessionThread thread,
+        SessionTurn turn,
+        IReadOnlyList<ChatMessage> modelHistory,
+        TurnCompactionHistory? compaction,
+        CancellationToken ct)
+    {
+        if (IsPendingPermanentDeletion(thread.Id))
+            return;
+        if (thread.Ephemeral)
+        {
+            _runtimeRegistry.SetThread(thread).Materialized = false;
+            return;
+        }
+
+        await persistence.CommitTurnAsync(
+            new TurnPersistenceCommit(thread, turn, modelHistory, compaction),
+            ct);
         _runtimeRegistry.SetThread(thread).Materialized = true;
     }
 
@@ -4970,7 +4924,8 @@ public sealed partial class SessionService(
         string Trigger,
         string Mode,
         long TokensBefore,
-        long TokensAfter);
+        long TokensAfter,
+        IReadOnlyList<ChatMessage>? ReplacementHistory = null);
 
     private sealed class ContextCompactionFailedException(string message) : InvalidOperationException(message);
 

--- a/src/DotCraft.Core/Protocol/ThreadAttachmentStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadAttachmentStore.cs
@@ -1,39 +1,23 @@
 using System.Security.Cryptography;
 using System.Text;
 using DotCraft.State;
+using Microsoft.Data.Sqlite;
 
 namespace DotCraft.Protocol;
 
 internal sealed class ThreadAttachmentStore(StateRuntime stateRuntime, string botPath)
 {
-    private static readonly TimeSpan DraftAttachmentTtl = TimeSpan.FromHours(24);
     private readonly string _attachmentsImageDir = Path.Combine(botPath, "attachments", "images");
 
-    public void RebuildFromThreads(IEnumerable<SessionThread> threads)
+    public IReadOnlySet<string> ReplaceThreadAttachments(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        SessionThread thread)
     {
-        using var connection = stateRuntime.OpenConnection();
-        using (var delete = connection.CreateCommand())
-        {
-            delete.CommandText = "DELETE FROM thread_attachments";
-            delete.ExecuteNonQuery();
-        }
-
-        foreach (var thread in threads)
-            ReplaceThreadAttachments(thread, cleanupRemoved: false);
-
-        CleanupUnreferencedAttachments(DraftAttachmentTtl);
-    }
-
-    public void ReplaceThreadAttachments(SessionThread thread, bool cleanupRemoved = true)
-    {
-        var previousPaths = cleanupRemoved
-            ? LoadPathsForThread(thread.Id)
-            : [];
         var refs = ExtractReferences(thread).ToList();
-
-        using var connection = stateRuntime.OpenConnection();
         using (var delete = connection.CreateCommand())
         {
+            delete.Transaction = transaction;
             delete.CommandText = "DELETE FROM thread_attachments WHERE thread_id = $thread_id";
             delete.Parameters.AddWithValue("$thread_id", thread.Id);
             delete.ExecuteNonQuery();
@@ -42,6 +26,7 @@ internal sealed class ThreadAttachmentStore(StateRuntime stateRuntime, string bo
         foreach (var reference in refs)
         {
             using var insert = connection.CreateCommand();
+            insert.Transaction = transaction;
             insert.CommandText = """
                 INSERT INTO thread_attachments(
                     ref_id,
@@ -80,24 +65,22 @@ internal sealed class ThreadAttachmentStore(StateRuntime stateRuntime, string bo
             insert.ExecuteNonQuery();
         }
 
-        if (cleanupRemoved)
-            CleanupUnreferencedPaths(previousPaths.Except(refs.Select(r => r.Path), StringComparer.OrdinalIgnoreCase));
+        return refs.Select(static reference => reference.Path)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    public void DeleteThreadReferencesAndCleanup(string threadId, IEnumerable<string>? additionalCandidatePaths = null)
+    public IReadOnlySet<string> LoadCandidatePaths(
+        string threadId,
+        IEnumerable<string>? additionalCandidatePaths = null)
     {
         var candidatePaths = LoadPathsForThread(threadId);
         if (additionalCandidatePaths != null)
             candidatePaths.UnionWith(additionalCandidatePaths.Where(IsManagedImagePath));
-
-        using var connection = stateRuntime.OpenConnection();
-        using var delete = connection.CreateCommand();
-        delete.CommandText = "DELETE FROM thread_attachments WHERE thread_id = $thread_id";
-        delete.Parameters.AddWithValue("$thread_id", threadId);
-        delete.ExecuteNonQuery();
-
-        CleanupUnreferencedPaths(candidatePaths);
+        return candidatePaths;
     }
+
+    public void CleanupCandidates(IEnumerable<string> candidatePaths) =>
+        CleanupUnreferencedPaths(candidatePaths);
 
     public void CleanupUnreferencedAttachments(TimeSpan minAge)
     {

--- a/src/DotCraft.Core/Protocol/ThreadMetadataStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadMetadataStore.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using DotCraft.Context.Compaction;
 using DotCraft.State;
+using Microsoft.Data.Sqlite;
 
 namespace DotCraft.Protocol;
 
@@ -11,14 +12,19 @@ public sealed record ContextUsagePersistenceSnapshot(long Tokens, string? Source
 
 internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
 {
-    public void UpsertThread(SessionThread thread, string rolloutPath)
+    public void UpsertThread(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        SessionThread thread,
+        string rolloutPath,
+        long projectedRolloutOffset)
     {
         var summary = ThreadSummary.FromThread(thread);
         var firstUserMessage = ExtractFirstUserMessage(thread);
         var archivedAt = thread.Status == ThreadStatus.Archived ? thread.LastActiveAt : (DateTimeOffset?)null;
 
-        using var connection = stateRuntime.OpenConnection();
         using var command = connection.CreateCommand();
+        command.Transaction = transaction;
         command.CommandText = """
             INSERT INTO threads (
                 thread_id,
@@ -30,6 +36,7 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 forked_from_id,
                 ephemeral,
                 worktree_json,
+                source_json,
                 display_name,
                 status,
                 created_at,
@@ -38,7 +45,8 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 history_mode,
                 turn_count,
                 first_user_message,
-                metadata_json
+                metadata_json,
+                projected_rollout_offset
             ) VALUES (
                 $thread_id,
                 $rollout_path,
@@ -49,6 +57,7 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 $forked_from_id,
                 $ephemeral,
                 $worktree_json,
+                $source_json,
                 $display_name,
                 $status,
                 $created_at,
@@ -57,7 +66,8 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 $history_mode,
                 $turn_count,
                 $first_user_message,
-                $metadata_json
+                $metadata_json,
+                $projected_rollout_offset
             )
             ON CONFLICT(thread_id) DO UPDATE SET
                 rollout_path = excluded.rollout_path,
@@ -68,6 +78,7 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 forked_from_id = excluded.forked_from_id,
                 ephemeral = excluded.ephemeral,
                 worktree_json = excluded.worktree_json,
+                source_json = excluded.source_json,
                 display_name = excluded.display_name,
                 status = excluded.status,
                 created_at = excluded.created_at,
@@ -76,7 +87,8 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 history_mode = excluded.history_mode,
                 turn_count = excluded.turn_count,
                 first_user_message = excluded.first_user_message,
-                metadata_json = excluded.metadata_json
+                metadata_json = excluded.metadata_json,
+                projected_rollout_offset = excluded.projected_rollout_offset
             """;
         command.Parameters.AddWithValue("$thread_id", thread.Id);
         command.Parameters.AddWithValue("$rollout_path", rolloutPath);
@@ -91,6 +103,11 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
             summary.Worktree == null
                 ? DBNull.Value
                 : JsonSerializer.Serialize(summary.Worktree));
+        command.Parameters.AddWithValue(
+            "$source_json",
+            JsonSerializer.Serialize(
+                PersistedThreadSourceCodec.Encode(summary.Source),
+                SessionPersistenceJsonOptions.Default));
         command.Parameters.AddWithValue("$display_name", (object?)summary.DisplayName ?? DBNull.Value);
         command.Parameters.AddWithValue("$status", summary.Status.ToString());
         command.Parameters.AddWithValue("$created_at", summary.CreatedAt.UtcDateTime.ToString("O"));
@@ -100,7 +117,53 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
         command.Parameters.AddWithValue("$turn_count", summary.TurnCount);
         command.Parameters.AddWithValue("$first_user_message", (object?)firstUserMessage ?? DBNull.Value);
         command.Parameters.AddWithValue("$metadata_json", JsonSerializer.Serialize(summary.Metadata));
+        command.Parameters.AddWithValue("$projected_rollout_offset", projectedRolloutOffset);
         command.ExecuteNonQuery();
+    }
+
+    public void UpdateProjectedRolloutOffset(string threadId, string rolloutPath, long projectedRolloutOffset)
+    {
+        using var connection = stateRuntime.OpenConnection();
+        using var transaction = connection.BeginTransaction();
+        UpdateProjectedRolloutOffset(connection, transaction, threadId, rolloutPath, projectedRolloutOffset);
+        transaction.Commit();
+    }
+
+    public static void UpdateProjectedRolloutOffset(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string threadId,
+        string rolloutPath,
+        long projectedRolloutOffset)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE threads
+            SET rollout_path = $rollout_path,
+                projected_rollout_offset = $projected_rollout_offset
+            WHERE thread_id = $thread_id
+            """;
+        command.Parameters.AddWithValue("$thread_id", threadId);
+        command.Parameters.AddWithValue("$rollout_path", rolloutPath);
+        command.Parameters.AddWithValue("$projected_rollout_offset", projectedRolloutOffset);
+        command.ExecuteNonQuery();
+    }
+
+    public Dictionary<string, ThreadProjectionState> LoadProjectionStates()
+    {
+        var states = new Dictionary<string, ThreadProjectionState>(StringComparer.Ordinal);
+        using var connection = stateRuntime.OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT thread_id, rollout_path, projected_rollout_offset FROM threads";
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            states[reader.GetString(0)] = new ThreadProjectionState(
+                reader.GetString(1),
+                reader.IsDBNull(2) ? 0 : reader.GetInt64(2));
+        }
+        return states;
     }
 
     public List<ThreadSummary> LoadIndex()
@@ -123,7 +186,8 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 metadata_json,
                 forked_from_id,
                 ephemeral,
-                worktree_json
+                worktree_json,
+                source_json
             FROM threads
             ORDER BY updated_at DESC, thread_id DESC
             """;
@@ -131,6 +195,9 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
         while (reader.Read())
         {
             var originChannel = reader.GetString(3);
+            var metadata = reader.IsDBNull(10)
+                ? new Dictionary<string, string>()
+                : ParseMetadata(reader.GetString(10));
             list.Add(new ThreadSummary
             {
                 Id = reader.GetString(0),
@@ -139,16 +206,18 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
                 OriginChannel = originChannel,
                 ChannelContext = reader.IsDBNull(4) ? null : reader.GetString(4),
                 DisplayName = reader.IsDBNull(5) ? null : reader.GetString(5),
-                Source = string.Equals(originChannel, SubAgentThreadOrigin.ChannelName, StringComparison.OrdinalIgnoreCase)
-                    ? ThreadSource.ForSubAgent(new SubAgentThreadSource())
-                    : ThreadSource.User(),
+                Source = reader.IsDBNull(14)
+                    ? PersistedThreadSourceCodec.InferLegacy(originChannel, metadata)
+                    : PersistedThreadSourceCodec.Decode(
+                        JsonSerializer.Deserialize<PersistedThreadSource>(
+                            reader.GetString(14),
+                            SessionPersistenceJsonOptions.Default)
+                        ?? throw new JsonException("Thread source projection decoded to null.")),
                 Status = Enum.TryParse<ThreadStatus>(reader.GetString(6), out var status) ? status : ThreadStatus.Active,
                 CreatedAt = DateTimeOffset.Parse(reader.GetString(7)),
                 LastActiveAt = DateTimeOffset.Parse(reader.GetString(8)),
                 TurnCount = reader.GetInt32(9),
-                Metadata = reader.IsDBNull(10)
-                    ? []
-                    : ParseMetadata(reader.GetString(10)),
+                Metadata = metadata,
                 ForkedFromId = reader.IsDBNull(11) ? null : reader.GetString(11),
                 Ephemeral = !reader.IsDBNull(12) && reader.GetInt32(12) != 0,
                 Worktree = reader.IsDBNull(13) ? null : ParseWorktree(reader.GetString(13))
@@ -491,50 +560,6 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
             CreatedAt = DateTimeOffset.Parse(reader.GetString(6)),
             DeliveredAt = reader.IsDBNull(7) ? null : DateTimeOffset.Parse(reader.GetString(7))
         };
-
-    public void SaveSessionJson(string threadId, string sessionJson)
-    {
-        using var connection = stateRuntime.OpenConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO thread_sessions(thread_id, session_json, updated_at)
-            VALUES ($thread_id, $session_json, $updated_at)
-            ON CONFLICT(thread_id) DO UPDATE SET
-                session_json = excluded.session_json,
-                updated_at = excluded.updated_at
-            """;
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.Parameters.AddWithValue("$session_json", sessionJson);
-        command.Parameters.AddWithValue("$updated_at", DateTimeOffset.UtcNow.UtcDateTime.ToString("O"));
-        command.ExecuteNonQuery();
-    }
-
-    public string? LoadSessionJson(string threadId)
-    {
-        using var connection = stateRuntime.OpenConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT session_json FROM thread_sessions WHERE thread_id = $thread_id LIMIT 1";
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        return command.ExecuteScalar() as string;
-    }
-
-    public bool SessionExists(string threadId)
-    {
-        using var connection = stateRuntime.OpenConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT 1 FROM thread_sessions WHERE thread_id = $thread_id LIMIT 1";
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        return command.ExecuteScalar() != null;
-    }
-
-    public void DeleteSession(string threadId)
-    {
-        using var connection = stateRuntime.OpenConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = "DELETE FROM thread_sessions WHERE thread_id = $thread_id";
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.ExecuteNonQuery();
-    }
 
     public ThreadGoal? LoadThreadGoal(string threadId)
     {
@@ -1006,5 +1031,7 @@ internal sealed class ThreadMetadataStore(StateRuntime stateRuntime)
         || usage.LlmCallCount > 0
         || usage.TotalTokens > 0;
 }
+
+internal sealed record ThreadProjectionState(string RolloutPath, long ProjectedRolloutOffset);
 
 internal sealed record ThreadRolloutLocation(string ThreadId, string RolloutPath, ThreadStatus Status);

--- a/src/DotCraft.Core/Protocol/ThreadRolloutStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadRolloutStore.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace DotCraft.Protocol;
@@ -30,27 +32,37 @@ internal sealed class ThreadRolloutStore
 
     public string GetExpectedPath(string threadId, bool archived)
     {
-        var safe = MakeSafe(threadId);
-        return Path.Combine(archived ? _archivedDir : _activeDir, $"{safe}.jsonl");
+        ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
+        var fileName = BuildFileName(threadId);
+        return Path.Combine(archived ? _archivedDir : _activeDir, fileName);
     }
 
     public string? ResolveExistingPath(string threadId)
     {
-        var active = GetExpectedPath(threadId, archived: false);
-        if (File.Exists(active))
-            return active;
+        foreach (var archived in new[] { false, true })
+        {
+            var path = GetExpectedPath(threadId, archived);
+            if (File.Exists(path))
+                return path;
+        }
 
-        var archived = GetExpectedPath(threadId, archived: true);
-        return File.Exists(archived) ? archived : null;
+        return null;
     }
 
     public async Task<SessionThread?> LoadThreadAsync(string threadId, CancellationToken ct = default)
     {
-        var path = ResolveExistingPath(threadId);
-        if (path == null)
-            return null;
+        foreach (var archived in new[] { false, true })
+        {
+            var path = GetExpectedPath(threadId, archived);
+            if (!File.Exists(path))
+                continue;
 
-        return await LoadThreadFromPathAsync(path, ct);
+            var thread = await LoadThreadFromPathAsync(path, ct);
+            if (thread != null && string.Equals(thread.Id, threadId, StringComparison.Ordinal))
+                return thread;
+        }
+
+        return null;
     }
 
     public async Task<SessionThread?> LoadThreadFromPathAsync(string path, CancellationToken ct = default)
@@ -106,7 +118,7 @@ internal sealed class ThreadRolloutStore
         if (existingPath != null && !string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
         {
             await _writer.CloseAsync(thread.Id, ct);
-            existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
+            existingPath = MoveToTargetPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
         }
 
         var records = BuildRecords(previous, thread);
@@ -135,7 +147,7 @@ internal sealed class ThreadRolloutStore
         if (existingPath != null && !string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
         {
             await _writer.CloseAsync(thread.Id, ct);
-            existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
+            existingPath = MoveToTargetPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
         }
 
         if (existingPath == null && !File.Exists(targetPath))
@@ -170,9 +182,8 @@ internal sealed class ThreadRolloutStore
         if (!string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
         {
             await _writer.CloseAsync(thread.Id, ct);
-            existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
+            existingPath = MoveToTargetPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
         }
-
         var record = new ThreadRolloutRecord
         {
             Kind = "turn_state_replaced",
@@ -321,9 +332,8 @@ internal sealed class ThreadRolloutStore
         if (!string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
         {
             await _writer.CloseAsync(thread.Id, ct);
-            existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
+            existingPath = MoveToTargetPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
         }
-
         var records = new List<ThreadRolloutRecord>
         {
             new()
@@ -395,7 +405,8 @@ internal sealed class ThreadRolloutStore
             path,
             thread.Turns,
             excludedTurnId,
-            ct);
+            ct,
+            threadId);
     }
 
     public async Task DeleteThreadAsync(string threadId, CancellationToken ct = default)
@@ -403,8 +414,9 @@ internal sealed class ThreadRolloutStore
         await _writer.CloseAsync(threadId, ct);
         if (_beforeDeleteAsync != null)
             await _beforeDeleteAsync(threadId, ct);
-        foreach (var path in EnumerateCandidatePaths(threadId).Distinct(StringComparer.OrdinalIgnoreCase))
+        foreach (var archived in new[] { false, true })
         {
+            var path = GetExpectedPath(threadId, archived);
             if (File.Exists(path))
                 File.Delete(path);
         }
@@ -413,7 +425,7 @@ internal sealed class ThreadRolloutStore
     public Task CloseThreadAsync(string threadId, CancellationToken ct = default) =>
         _writer.CloseAsync(threadId, ct);
 
-    public string PromoteToCanonicalPath(string threadId, bool archived, string existingPath)
+    private string MoveToTargetPath(string threadId, bool archived, string existingPath)
     {
         var targetPath = GetExpectedPath(threadId, archived);
         if (string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
@@ -422,10 +434,8 @@ internal sealed class ThreadRolloutStore
         Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
         if (File.Exists(targetPath))
             File.Delete(targetPath);
-
         if (File.Exists(existingPath))
             File.Move(existingPath, targetPath);
-
         return targetPath;
     }
 
@@ -468,10 +478,15 @@ internal sealed class ThreadRolloutStore
         return true;
     }
 
-    private IEnumerable<string> EnumerateCandidatePaths(string threadId)
+    internal static string BuildFileName(string threadId)
     {
-        yield return GetExpectedPath(threadId, archived: false);
-        yield return GetExpectedPath(threadId, archived: true);
+        ArgumentException.ThrowIfNullOrWhiteSpace(threadId);
+        var safeName = string.Concat(threadId.Split(Path.GetInvalidFileNameChars()));
+        if (string.Equals(safeName, threadId, StringComparison.Ordinal))
+            return $"{safeName}.jsonl";
+
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(threadId))).ToLowerInvariant();
+        return $"thread-{hash}.jsonl";
     }
 
     private static List<ThreadRolloutRecord> BuildRecords(SessionThread? previous, SessionThread current)
@@ -1004,8 +1019,6 @@ internal sealed class ThreadRolloutStore
             return _thread;
         }
     }
-
-    private static string MakeSafe(string key) => string.Concat(key.Split(Path.GetInvalidFileNameChars()));
 
     private static void ApplyRollback(Dictionary<string, SessionTurn> turns, int numTurns)
     {

--- a/src/DotCraft.Core/Protocol/ThreadRolloutStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadRolloutStore.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 
 namespace DotCraft.Protocol;
@@ -7,15 +6,24 @@ internal sealed class ThreadRolloutStore
 {
     private readonly string _activeDir;
     private readonly string _archivedDir;
-
-    private const int AppendRetryCount = 5;
+    private readonly IRolloutWriter _writer;
+    private readonly Func<string, CancellationToken, Task>? _beforeDeleteAsync;
 
     private static readonly JsonSerializerOptions JsonOptions = SessionJsonOptions.Default;
 
     public ThreadRolloutStore(string botPath)
+        : this(botPath, beforeDeleteAsync: null)
+    {
+    }
+
+    internal ThreadRolloutStore(
+        string botPath,
+        Func<string, CancellationToken, Task>? beforeDeleteAsync)
     {
         _activeDir = Path.Combine(botPath, "threads", "active");
         _archivedDir = Path.Combine(botPath, "threads", "archived");
+        _writer = new OrderedRolloutWriter(JsonOptions);
+        _beforeDeleteAsync = beforeDeleteAsync;
         Directory.CreateDirectory(_activeDir);
         Directory.CreateDirectory(_archivedDir);
     }
@@ -80,12 +88,24 @@ internal sealed class ThreadRolloutStore
         }
     }
 
-    public async Task<string> SaveThreadAsync(SessionThread thread, SessionThread? previous, CancellationToken ct = default)
+    public IEnumerable<string> EnumerateRolloutPaths()
+    {
+        foreach (var dir in new[] { _activeDir, _archivedDir })
+        {
+            if (!Directory.Exists(dir))
+                continue;
+            foreach (var path in Directory.EnumerateFiles(dir, "*.jsonl", SearchOption.TopDirectoryOnly))
+                yield return Path.GetFullPath(path);
+        }
+    }
+
+    public async Task<RolloutAppendResult> SaveThreadAsync(SessionThread thread, SessionThread? previous, CancellationToken ct = default)
     {
         var targetPath = GetExpectedPath(thread.Id, thread.Status == ThreadStatus.Archived);
         var existingPath = ResolveExistingPath(thread.Id);
         if (existingPath != null && !string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
         {
+            await _writer.CloseAsync(thread.Id, ct);
             existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
         }
 
@@ -96,16 +116,16 @@ internal sealed class ThreadRolloutStore
         if (records.Count > 0)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-            var payload = string.Join(
-                Environment.NewLine,
-                records.Select(r => JsonSerializer.Serialize(r, JsonOptions))) + Environment.NewLine;
-            await AppendJsonLinesAsync(targetPath, payload, ct);
+            var receipt = await AppendRecordsAsync(thread.Id, targetPath, records, ct);
+            return new RolloutAppendResult(targetPath, receipt);
         }
 
-        return targetPath;
+        return new RolloutAppendResult(
+            targetPath,
+            new RolloutWriteReceipt(File.Exists(targetPath) ? new FileInfo(targetPath).Length : 0, 0, new Dictionary<string, long>()));
     }
 
-    public async Task<string> AppendRollbackAsync(
+    public async Task<RolloutAppendResult> AppendRollbackAsync(
         SessionThread thread,
         int numTurns,
         CancellationToken ct = default)
@@ -114,6 +134,7 @@ internal sealed class ThreadRolloutStore
         var existingPath = ResolveExistingPath(thread.Id);
         if (existingPath != null && !string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
         {
+            await _writer.CloseAsync(thread.Id, ct);
             existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
         }
 
@@ -133,19 +154,51 @@ internal sealed class ThreadRolloutStore
         };
 
         Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-        var payload = JsonSerializer.Serialize(record, JsonOptions) + Environment.NewLine;
-        await AppendJsonLinesAsync(targetPath, payload, ct);
-        return targetPath;
+        var receipt = await AppendRecordsAsync(thread.Id, targetPath, [record], ct);
+        return new RolloutAppendResult(targetPath, receipt);
     }
 
-    public async Task<string> AppendCompactionCheckpointAsync(
+    public async Task<RolloutAppendResult> AppendTurnStateAsync(
+        SessionThread thread,
+        SessionTurn turn,
+        CancellationToken ct = default)
+    {
+        var targetPath = GetExpectedPath(thread.Id, thread.Status == ThreadStatus.Archived);
+        var existingPath = ResolveExistingPath(thread.Id);
+        if (existingPath == null)
+            return await SaveThreadAsync(thread, previous: null, ct);
+        if (!string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
+        {
+            await _writer.CloseAsync(thread.Id, ct);
+            existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
+        }
+
+        var record = new ThreadRolloutRecord
+        {
+            Kind = "turn_state_replaced",
+            Timestamp = thread.LastActiveAt,
+            TurnStateReplaced = new TurnStateReplacedPayload
+            {
+                ThreadId = thread.Id,
+                Turn = turn,
+                ThreadStatus = thread.Status,
+                LastActiveAt = thread.LastActiveAt,
+                DisplayName = thread.DisplayName
+            }
+        };
+
+        var receipt = await AppendRecordsAsync(thread.Id, existingPath, [record], ct);
+        return new RolloutAppendResult(existingPath, receipt);
+    }
+
+    public async Task<RolloutAppendResult> AppendCompactionCheckpointAsync(
         string threadId,
         string coveredThroughTurnId,
         string trigger,
         string mode,
         long tokensBefore,
         long tokensAfter,
-        JsonElement replacementHistory,
+        IReadOnlyList<ModelHistoryMessage> replacementHistory,
         DateTimeOffset createdAt,
         CancellationToken ct = default)
     {
@@ -167,14 +220,13 @@ internal sealed class ThreadRolloutStore
                 TokensBefore = tokensBefore,
                 TokensAfter = tokensAfter,
                 CreatedAt = createdAt,
-                ReplacementHistory = replacementHistory.Clone()
+                ReplacementHistory = [.. replacementHistory]
             }
         };
 
         Directory.CreateDirectory(Path.GetDirectoryName(existingPath)!);
-        var payload = JsonSerializer.Serialize(record, JsonOptions) + Environment.NewLine;
-        await AppendJsonLinesAsync(existingPath, payload, ct);
-        return existingPath;
+        var receipt = await AppendRecordsAsync(threadId, existingPath, [record], ct);
+        return new RolloutAppendResult(existingPath, receipt);
     }
 
     public async Task<IReadOnlyList<ThreadCompactionCheckpoint>> LoadCompactionCheckpointsAsync(
@@ -217,20 +269,149 @@ internal sealed class ThreadRolloutStore
                 checkpoint.TokensBefore,
                 checkpoint.TokensAfter,
                 checkpoint.CreatedAt,
-                checkpoint.ReplacementHistory.Clone()));
+                checkpoint.ReplacementHistory));
         }
 
         return checkpoints;
     }
 
-    public void DeleteThread(string threadId)
+    public async Task<RolloutAppendResult> AppendModelHistoryAsync(
+        string threadId,
+        string turnId,
+        IReadOnlyList<ModelHistoryMessage> messages,
+        CancellationToken ct = default)
     {
+        var existingPath = ResolveExistingPath(threadId)
+            ?? throw new KeyNotFoundException($"Thread '{threadId}' not found.");
+        if (messages.Count == 0)
+            return new RolloutAppendResult(
+                existingPath,
+                new RolloutWriteReceipt(new FileInfo(existingPath).Length, 0, new Dictionary<string, long>()));
+
+        var record = new ThreadRolloutRecord
+        {
+            Kind = "model_history_messages_appended",
+            Timestamp = DateTimeOffset.UtcNow,
+            ModelHistoryMessagesAppended = new ModelHistoryMessagesAppendedPayload
+            {
+                ThreadId = threadId,
+                TurnId = turnId,
+                Messages = [.. messages]
+            }
+        };
+
+        var receipt = await AppendRecordsAsync(threadId, existingPath, [record], ct);
+        return new RolloutAppendResult(existingPath, receipt);
+    }
+
+    public async Task<RolloutAppendResult> AppendTurnCommitAsync(
+        SessionThread thread,
+        SessionTurn turn,
+        IReadOnlyList<ModelHistoryMessage> modelHistory,
+        TurnCompactionCommit? compaction,
+        CancellationToken ct = default)
+    {
+        var targetPath = GetExpectedPath(thread.Id, thread.Status == ThreadStatus.Archived);
+        var existingPath = ResolveExistingPath(thread.Id);
+        if (existingPath == null)
+        {
+            var opened = await SaveThreadAsync(thread, previous: null, ct);
+            existingPath = opened.Path;
+        }
+        if (!string.Equals(existingPath, targetPath, StringComparison.OrdinalIgnoreCase))
+        {
+            await _writer.CloseAsync(thread.Id, ct);
+            existingPath = PromoteToCanonicalPath(thread.Id, thread.Status == ThreadStatus.Archived, existingPath);
+        }
+
+        var records = new List<ThreadRolloutRecord>
+        {
+            new()
+            {
+                Kind = "turn_state_replaced",
+                Timestamp = thread.LastActiveAt,
+                TurnStateReplaced = new TurnStateReplacedPayload
+                {
+                    ThreadId = thread.Id,
+                    Turn = turn,
+                    ThreadStatus = thread.Status,
+                    LastActiveAt = thread.LastActiveAt,
+                    DisplayName = thread.DisplayName
+                }
+            }
+        };
+
+        if (compaction != null)
+        {
+            records.Add(new ThreadRolloutRecord
+            {
+                Kind = "context_compacted",
+                Timestamp = compaction.CreatedAt,
+                ContextCompacted = new ContextCompactedPayload
+                {
+                    ThreadId = thread.Id,
+                    CoveredThroughTurnId = turn.Id,
+                    CheckpointId = $"compact_{compaction.CreatedAt:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}",
+                    Trigger = compaction.Trigger,
+                    Mode = compaction.Mode,
+                    TokensBefore = compaction.TokensBefore,
+                    TokensAfter = compaction.TokensAfter,
+                    CreatedAt = compaction.CreatedAt,
+                    ReplacementHistory = [.. compaction.ReplacementHistory]
+                }
+            });
+        }
+
+        if (modelHistory.Count > 0)
+        {
+            records.Add(new ThreadRolloutRecord
+            {
+                Kind = "model_history_messages_appended",
+                Timestamp = DateTimeOffset.UtcNow,
+                ModelHistoryMessagesAppended = new ModelHistoryMessagesAppendedPayload
+                {
+                    ThreadId = thread.Id,
+                    TurnId = turn.Id,
+                    Messages = [.. modelHistory]
+                }
+            });
+        }
+
+        var receipt = await AppendRecordsAsync(thread.Id, existingPath, records, ct);
+        return new RolloutAppendResult(existingPath, receipt);
+    }
+
+    public async Task<ModelHistoryReplayResult> ReplayModelHistoryAsync(
+        string threadId,
+        SessionThread thread,
+        string? excludedTurnId = null,
+        CancellationToken ct = default)
+    {
+        var path = ResolveExistingPath(threadId);
+        if (path == null)
+            return new ModelHistoryReplayResult([], HasModelHistoryRecords: false);
+
+        return await new RolloutReplayer().ReplayModelHistoryAsync(
+            path,
+            thread.Turns,
+            excludedTurnId,
+            ct);
+    }
+
+    public async Task DeleteThreadAsync(string threadId, CancellationToken ct = default)
+    {
+        await _writer.CloseAsync(threadId, ct);
+        if (_beforeDeleteAsync != null)
+            await _beforeDeleteAsync(threadId, ct);
         foreach (var path in EnumerateCandidatePaths(threadId).Distinct(StringComparer.OrdinalIgnoreCase))
         {
             if (File.Exists(path))
                 File.Delete(path);
         }
     }
+
+    public Task CloseThreadAsync(string threadId, CancellationToken ct = default) =>
+        _writer.CloseAsync(threadId, ct);
 
     public string PromoteToCanonicalPath(string threadId, bool archived, string existingPath)
     {
@@ -486,35 +667,16 @@ internal sealed class ThreadRolloutStore
         return records;
     }
 
-    private static async Task AppendJsonLinesAsync(string path, string payload, CancellationToken ct)
-    {
-        var bytes = Encoding.UTF8.GetBytes(payload);
-        for (var attempt = 0; ; attempt++)
-        {
-            try
-            {
-                await using var stream = new FileStream(
-                    path,
-                    FileMode.Append,
-                    FileAccess.Write,
-                    FileShare.Read,
-                    bufferSize: 4096,
-                    FileOptions.Asynchronous);
-                await stream.WriteAsync(bytes, ct);
-                await stream.FlushAsync(ct);
-                return;
-            }
-            catch (IOException ex) when (IsSharingViolation(ex) && attempt < AppendRetryCount)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(20 << attempt), ct);
-            }
-        }
-    }
+    public Task ShutdownAsync(CancellationToken ct = default) => _writer.ShutdownAllAsync(ct);
 
-    private static bool IsSharingViolation(IOException ex)
+    private async Task<RolloutWriteReceipt> AppendRecordsAsync(
+        string threadId,
+        string path,
+        IReadOnlyList<ThreadRolloutRecord> records,
+        CancellationToken ct)
     {
-        var errorCode = ex.HResult & 0xFFFF;
-        return errorCode is 32 or 33;
+        await _writer.AddBatchAsync(threadId, path, records, ct);
+        return await _writer.FlushAsync(threadId, ct);
     }
 
     private static bool ThreadBaselineChanged(SessionThread previous, SessionThread current)
@@ -536,6 +698,8 @@ internal sealed class ThreadRolloutStore
         if (previous.Ephemeral != current.Ephemeral)
             return true;
         if (!JsonEquals(previous.Worktree, current.Worktree))
+            return true;
+        if (!JsonEquals(previous.Source, current.Source))
             return true;
         if (!JsonEquals(previous.Configuration, current.Configuration))
             return true;
@@ -565,6 +729,7 @@ internal sealed class ThreadRolloutStore
                 UserId = thread.UserId,
                 OriginChannel = thread.OriginChannel,
                 ChannelContext = thread.ChannelContext,
+                Source = PersistedThreadSourceCodec.Encode(thread.Source),
                 ForkedFromId = thread.ForkedFromId,
                 Ephemeral = thread.Ephemeral,
                 Worktree = thread.Worktree,
@@ -661,6 +826,7 @@ internal sealed class ThreadRolloutStore
         private readonly Dictionary<string, SessionTurn> _turns = new(StringComparer.Ordinal);
         private SessionThread? _thread;
         private int _turnSequenceHighWatermark;
+        private bool _hasCanonicalHeader;
 
         public void Apply(string line)
         {
@@ -672,13 +838,30 @@ internal sealed class ThreadRolloutStore
             {
                 record = JsonSerializer.Deserialize<ThreadRolloutRecord>(line, JsonOptions);
             }
-            catch
+            catch (JsonException ex)
             {
+                if (!_hasCanonicalHeader)
+                    throw new InvalidDataException("The canonical thread header is unreadable.", ex);
+                System.Diagnostics.Trace.TraceWarning("Skipped a malformed rollout record after the canonical thread header.");
                 return;
             }
 
             if (record == null)
+            {
+                if (!_hasCanonicalHeader)
+                    throw new InvalidDataException("The canonical thread header is empty.");
+                System.Diagnostics.Trace.TraceWarning("Skipped an empty rollout record after the canonical thread header.");
                 return;
+            }
+
+            if (record.Kind == "thread_opened" && record.ThreadOpened == null)
+                throw new InvalidDataException("A canonical thread baseline record is incomplete.");
+
+            if (!_hasCanonicalHeader
+                && (record.Kind != "thread_opened" || record.ThreadOpened == null))
+            {
+                throw new InvalidDataException("The rollout does not begin with a canonical thread header.");
+            }
 
             switch (record.Kind)
             {
@@ -689,6 +872,11 @@ internal sealed class ThreadRolloutStore
                     _thread.UserId = record.ThreadOpened.UserId;
                     _thread.OriginChannel = record.ThreadOpened.OriginChannel;
                     _thread.ChannelContext = record.ThreadOpened.ChannelContext;
+                    _thread.Source = record.ThreadOpened.Source == null
+                        ? PersistedThreadSourceCodec.InferLegacy(
+                            record.ThreadOpened.OriginChannel,
+                            record.ThreadOpened.Metadata)
+                        : PersistedThreadSourceCodec.Decode(record.ThreadOpened.Source);
                     _thread.ForkedFromId = record.ThreadOpened.ForkedFromId;
                     _thread.Ephemeral = record.ThreadOpened.Ephemeral;
                     _thread.Worktree = record.ThreadOpened.Worktree;
@@ -697,6 +885,7 @@ internal sealed class ThreadRolloutStore
                     _thread.Metadata = new Dictionary<string, string>(record.ThreadOpened.Metadata);
                     _thread.HistoryMode = record.ThreadOpened.HistoryMode;
                     _thread.Configuration = record.ThreadOpened.Configuration;
+                    _hasCanonicalHeader = true;
                     break;
 
                 case "thread_name_updated" when _thread != null && record.ThreadNameUpdated != null:
@@ -706,6 +895,20 @@ internal sealed class ThreadRolloutStore
                 case "thread_status_changed" when _thread != null && record.ThreadStatusChanged != null:
                     _thread.Status = record.ThreadStatusChanged.Status;
                     _thread.LastActiveAt = record.ThreadStatusChanged.LastActiveAt;
+                    break;
+
+                case "turn_state_replaced" when _thread != null && record.TurnStateReplaced != null:
+                    var replacement = record.TurnStateReplaced;
+                    var replacementTurn = replacement.Turn;
+                    _turnSequenceHighWatermark = Math.Max(
+                        _turnSequenceHighWatermark,
+                        SessionIdGenerator.LastTurnSequence([replacementTurn.Id]));
+                    replacementTurn.Input ??= replacementTurn.Items.FirstOrDefault(static item =>
+                        item.Type == ItemType.UserMessage);
+                    _turns[replacementTurn.Id] = replacementTurn;
+                    _thread.Status = replacement.ThreadStatus;
+                    _thread.LastActiveAt = replacement.LastActiveAt;
+                    _thread.DisplayName = replacement.DisplayName;
                     break;
 
                 case "turn_started" when _thread != null && record.TurnStarted != null:
@@ -821,6 +1024,16 @@ internal sealed class ThreadRolloutStore
     }
 }
 
+internal sealed record RolloutAppendResult(string Path, RolloutWriteReceipt Receipt);
+
+internal sealed record TurnCompactionCommit(
+    string Trigger,
+    string Mode,
+    long TokensBefore,
+    long TokensAfter,
+    DateTimeOffset CreatedAt,
+    IReadOnlyList<ModelHistoryMessage> ReplacementHistory);
+
 internal sealed class ThreadRolloutRecord
 {
     public string Kind { get; init; } = string.Empty;
@@ -843,6 +1056,10 @@ internal sealed class ThreadRolloutRecord
 
     public ContextCompactedPayload? ContextCompacted { get; init; }
 
+    public ModelHistoryMessagesAppendedPayload? ModelHistoryMessagesAppended { get; init; }
+
+    public TurnStateReplacedPayload? TurnStateReplaced { get; init; }
+
     public QueuedInputAddedPayload? QueuedInputAdded { get; init; }
 
     public QueuedInputRemovedPayload? QueuedInputRemoved { get; init; }
@@ -863,6 +1080,8 @@ internal sealed class ThreadOpenedPayload
     public string OriginChannel { get; init; } = string.Empty;
 
     public string? ChannelContext { get; init; }
+
+    public PersistedThreadSource? Source { get; init; }
 
     public string? ForkedFromId { get; init; }
 
@@ -953,7 +1172,7 @@ internal sealed class ContextCompactedPayload
 
     public DateTimeOffset CreatedAt { get; init; }
 
-    public JsonElement ReplacementHistory { get; init; }
+    public List<ModelHistoryMessage> ReplacementHistory { get; init; } = [];
 }
 
 internal sealed record ThreadCompactionCheckpoint(
@@ -965,7 +1184,29 @@ internal sealed record ThreadCompactionCheckpoint(
     long TokensBefore,
     long TokensAfter,
     DateTimeOffset CreatedAt,
-    JsonElement ReplacementHistory);
+    IReadOnlyList<ModelHistoryMessage> ReplacementHistory);
+
+internal sealed class ModelHistoryMessagesAppendedPayload
+{
+    public string ThreadId { get; init; } = string.Empty;
+
+    public string TurnId { get; init; } = string.Empty;
+
+    public List<ModelHistoryMessage> Messages { get; init; } = [];
+}
+
+internal sealed class TurnStateReplacedPayload
+{
+    public string ThreadId { get; init; } = string.Empty;
+
+    public SessionTurn Turn { get; init; } = new();
+
+    public ThreadStatus ThreadStatus { get; init; }
+
+    public DateTimeOffset LastActiveAt { get; init; }
+
+    public string? DisplayName { get; init; }
+}
 
 internal sealed class QueuedInputAddedPayload
 {

--- a/src/DotCraft.Core/Protocol/ThreadSource.cs
+++ b/src/DotCraft.Core/Protocol/ThreadSource.cs
@@ -94,6 +94,130 @@ public sealed class SubAgentThreadSource
     public bool SupportsClose { get; set; } = true;
 }
 
+internal sealed class PersistedThreadSource
+{
+    public int SchemaVersion { get; init; } = PersistedThreadSourceCodec.CurrentSchemaVersion;
+
+    public string Kind { get; init; } = ThreadSourceKinds.User;
+
+    public string? SpawnedFromThreadId { get; init; }
+
+    public PersistedSubAgentThreadSource? SubAgent { get; init; }
+}
+
+internal sealed class PersistedSubAgentThreadSource
+{
+    public string ParentThreadId { get; init; } = string.Empty;
+    public string? ParentTurnId { get; init; }
+    public string? SpawnCallId { get; init; }
+    public string RootThreadId { get; init; } = string.Empty;
+    public int Depth { get; init; }
+    public string? AgentPath { get; init; }
+    public string? TaskName { get; init; }
+    public string? AgentNickname { get; init; }
+    public string? AgentRole { get; init; }
+    public string? ProfileName { get; init; }
+    public string? RuntimeType { get; init; }
+    public bool SupportsSendInput { get; init; }
+    public bool SupportsResume { get; init; }
+    public bool SupportsSendMessage { get; init; }
+    public bool SupportsFollowupTask { get; init; }
+    public bool SupportsClose { get; init; } = true;
+}
+
+internal static class PersistedThreadSourceCodec
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public static PersistedThreadSource Encode(ThreadSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return source.Kind switch
+        {
+            ThreadSourceKinds.User => new PersistedThreadSource
+            {
+                Kind = ThreadSourceKinds.User,
+                SpawnedFromThreadId = source.SpawnedFromThreadId
+            },
+            ThreadSourceKinds.SubAgent when source.SubAgent is { } subAgent => new PersistedThreadSource
+            {
+                Kind = ThreadSourceKinds.SubAgent,
+                SubAgent = new PersistedSubAgentThreadSource
+                {
+                    ParentThreadId = subAgent.ParentThreadId,
+                    ParentTurnId = subAgent.ParentTurnId,
+                    SpawnCallId = subAgent.SpawnCallId,
+                    RootThreadId = subAgent.RootThreadId,
+                    Depth = subAgent.Depth,
+                    AgentPath = subAgent.AgentPath,
+                    TaskName = subAgent.TaskName,
+                    AgentNickname = subAgent.AgentNickname,
+                    AgentRole = subAgent.AgentRole,
+                    ProfileName = subAgent.ProfileName,
+                    RuntimeType = subAgent.RuntimeType,
+                    SupportsSendInput = subAgent.SupportsSendInput,
+                    SupportsResume = subAgent.SupportsResume,
+                    SupportsSendMessage = subAgent.SupportsSendMessage,
+                    SupportsFollowupTask = subAgent.SupportsFollowupTask,
+                    SupportsClose = subAgent.SupportsClose
+                }
+            },
+            ThreadSourceKinds.SubAgent => throw new InvalidOperationException("A subagent thread source requires subagent details."),
+            _ => throw new NotSupportedException($"Unsupported thread source kind '{source.Kind}'.")
+        };
+    }
+
+    public static ThreadSource Decode(PersistedThreadSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (source.SchemaVersion != CurrentSchemaVersion)
+            throw new NotSupportedException($"Unsupported thread source schema version '{source.SchemaVersion}'.");
+
+        return source.Kind switch
+        {
+            ThreadSourceKinds.User when source.SubAgent == null => string.IsNullOrWhiteSpace(source.SpawnedFromThreadId)
+                ? ThreadSource.User()
+                : ThreadSource.SpawnedFromThread(source.SpawnedFromThreadId),
+            ThreadSourceKinds.SubAgent when source.SubAgent is { } subAgent => ThreadSource.ForSubAgent(
+                new SubAgentThreadSource
+                {
+                    ParentThreadId = subAgent.ParentThreadId,
+                    ParentTurnId = subAgent.ParentTurnId,
+                    SpawnCallId = subAgent.SpawnCallId,
+                    RootThreadId = subAgent.RootThreadId,
+                    Depth = subAgent.Depth,
+                    AgentPath = subAgent.AgentPath,
+                    TaskName = subAgent.TaskName,
+                    AgentNickname = subAgent.AgentNickname,
+                    AgentRole = subAgent.AgentRole,
+                    ProfileName = subAgent.ProfileName,
+                    RuntimeType = subAgent.RuntimeType,
+                    SupportsSendInput = subAgent.SupportsSendInput,
+                    SupportsResume = subAgent.SupportsResume,
+                    SupportsSendMessage = subAgent.SupportsSendMessage,
+                    SupportsFollowupTask = subAgent.SupportsFollowupTask,
+                    SupportsClose = subAgent.SupportsClose
+                }),
+            ThreadSourceKinds.User => throw new InvalidOperationException("A user thread source cannot contain subagent details."),
+            ThreadSourceKinds.SubAgent => throw new InvalidOperationException("A subagent thread source requires subagent details."),
+            _ => throw new NotSupportedException($"Unsupported thread source kind '{source.Kind}'.")
+        };
+    }
+
+    public static ThreadSource InferLegacy(
+        string originChannel,
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        if (string.Equals(originChannel, SubAgentThreadOrigin.ChannelName, StringComparison.OrdinalIgnoreCase))
+            return ThreadSource.ForSubAgent(new SubAgentThreadSource());
+
+        return metadata.TryGetValue("spawnedFromThreadId", out var parentThreadId)
+               && !string.IsNullOrWhiteSpace(parentThreadId)
+            ? ThreadSource.SpawnedFromThread(parentThreadId)
+            : ThreadSource.User();
+    }
+}
+
 public static class ThreadSpawnEdgeStatus
 {
     public const string Open = "open";

--- a/src/DotCraft.Core/Protocol/ThreadStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using DotCraft.Agents;
@@ -24,29 +23,48 @@ internal sealed record ForkModelHistoryMaterialization(
         !string.IsNullOrWhiteSpace(CheckpointCoveredThroughTurnId);
 }
 
+internal sealed record TurnPersistenceCommit(
+    SessionThread Thread,
+    SessionTurn Turn,
+    IReadOnlyList<ChatMessage> ModelHistory,
+    TurnCompactionHistory? Compaction);
+
+internal sealed record TurnCompactionHistory(
+    string Trigger,
+    string Mode,
+    long TokensBefore,
+    long TokensAfter,
+    IReadOnlyList<ChatMessage> ReplacementHistory);
+
 /// <summary>
 /// Manages thread persistence under the .craft directory.
-/// Canonical thread history is stored as thread JSONL under threads/active|archived while metadata and agent sessions live in SQLite.
+/// Canonical thread and model-visible history is stored as thread JSONL under threads/active|archived.
+/// SQLite contains classified durable state, continuity state, diagnostics, and rebuildable projections.
 /// </summary>
-public sealed class ThreadStore
+public sealed class ThreadStore : IAsyncDisposable
 {
     private readonly string _botPath;
     private readonly ThreadMetadataStore _metadataStore;
     private readonly ThreadRolloutStore _rolloutStore;
+    private readonly IRolloutReplayer _rolloutReplayer;
     private readonly ThreadAttachmentStore _attachmentStore;
-    private readonly ConcurrentDictionary<string, SessionThread> _threadSnapshotCache = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _reconcileGate = new(1, 1);
 
     public ThreadStore(string botPath)
         : this(botPath, null)
     {
     }
 
-    internal ThreadStore(string botPath, StateRuntime? stateRuntime)
+    internal ThreadStore(
+        string botPath,
+        StateRuntime? stateRuntime,
+        Func<string, CancellationToken, Task>? beforeRolloutDeleteAsync = null)
     {
         _botPath = Path.GetFullPath(botPath);
         StateRuntime = stateRuntime ?? new StateRuntime(botPath);
         _metadataStore = new ThreadMetadataStore(StateRuntime);
-        _rolloutStore = new ThreadRolloutStore(botPath);
+        _rolloutStore = new ThreadRolloutStore(botPath, beforeRolloutDeleteAsync);
+        _rolloutReplayer = new RolloutReplayer();
         _attachmentStore = new ThreadAttachmentStore(StateRuntime, botPath);
     }
 
@@ -58,17 +76,10 @@ public sealed class ThreadStore
     public async Task SaveThreadAsync(SessionThread thread, CancellationToken ct = default)
     {
         using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, thread.Id, ct);
-        if (!_threadSnapshotCache.TryGetValue(thread.Id, out var previous))
-        {
-            previous = await _rolloutStore.LoadThreadAsync(thread.Id, ct);
-            if (previous != null)
-                _threadSnapshotCache[thread.Id] = CloneThreadSnapshot(previous);
-        }
+        var previous = await _rolloutStore.LoadThreadAsync(thread.Id, ct);
 
-        var rolloutPath = await _rolloutStore.SaveThreadAsync(thread, previous, ct);
-        _threadSnapshotCache[thread.Id] = CloneThreadSnapshot(thread);
-        _metadataStore.UpsertThread(thread, rolloutPath);
-        _attachmentStore.ReplaceThreadAttachments(thread);
+        var result = await _rolloutStore.SaveThreadAsync(thread, previous, ct);
+        TryUpdateThreadProjection(thread, result);
     }
 
     /// <summary>
@@ -80,10 +91,44 @@ public sealed class ThreadStore
         CancellationToken ct = default)
     {
         using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, thread.Id, ct);
-        var rolloutPath = await _rolloutStore.AppendRollbackAsync(thread, numTurns, ct);
-        _threadSnapshotCache[thread.Id] = CloneThreadSnapshot(thread);
-        _metadataStore.UpsertThread(thread, rolloutPath);
-        _attachmentStore.ReplaceThreadAttachments(thread);
+        var result = await _rolloutStore.AppendRollbackAsync(thread, numTurns, ct);
+        TryUpdateThreadProjection(thread, result);
+    }
+
+    internal async Task SaveTurnAsync(
+        SessionThread thread,
+        SessionTurn turn,
+        CancellationToken ct = default)
+    {
+        using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, thread.Id, ct);
+        var result = await _rolloutStore.AppendTurnStateAsync(thread, turn, ct);
+        TryUpdateThreadProjection(thread, result);
+    }
+
+    internal async Task CommitTurnAsync(TurnPersistenceCommit commit, CancellationToken ct = default)
+    {
+        using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, commit.Thread.Id, ct);
+        var codec = new ModelHistoryCodec();
+        var modelHistory = commit.ModelHistory
+            .Select(message => codec.Encode(message, commit.Turn.Id))
+            .ToList();
+        var compaction = commit.Compaction == null
+            ? null
+            : new TurnCompactionCommit(
+                commit.Compaction.Trigger,
+                commit.Compaction.Mode,
+                commit.Compaction.TokensBefore,
+                commit.Compaction.TokensAfter,
+                DateTimeOffset.UtcNow,
+                commit.Compaction.ReplacementHistory.Select(message => codec.Encode(message)).ToList());
+
+        var result = await _rolloutStore.AppendTurnCommitAsync(
+            commit.Thread,
+            commit.Turn,
+            modelHistory,
+            compaction,
+            ct);
+        TryUpdateThreadProjection(commit.Thread, result);
     }
 
     internal async Task AppendCompactionCheckpointAsync(
@@ -98,20 +143,20 @@ public sealed class ThreadStore
     {
         ct.ThrowIfCancellationRequested();
         using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, threadId, ct);
-        var replacementElement = JsonSerializer.SerializeToElement(
-            replacementHistory,
-            SessionPersistenceJsonOptions.Default);
+        var codec = new ModelHistoryCodec();
+        var replacementMessages = replacementHistory.Select(message => codec.Encode(message)).ToList();
 
-        await _rolloutStore.AppendCompactionCheckpointAsync(
+        var result = await _rolloutStore.AppendCompactionCheckpointAsync(
             threadId,
             coveredThroughTurnId,
             trigger,
             mode,
             tokensBefore,
             tokensAfter,
-            replacementElement,
+            replacementMessages,
             DateTimeOffset.UtcNow,
             ct);
+        TryUpdateRolloutOffsetProjection(threadId, result);
     }
 
     internal Task<IReadOnlyList<ThreadCompactionCheckpoint>> LoadCompactionCheckpointsAsync(
@@ -125,13 +170,6 @@ public sealed class ThreadStore
     public async Task<SessionThread?> LoadThreadAsync(string threadId, CancellationToken ct = default)
     {
         var thread = await _rolloutStore.LoadThreadAsync(threadId, ct);
-        if (thread == null)
-        {
-            _threadSnapshotCache.TryRemove(threadId, out _);
-            return null;
-        }
-
-        _threadSnapshotCache[threadId] = CloneThreadSnapshot(thread);
         return thread;
     }
 
@@ -141,10 +179,6 @@ public sealed class ThreadStore
     public async Task<SessionThread?> LoadThreadFromPathAsync(string path, CancellationToken ct = default)
     {
         var thread = await _rolloutStore.LoadThreadFromPathAsync(path, ct);
-        if (thread == null)
-            return null;
-
-        _threadSnapshotCache[thread.Id] = CloneThreadSnapshot(thread);
         return thread;
     }
 
@@ -154,44 +188,59 @@ public sealed class ThreadStore
     public void DeleteThread(string threadId)
     {
         using var writeLock = ThreadRolloutWriteGate.Acquire(_botPath, threadId);
-        var candidatePaths = _threadSnapshotCache.TryGetValue(threadId, out var cached)
-            ? _attachmentStore.ExtractManagedImagePaths(cached)
-            : _rolloutStore.LoadThreadAsync(threadId).GetAwaiter().GetResult() is { } loaded
-                ? _attachmentStore.ExtractManagedImagePaths(loaded)
-                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        _threadSnapshotCache.TryRemove(threadId, out _);
-        _attachmentStore.DeleteThreadReferencesAndCleanup(threadId, candidatePaths);
-        _rolloutStore.DeleteThread(threadId);
+        _rolloutStore.CloseThreadAsync(threadId).GetAwaiter().GetResult();
+        var candidatePaths = _rolloutStore.LoadThreadAsync(threadId).GetAwaiter().GetResult() is { } loaded
+            ? _attachmentStore.ExtractManagedImagePaths(loaded)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var cleanupCandidates = _attachmentStore.LoadCandidatePaths(threadId, candidatePaths);
+        _rolloutStore.DeleteThreadAsync(threadId).GetAwaiter().GetResult();
         _metadataStore.DeleteThread(threadId);
+        _attachmentStore.CleanupCandidates(cleanupCandidates);
     }
 
-    /// <summary>
-    /// Deletes the persisted agent session for a thread from SQLite.
-    /// </summary>
-    public void DeleteSessionFile(string threadId) => _metadataStore.DeleteSession(threadId);
-
-    /// <summary>
-    /// Saves the agent session JSON into SQLite.
-    /// </summary>
-    public async Task SaveSessionAsync(
-        AIAgent agent,
+    internal async Task PersistModelHistoryAsync(
         AgentSession session,
         string threadId,
+        string turnId,
+        int persistedPrefixLength,
         CancellationToken ct = default)
     {
-        var serialized = await agent.SerializeSessionAsync(session, SessionPersistenceJsonOptions.Default, ct);
-        _metadataStore.SaveSessionJson(threadId, serialized.GetRawText());
+        if (!session.TryGetInMemoryChatHistory(
+                out var currentHistory,
+                jsonSerializerOptions: SessionPersistenceJsonOptions.Default))
+        {
+            return;
+        }
+
+        if (persistedPrefixLength < 0 || persistedPrefixLength > currentHistory.Count)
+        {
+            throw new InvalidOperationException($"Invalid model-history prefix length for thread '{threadId}'.");
+        }
+
+        using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, threadId, ct);
+        var codec = new ModelHistoryCodec();
+        var appended = currentHistory
+            .Skip(persistedPrefixLength)
+            .Select(message => codec.Encode(message, turnId))
+            .ToList();
+        var result = await _rolloutStore.AppendModelHistoryAsync(threadId, turnId, appended, ct);
+        TryUpdateRolloutOffsetProjection(threadId, result);
     }
 
-    internal async Task<AgentSession> SaveSessionFromHistoryAsync(
-        AIAgent agent,
+    internal async Task AppendModelHistoryAsync(
         string threadId,
         IReadOnlyList<ChatMessage> history,
+        string turnId,
         CancellationToken ct = default)
     {
-        var session = await CreateSessionWithHistoryAsync(agent, history.ToList(), ct);
-        await SaveSessionAsync(agent, session, threadId, ct);
-        return session;
+        using var writeLock = await ThreadRolloutWriteGate.AcquireAsync(_botPath, threadId, ct);
+        var codec = new ModelHistoryCodec();
+        var result = await _rolloutStore.AppendModelHistoryAsync(
+            threadId,
+            turnId,
+            history.Select(message => codec.Encode(message, turnId)).ToList(),
+            ct);
+        TryUpdateRolloutOffsetProjection(threadId, result);
     }
 
     internal async Task<ForkModelHistoryMaterialization> BuildForkModelHistoryMaterializationAsync(
@@ -239,54 +288,24 @@ public sealed class ThreadStore
     }
 
     /// <summary>
-    /// Rebuilds and saves the persisted agent session from canonical thread history.
-    /// </summary>
-    public async Task RebuildAndSaveSessionFromThreadAsync(
-        AIAgent agent,
-        string threadId,
-        CancellationToken ct = default)
-    {
-        var rebuilt = await RebuildSessionFromRolloutAsync(agent, threadId, ct);
-        await SaveSessionAsync(agent, rebuilt, threadId, ct);
-    }
-
-    /// <summary>
-    /// Loads an existing agent session from SQLite, or creates a new session when none exists.
+    /// Creates a runtime agent session and hydrates its model history from canonical rollout records.
     /// </summary>
     public async Task<AgentSession> LoadOrCreateSessionAsync(
         AIAgent agent,
         string threadId,
         CancellationToken ct = default)
     {
-        var sessionJson = _metadataStore.LoadSessionJson(threadId);
-        if (!string.IsNullOrWhiteSpace(sessionJson))
-        {
-            try
-            {
-                var element = JsonSerializer.Deserialize<JsonElement>(sessionJson, SessionPersistenceJsonOptions.Default);
-                var session = await agent.DeserializeSessionAsync(element, SessionPersistenceJsonOptions.Default, ct);
-                NormalizeSessionToolCallArguments(session);
-                return session;
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch
-            {
-                // Fall back to canonical rollout history when the SQLite session is
-                // missing, malformed, or cannot be deserialized by the current agent.
-            }
-        }
-
         return await RebuildSessionFromRolloutAsync(agent, threadId, ct);
     }
 
-    /// <summary>
-    /// Returns true when a thread has a persisted server-side session in SQLite.
-    /// </summary>
-    public bool SessionFileExists(string threadId)
-        => _metadataStore.SessionExists(threadId);
+    internal async Task<AgentSession> LoadOrCreateSessionAsync(
+        AIAgent agent,
+        SessionThread thread,
+        string? excludedTurnId = null,
+        CancellationToken ct = default)
+    {
+        return await RebuildSessionFromRolloutAsync(agent, thread, excludedTurnId, ct);
+    }
 
     /// <summary>
     /// Loads the persisted context-window usage token count for a thread.
@@ -428,17 +447,90 @@ public sealed class ThreadStore
     /// Returns all persisted thread summaries from SQLite metadata, ordered by activity.
     /// Rows whose canonical rollout file is missing are omitted because callers cannot read them.
     /// </summary>
-    public Task<List<ThreadSummary>> LoadIndexAsync(CancellationToken ct = default)
+    public async Task<List<ThreadSummary>> LoadIndexAsync(CancellationToken ct = default)
     {
-        ct.ThrowIfCancellationRequested();
-        var index = _metadataStore.LoadIndex()
-            .Where(summary =>
+        await _reconcileGate.WaitAsync(ct);
+        try
+        {
+            var paths = _rolloutStore.EnumerateRolloutPaths().ToList();
+            try
             {
-                ct.ThrowIfCancellationRequested();
-                return _rolloutStore.ResolveExistingPath(summary.Id) != null;
-            })
+                var projectionStates = _metadataStore.LoadProjectionStates();
+                var unreadableThreadIds = new HashSet<string>(StringComparer.Ordinal);
+
+                foreach (var path in paths)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var length = new FileInfo(path).Length;
+                    var threadId = Path.GetFileNameWithoutExtension(path);
+                    if (projectionStates.TryGetValue(threadId, out var state)
+                        && string.Equals(Path.GetFullPath(state.RolloutPath), path, StringComparison.OrdinalIgnoreCase)
+                        && state.ProjectedRolloutOffset == length)
+                    {
+                        continue;
+                    }
+
+                    SessionThread? thread;
+                    try
+                    {
+                        thread = await _rolloutStore.LoadThreadFromPathAsync(path, ct);
+                    }
+                    catch (Exception ex) when (ex is JsonException or IOException or NotSupportedException)
+                    {
+                        unreadableThreadIds.Add(threadId);
+                        System.Diagnostics.Trace.TraceWarning(
+                            $"Unable to repair rollout '{Path.GetFileName(path)}': {ex.Message}");
+                        continue;
+                    }
+                    if (thread == null)
+                        continue;
+                    UpdateThreadProjection(thread, path, length);
+                }
+
+                return _metadataStore.LoadIndex()
+                    .Where(summary => !unreadableThreadIds.Contains(summary.Id)
+                                      && _rolloutStore.ResolveExistingPath(summary.Id) != null)
+                    .ToList();
+            }
+            catch (Exception ex) when (ex is Microsoft.Data.Sqlite.SqliteException
+                                               or InvalidOperationException
+                                               or JsonException
+                                               or NotSupportedException)
+            {
+                System.Diagnostics.Trace.TraceWarning($"Thread metadata read-repair failed; using rollout files: {ex.Message}");
+                return await LoadFilesystemIndexAsync(paths, ct);
+            }
+        }
+        finally
+        {
+            _reconcileGate.Release();
+        }
+    }
+
+    private async Task<List<ThreadSummary>> LoadFilesystemIndexAsync(
+        IReadOnlyList<string> paths,
+        CancellationToken ct)
+    {
+        var summaries = new List<ThreadSummary>();
+        foreach (var path in paths)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var thread = await _rolloutStore.LoadThreadFromPathAsync(path, ct);
+                if (thread != null)
+                    summaries.Add(ThreadSummary.FromThread(thread));
+            }
+            catch (Exception ex) when (ex is JsonException or IOException or InvalidOperationException or NotSupportedException)
+            {
+                System.Diagnostics.Trace.TraceWarning($"Unable to read rollout '{Path.GetFileName(path)}': {ex.Message}");
+            }
+        }
+
+        return summaries
+            .OrderByDescending(static summary => summary.LastActiveAt)
+            .ThenByDescending(static summary => summary.Id, StringComparer.Ordinal)
             .ToList();
-        return Task.FromResult(index);
     }
 
     public Task UpsertThreadSpawnEdgeAsync(ThreadSpawnEdge edge, CancellationToken ct = default)
@@ -496,11 +588,60 @@ public sealed class ThreadStore
         return Task.CompletedTask;
     }
 
-    private static SessionThread CloneThreadSnapshot(SessionThread thread)
+    public async ValueTask DisposeAsync()
     {
-        var json = JsonSerializer.SerializeToUtf8Bytes(thread, SessionJsonOptions.Default);
-        return JsonSerializer.Deserialize<SessionThread>(json, SessionJsonOptions.Default)
-            ?? throw new InvalidOperationException($"Failed to clone thread snapshot for {thread.Id}.");
+        await FlushAndCloseAsync(CancellationToken.None);
+        _reconcileGate.Dispose();
+    }
+
+    internal Task FlushAndCloseAsync(CancellationToken ct = default) => _rolloutStore.ShutdownAsync(ct);
+
+    private void TryUpdateThreadProjection(SessionThread thread, RolloutAppendResult result)
+    {
+        try
+        {
+            UpdateThreadProjection(thread, result.Path, result.Receipt.ConfirmedOffset);
+        }
+        catch (Exception ex) when (ex is Microsoft.Data.Sqlite.SqliteException or InvalidOperationException)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                $"Thread projection update failed after rollout commit for '{thread.Id}': {ex.Message}");
+        }
+    }
+
+    private void UpdateThreadProjection(SessionThread thread, string rolloutPath, long projectedRolloutOffset)
+    {
+        var previousPaths = _attachmentStore.LoadCandidatePaths(thread.Id);
+        using var connection = StateRuntime.OpenConnection();
+        using var transaction = connection.BeginTransaction();
+
+        // Establish the parent row before attachment inserts. The confirmed offset is
+        // deliberately advanced only after every attachment reference has succeeded.
+        _metadataStore.UpsertThread(connection, transaction, thread, rolloutPath, projectedRolloutOffset: 0);
+        var currentPaths = _attachmentStore.ReplaceThreadAttachments(connection, transaction, thread);
+        ThreadMetadataStore.UpdateProjectedRolloutOffset(
+            connection,
+            transaction,
+            thread.Id,
+            rolloutPath,
+            projectedRolloutOffset);
+        transaction.Commit();
+
+        _attachmentStore.CleanupCandidates(
+            previousPaths.Except(currentPaths, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private void TryUpdateRolloutOffsetProjection(string threadId, RolloutAppendResult result)
+    {
+        try
+        {
+            _metadataStore.UpdateProjectedRolloutOffset(threadId, result.Path, result.Receipt.ConfirmedOffset);
+        }
+        catch (Exception ex) when (ex is Microsoft.Data.Sqlite.SqliteException or InvalidOperationException)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                $"Thread rollout offset projection failed after commit for '{threadId}': {ex.Message}");
+        }
     }
 
     private async Task<AgentSession> RebuildSessionFromRolloutAsync(
@@ -512,9 +653,36 @@ public sealed class ThreadStore
         if (thread == null)
             return await agent.CreateSessionAsync(ct);
 
-        var history =
-            await TryBuildModelVisibleHistoryFromLatestCheckpointAsync(thread, ct) ??
-            BuildModelVisibleHistoryFromTurns(thread.Turns);
+        return await RebuildSessionFromRolloutAsync(agent, thread, excludedTurnId: null, ct);
+    }
+
+    private async Task<AgentSession> RebuildSessionFromRolloutAsync(
+        AIAgent agent,
+        SessionThread thread,
+        string? excludedTurnId,
+        CancellationToken ct)
+    {
+        var rolloutPath = _rolloutStore.ResolveExistingPath(thread.Id);
+        var replayed = rolloutPath == null
+            ? new ModelHistoryReplayResult([], HasModelHistoryRecords: false)
+            : await _rolloutReplayer.ReplayModelHistoryAsync(
+                rolloutPath,
+                thread.Turns,
+                excludedTurnId,
+                ct);
+        foreach (var warning in replayed.Warnings ?? [])
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                string.IsNullOrWhiteSpace(warning.TurnId)
+                    ? $"Rollout model-history replay warning ({warning.Code}): {warning.Message}"
+                    : $"Rollout model-history replay warning for turn '{warning.TurnId}' ({warning.Code}): {warning.Message}");
+        }
+        var fallbackTurns = thread.Turns
+            .Where(turn => !string.Equals(turn.Id, excludedTurnId, StringComparison.Ordinal));
+        var history = replayed.HasModelHistoryRecords
+            ? replayed.Messages.ToList()
+            : BuildModelVisibleHistoryFromTurns(fallbackTurns);
+        history = MessageGrouper.NormalizeFunctionCallArguments(history).ToList();
 
         if (history.Count == 0)
             return await agent.CreateSessionAsync(ct);
@@ -559,11 +727,8 @@ public sealed class ThreadStore
         history = [];
         try
         {
-            var restored = checkpoint.ReplacementHistory.Deserialize<List<ChatMessage>>(
-                SessionPersistenceJsonOptions.Default);
-            if (restored is null)
-                return false;
-
+            var codec = new ModelHistoryCodec();
+            var restored = checkpoint.ReplacementHistory.Select(codec.Decode).ToList();
             history = MessageGrouper.NormalizeFunctionCallArguments(restored).ToList();
             return true;
         }

--- a/src/DotCraft.Core/Protocol/ThreadStore.cs
+++ b/src/DotCraft.Core/Protocol/ThreadStore.cs
@@ -669,7 +669,8 @@ public sealed class ThreadStore : IAsyncDisposable
                 rolloutPath,
                 thread.Turns,
                 excludedTurnId,
-                ct);
+                ct,
+                thread.Id);
         foreach (var warning in replayed.Warnings ?? [])
         {
             System.Diagnostics.Trace.TraceWarning(

--- a/src/DotCraft.Core/State/StateRuntime.cs
+++ b/src/DotCraft.Core/State/StateRuntime.cs
@@ -74,6 +74,7 @@ public sealed class StateRuntime
     /// </summary>
     public void CheckpointWalTruncate()
     {
+        EnsureWritable();
         using var connection = OpenConnection();
         CheckpointWalTruncate(connection);
     }
@@ -87,6 +88,7 @@ public sealed class StateRuntime
         double minFreelistRatio = DefaultCompactFreelistRatio,
         int minFreelistPages = DefaultCompactMinFreelistPages)
     {
+        EnsureWritable();
         using var connection = OpenConnection();
         var pageCount = ReadPragmaLong(connection, "page_count");
         var freelistCount = ReadPragmaLong(connection, "freelist_count");
@@ -121,6 +123,7 @@ public sealed class StateRuntime
 
     public void SetInfo(string key, string value)
     {
+        EnsureWritable();
         using var connection = OpenConnection();
         using var command = connection.CreateCommand();
         command.CommandText = """
@@ -131,6 +134,12 @@ public sealed class StateRuntime
         command.Parameters.AddWithValue("$key", key);
         command.Parameters.AddWithValue("$value", value);
         command.ExecuteNonQuery();
+    }
+
+    private void EnsureWritable()
+    {
+        if (_readOnly)
+            throw new InvalidOperationException("This state runtime is read-only.");
     }
 
     private void EnsureInitialized()

--- a/src/DotCraft.Core/State/StateRuntime.cs
+++ b/src/DotCraft.Core/State/StateRuntime.cs
@@ -170,6 +170,7 @@ public sealed class StateRuntime
                     forked_from_id TEXT,
                     ephemeral INTEGER NOT NULL DEFAULT 0,
                     worktree_json TEXT,
+                    source_json TEXT,
                     display_name TEXT,
                     status TEXT NOT NULL,
                     created_at TEXT NOT NULL,
@@ -178,20 +179,14 @@ public sealed class StateRuntime
                     history_mode TEXT NOT NULL,
                     turn_count INTEGER NOT NULL DEFAULT 0,
                     first_user_message TEXT,
-                    metadata_json TEXT
+                    metadata_json TEXT,
+                    projected_rollout_offset INTEGER NOT NULL DEFAULT 0
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_threads_updated_at ON threads(updated_at DESC, thread_id DESC);
                 CREATE INDEX IF NOT EXISTS idx_threads_workspace_identity
                     ON threads(workspace_path, user_id, channel_context, origin_channel);
                 CREATE INDEX IF NOT EXISTS idx_threads_status ON threads(status);
-
-                CREATE TABLE IF NOT EXISTS thread_sessions (
-                    thread_id TEXT PRIMARY KEY,
-                    session_json TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    FOREIGN KEY(thread_id) REFERENCES threads(thread_id) ON DELETE CASCADE
-                );
 
                 CREATE TABLE IF NOT EXISTS thread_context_usage (
                     thread_id TEXT PRIMARY KEY,
@@ -450,6 +445,8 @@ public sealed class StateRuntime
             EnsureColumn(connection, "threads", "forked_from_id", "TEXT");
             EnsureColumn(connection, "threads", "ephemeral", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "threads", "worktree_json", "TEXT");
+            EnsureColumn(connection, "threads", "source_json", "TEXT");
+            EnsureColumn(connection, "threads", "projected_rollout_offset", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "thread_spawn_edges", "supports_send_input", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "thread_spawn_edges", "supports_resume", "INTEGER NOT NULL DEFAULT 0");
             EnsureColumn(connection, "thread_spawn_edges", "supports_send_message", "INTEGER NOT NULL DEFAULT 0");

--- a/src/DotCraft.Core/Tools/Architecture/ToolDispatchPipeline.cs
+++ b/src/DotCraft.Core/Tools/Architecture/ToolDispatchPipeline.cs
@@ -191,7 +191,8 @@ internal sealed class DefaultToolResultNormalizer(
                     limit,
                     workspacePath,
                     context.ThreadId,
-                    spillPreviewLines)!;
+                    spillPreviewLines,
+                    context.CallId)!;
             result = new ToolExecutionResult(
                 result.Success,
                 normalizedContent,

--- a/src/DotCraft.Core/Tools/BackgroundTerminals/BackgroundTerminalService.cs
+++ b/src/DotCraft.Core/Tools/BackgroundTerminals/BackgroundTerminalService.cs
@@ -2,9 +2,9 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using DotCraft.Configuration;
+using DotCraft.Tools;
 using Microsoft.Extensions.Logging;
 
 namespace DotCraft.Tools.BackgroundTerminals;
@@ -121,7 +121,22 @@ public interface IBackgroundTerminalService
 
     Task<BackgroundTerminalSnapshot> StopAsync(string sessionId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Stops active terminals for a thread without deleting persisted artifacts.
+    /// </summary>
     Task<IReadOnlyList<BackgroundTerminalSnapshot>> CleanThreadAsync(string threadId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Permanently removes all terminal artifacts for a thread after stopping active terminals.
+    /// This operation is idempotent and best effort.
+    /// </summary>
+    Task<IReadOnlyList<string>> DeleteThreadArtifactsAsync(string threadId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes completed terminal artifacts older than the configured retention period.
+    /// Running terminals are never removed.
+    /// </summary>
+    Task<int> CleanupExpiredArtifactsAsync(CancellationToken ct = default);
 }
 
 /// <summary>
@@ -140,8 +155,10 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
     private readonly string _terminalRoot;
     private readonly AppConfig.ShellBackgroundConfig _config;
     private readonly ILogger<BackgroundTerminalService>? _logger;
+    private readonly Timer _retentionTimer;
     private readonly ConcurrentDictionary<string, ActiveTerminal> _active = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, BackgroundTerminalMetadata> _metadata = new(StringComparer.Ordinal);
+    private int _cleanupRunning;
 
     public BackgroundTerminalService(
         string craftPath,
@@ -153,6 +170,12 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
         _logger = logger;
         Directory.CreateDirectory(_terminalRoot);
         LoadMetadataAndMarkLost();
+        CleanupExpiredArtifactsOnStartup();
+        _retentionTimer = new Timer(
+            static state => ((BackgroundTerminalService)state!).RunRetentionCleanup(),
+            this,
+            TimeSpan.FromHours(24),
+            TimeSpan.FromHours(24));
     }
 
     public event Action<BackgroundTerminalEvent>? TerminalEvent;
@@ -169,8 +192,7 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
         EnforceSessionLimits(request.ThreadId);
 
         var sessionId = "term_" + Guid.NewGuid().ToString("N")[..12];
-        var threadId = SanitizePathSegment(request.ThreadId);
-        var sessionDir = Path.Combine(_terminalRoot, threadId);
+        var sessionDir = GetThreadDirectory(request.ThreadId);
         Directory.CreateDirectory(sessionDir);
         var outputPath = Path.Combine(sessionDir, sessionId + OutputExtension);
         var metadataPath = Path.Combine(sessionDir, sessionId + MetadataExtension);
@@ -178,6 +200,13 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
         var psi = CreateStartInfo(request);
         var process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start process.");
+
+        // Materialize the output artifact even when the command produces no bytes. This keeps
+        // terminal ownership and archive/delete lifecycle observable for empty-output commands.
+        Directory.CreateDirectory(sessionDir);
+        using (File.Create(outputPath))
+        {
+        }
 
         var terminal = new ActiveTerminal(
             sessionId,
@@ -318,8 +347,49 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
         return snapshots;
     }
 
+    public async Task<IReadOnlyList<string>> DeleteThreadArtifactsAsync(
+        string threadId,
+        CancellationToken ct = default)
+    {
+        await CleanThreadAsync(threadId, ct).ConfigureAwait(false);
+
+        var failures = new List<string>();
+        var threadDirectory = GetThreadDirectory(threadId);
+        try
+        {
+            if (Directory.Exists(threadDirectory))
+                Directory.Delete(threadDirectory, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            failures.Add(threadDirectory);
+            _logger?.LogWarning(ex, "Failed to delete background terminal artifacts for thread {ThreadId}.", threadId);
+        }
+
+        foreach (var metadata in _metadata.Values.Where(m => string.Equals(m.ThreadId, threadId, StringComparison.Ordinal)).ToArray())
+            _metadata.TryRemove(metadata.SessionId, out _);
+
+        return failures;
+    }
+
+    public Task<int> CleanupExpiredArtifactsAsync(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _cleanupRunning, 1) != 0)
+            return Task.FromResult(0);
+
+        try
+        {
+            return Task.FromResult(CleanupExpiredArtifactsCore(ct));
+        }
+        finally
+        {
+            Volatile.Write(ref _cleanupRunning, 0);
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
+        _retentionTimer.Dispose();
         foreach (var active in _active.Values.ToArray())
         {
             try
@@ -478,6 +548,98 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
         return metadata.ToSnapshot(limited, original, truncated);
     }
 
+    private void CleanupExpiredArtifactsOnStartup()
+    {
+        RunRetentionCleanup("startup");
+    }
+
+    private void RunRetentionCleanup(string reason = "scheduled")
+    {
+        if (Interlocked.Exchange(ref _cleanupRunning, 1) != 0)
+            return;
+
+        try
+        {
+            CleanupExpiredArtifactsCore(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to clean expired background terminal artifacts during {Reason} maintenance.", reason);
+        }
+        finally
+        {
+            Volatile.Write(ref _cleanupRunning, 0);
+        }
+    }
+
+    private int CleanupExpiredArtifactsCore(CancellationToken ct)
+    {
+        var retentionDays = Math.Max(0, _config.OutputRetentionDays);
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-retentionDays);
+        var removed = 0;
+
+        foreach (var metadata in _metadata.Values.ToArray())
+        {
+            ct.ThrowIfCancellationRequested();
+            if (_active.ContainsKey(metadata.SessionId)
+                || string.Equals(metadata.Status, BackgroundTerminalStatus.Running, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var completedAt = metadata.CompletedAt ?? metadata.StartedAt;
+            if (completedAt > cutoff)
+                continue;
+
+            var directory = GetThreadDirectory(metadata.ThreadId);
+            var deletedAny = false;
+            var metadataPath = Path.Combine(directory, metadata.SessionId + MetadataExtension);
+            var outputPath = Path.Combine(directory, metadata.SessionId + OutputExtension);
+            deletedAny |= TryDeleteArtifact(metadataPath, metadata.SessionId);
+            deletedAny |= TryDeleteArtifact(outputPath, metadata.SessionId);
+            var artifactsRemain = File.Exists(metadataPath) || File.Exists(outputPath);
+            if (deletedAny && !artifactsRemain)
+                removed++;
+
+            if (!artifactsRemain)
+            {
+                _metadata.TryRemove(metadata.SessionId, out _);
+                TryDeleteEmptyDirectory(directory);
+            }
+        }
+
+        return removed;
+    }
+
+    private bool TryDeleteArtifact(string path, string sessionId)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return false;
+            File.Delete(path);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogWarning(ex, "Failed to delete background terminal artifact {Path} for session {SessionId}.", path, sessionId);
+            return false;
+        }
+    }
+
+    private void TryDeleteEmptyDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any())
+                Directory.Delete(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogWarning(ex, "Failed to remove empty background terminal directory {Path}.", path);
+        }
+    }
+
     private void LoadMetadataAndMarkLost()
     {
         if (!Directory.Exists(_terminalRoot))
@@ -569,11 +731,23 @@ public sealed class BackgroundTerminalService : IBackgroundTerminalService, IAsy
         return ($"... (truncated, {output.Length - maxOutputChars} earlier chars){Environment.NewLine}{truncated}", output.Length, true);
     }
 
-    private static string SanitizePathSegment(string value)
+    internal string GetThreadDirectory(string threadId)
     {
-        var normalized = string.IsNullOrWhiteSpace(value) ? "workspace" : value.Trim();
-        return Regex.Replace(normalized, @"[^A-Za-z0-9_.-]", "_");
+        var segment = string.IsNullOrWhiteSpace(threadId)
+            ? "workspace"
+            : ThreadArtifactPathResolver.GetCanonicalThreadSegment(threadId);
+        var path = Path.GetFullPath(Path.Combine(_terminalRoot, segment));
+        var root = Path.GetFullPath(_terminalRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                   + Path.DirectorySeparatorChar;
+        if (!path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Background terminal path escaped its artifact root.");
+        return path;
     }
+
+    internal static string GetCanonicalThreadDirectoryName(string value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? "workspace"
+            : ThreadArtifactPathResolver.GetCanonicalThreadSegment(value);
 
     private sealed class ActiveTerminal
     {

--- a/src/DotCraft.Core/Tools/ThreadArtifactPathResolver.cs
+++ b/src/DotCraft.Core/Tools/ThreadArtifactPathResolver.cs
@@ -1,0 +1,116 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DotCraft.Tools;
+
+/// <summary>
+/// Resolves current-protocol thread artifact paths. Artifact directories are owned by the
+/// canonical thread identity; no legacy sanitized-path lookup is supported.
+/// </summary>
+public static class ThreadArtifactPathResolver
+{
+    public const string CraftDirectoryName = ".craft";
+    public const string ToolResultsDirectoryName = "tool-results";
+
+    public static string GetToolResultsRoot(string workspacePath)
+        => CombineUnderWorkspace(workspacePath, CraftDirectoryName, ToolResultsDirectoryName);
+
+    public static string GetToolResultsThreadDirectory(string workspacePath, string? threadId)
+        => CombineUnderWorkspace(
+            workspacePath,
+            CraftDirectoryName,
+            ToolResultsDirectoryName,
+            GetCanonicalThreadSegment(threadId));
+
+    public static string GetToolResultPath(string workspacePath, string? threadId, string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName) || fileName is "." or "..")
+            throw new ArgumentException("A valid artifact file name is required.", nameof(fileName));
+        if (Path.GetFileName(fileName) != fileName)
+            throw new ArgumentException("Artifact file names must not contain directory separators.", nameof(fileName));
+
+        return CombineUnderWorkspace(
+            workspacePath,
+            CraftDirectoryName,
+            ToolResultsDirectoryName,
+            GetCanonicalThreadSegment(threadId),
+            fileName);
+    }
+
+    public static string GetToolResultRelativePath(string? threadId, string fileName)
+    {
+        if (Path.GetFileName(fileName) != fileName)
+            throw new ArgumentException("Artifact file names must not contain directory separators.", nameof(fileName));
+        return Path.Combine(
+            CraftDirectoryName,
+            ToolResultsDirectoryName,
+            GetCanonicalThreadSegment(threadId),
+            fileName).Replace('\\', '/');
+    }
+
+    /// <summary>Returns a collision-resistant directory segment for the current thread identity.</summary>
+    public static string GetCanonicalThreadSegment(string? threadId)
+    {
+        if (string.IsNullOrWhiteSpace(threadId))
+            return "_unsession";
+
+        var value = threadId.Trim();
+        if (value is "." or ".."
+            || value.Length > 80
+            || value.EndsWith(' ') || value.EndsWith('.')
+            || Regex.IsMatch(value, @"[^A-Za-z0-9_.-]"))
+        {
+            return "thread-" + Sha256(value);
+        }
+
+        return value;
+    }
+
+    /// <summary>Deletes one current-protocol thread artifact directory, idempotently.</summary>
+    public static ArtifactCleanupResult DeleteToolResultsThreadDirectory(string workspacePath, string? threadId)
+    {
+        var directory = GetToolResultsThreadDirectory(workspacePath, threadId);
+        try
+        {
+            if (!Directory.Exists(directory))
+                return ArtifactCleanupResult.Empty;
+
+            Directory.Delete(directory, recursive: true);
+            return new ArtifactCleanupResult(1, 0, Array.Empty<string>());
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return ArtifactCleanupResult.Empty;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return new ArtifactCleanupResult(0, 1, new[] { ex.Message });
+        }
+    }
+
+    private static string CombineUnderWorkspace(string workspacePath, params string[] segments)
+    {
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            throw new ArgumentException("A workspace path is required.", nameof(workspacePath));
+
+        var workspace = Path.GetFullPath(workspacePath);
+        var path = Path.GetFullPath(Path.Combine(new[] { workspace }.Concat(segments).ToArray()));
+        var root = workspace.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                   + Path.DirectorySeparatorChar;
+        if (!path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException("Artifact path escaped the workspace root.");
+        return path;
+    }
+
+    private static string Sha256(string value)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}
+
+public readonly record struct ArtifactCleanupResult(int DirectoriesDeleted, int Errors, IReadOnlyList<string> ErrorMessages)
+{
+    public static ArtifactCleanupResult Empty { get; } = new(0, 0, Array.Empty<string>());
+}

--- a/src/DotCraft.Core/Tools/ToolResultProcessor.cs
+++ b/src/DotCraft.Core/Tools/ToolResultProcessor.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 using DotCraft.Agents;
 
@@ -54,7 +55,8 @@ public static class ToolResultProcessor
         int maxResultChars,
         string workspacePath,
         string? sessionId,
-        int previewLines)
+        int previewLines,
+        string? callId = null)
     {
         var text = ToStringForLimit(rawResult);
         if (IsEffectivelyEmpty(text))
@@ -66,7 +68,7 @@ public static class ToolResultProcessor
         if (text.Length <= maxResultChars)
             return rawResult;
 
-        var relativePath = SpillToDisk(text, workspacePath, sessionId, toolName);
+        var relativePath = SpillToDisk(text, workspacePath, sessionId, toolName, callId);
         return BuildPreview(text, previewLines, relativePath, maxResultChars);
     }
 
@@ -77,15 +79,38 @@ public static class ToolResultProcessor
         string text,
         string workspacePath,
         string? sessionId,
-        string toolName)
+        string toolName,
+        string? callId = null)
     {
-        var spillDir = GetSpillDirectory(workspacePath, sessionId);
+        var spillDir = ThreadArtifactPathResolver.GetToolResultsThreadDirectory(workspacePath, sessionId);
         Directory.CreateDirectory(spillDir);
-        var fileName = $"{toolName}_{Guid.NewGuid():N}.txt";
-        var absolutePath = Path.Combine(spillDir, fileName);
-        File.WriteAllText(absolutePath, text, Encoding.UTF8);
-        return GetSpillRelativePath(sessionId, fileName);
+        var fileName = $"{SafeFileSegment(toolName)}_{GetStableCallSegment(callId, text)}.txt";
+        var absolutePath = ThreadArtifactPathResolver.GetToolResultPath(workspacePath, sessionId, fileName);
+
+        try
+        {
+            using var stream = new FileStream(
+                absolutePath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.Read,
+                bufferSize: 64 * 1024,
+                options: FileOptions.SequentialScan);
+            using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            writer.Write(text);
+        }
+        catch (IOException) when (File.Exists(absolutePath))
+        {
+            // A retry or concurrent invocation for the same call-id has already persisted this result.
+            // Never overwrite it: the deterministic path is the idempotency key.
+        }
+
+        return ThreadArtifactPathResolver.GetToolResultRelativePath(sessionId, fileName);
     }
+
+    /// <summary>Deletes the current-protocol tool-result directory for a thread.</summary>
+    public static ArtifactCleanupResult CleanupThreadArtifacts(string workspacePath, string? sessionId)
+        => ThreadArtifactPathResolver.DeleteToolResultsThreadDirectory(workspacePath, sessionId);
 
     /// <summary>
     /// Builds a head + tail preview with a reference to the spill file path.
@@ -171,23 +196,25 @@ public static class ToolResultProcessor
         tailText = tailText[^tailLen..];
     }
 
-    private static string GetSpillDirectory(string workspacePath, string? sessionId)
+    private static string SafeFileSegment(string value)
     {
-        var safeSession = SanitizeSessionSegment(sessionId);
-        return Path.Combine(workspacePath, ".craft", "tool-results", safeSession);
+        if (string.IsNullOrWhiteSpace(value))
+            return "tool";
+
+        var trimmed = value.Trim();
+        if (trimmed is not "." and not ".." && trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
+            return trimmed;
+
+        return "tool-" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(trimmed))).ToLowerInvariant();
     }
 
-    private static string GetSpillRelativePath(string? sessionId, string fileName)
+    private static string GetStableCallSegment(string? callId, string text)
     {
-        var safeSession = SanitizeSessionSegment(sessionId);
-        return Path.Combine(".craft", "tool-results", safeSession, fileName).Replace('\\', '/');
-    }
+        var value = string.IsNullOrWhiteSpace(callId) ? null : callId.Trim();
+        if (value is not null && value is not "." and not ".." && value.IndexOfAny(Path.GetInvalidFileNameChars()) < 0)
+            return value;
 
-    private static string SanitizeSessionSegment(string? sessionId)
-    {
-        var s = string.IsNullOrWhiteSpace(sessionId) ? "_unsession" : sessionId!;
-        foreach (var c in Path.GetInvalidFileNameChars())
-            s = s.Replace(c, '_');
-        return s;
+        var hashInput = value is null ? text : value;
+        return "call-" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(hashInput))).ToLowerInvariant();
     }
 }

--- a/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
+++ b/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
@@ -109,6 +109,51 @@ public sealed class ContextExportServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ExportAsync_UsesCanonicalExactHistoryAndRedactsInternalModelMetadata()
+    {
+        const string exactText = "exact model-visible answer";
+        const string reasoningSecret = "internal reasoning secret";
+        const string protectedSecret = "protected replay secret";
+        const string extensionSecret = "provider extension secret";
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "visible request", "projected answer");
+        await _threadStore.SaveThreadAsync(thread);
+
+        var exactMessage = new ChatMessage(ChatRole.Assistant,
+        [
+            new TextReasoningContent(reasoningSecret)
+            {
+                ProtectedData = protectedSecret,
+                AdditionalProperties = new AdditionalPropertiesDictionary
+                {
+                    ["providerSecret"] = extensionSecret
+                }
+            },
+            new TextContent(exactText)
+        ])
+        {
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["messageSecret"] = extensionSecret
+            }
+        };
+        await _threadStore.AppendModelHistoryAsync(thread.Id, [exactMessage], thread.Turns[0].Id);
+
+        var result = await new ContextExportService().ExportAsync(new ContextExportOptions
+        {
+            ThreadId = thread.Id,
+            WorkspacePath = _workspace
+        });
+
+        Assert.Contains(exactText, result.Markdown);
+        Assert.DoesNotContain("projected answer", result.Markdown.Split("## Conversation")[0]);
+        Assert.DoesNotContain(reasoningSecret, result.Markdown);
+        Assert.DoesNotContain(protectedSecret, result.Markdown);
+        Assert.DoesNotContain(extensionSecret, result.Markdown);
+        Assert.Contains("[reasoning omitted]", result.Markdown);
+    }
+
+    [Fact]
     public async Task SearchAsync_TraceEventMatch_ReturnsBoundThreadEvidence()
     {
         var thread = CreateThread();
@@ -135,6 +180,94 @@ public sealed class ContextExportServiceTests : IDisposable
         var hit = Assert.Single(result.Hits);
         Assert.Equal(thread.Id, hit.ThreadId);
         Assert.Contains(hit.Evidence, evidence => evidence.Source == "trace_events");
+    }
+
+    [Fact]
+    public async Task SearchAsync_RolloutSearch_UsesDeduplicatedDisplayableItemsAndSkipsInternalHistory()
+    {
+        const string visibleText = "VISIBLE_ROLLOUT_MARKER";
+        const string nativePartSecret = "NATIVE_PART_SECRET";
+        const string argumentSecret = "RAW_ARGUMENT_SECRET";
+        const string modelHistorySecret = "MODEL_HISTORY_ONLY_SECRET";
+        const string protectedDataSecret = "PROTECTED_DATA_SECRET";
+        const string checkpointSecret = "COMPACTION_ONLY_SECRET";
+
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, visibleText, "ordinary answer");
+        var turn = thread.Turns[0];
+        var userPayload = Assert.IsType<UserMessagePayload>(turn.Input!.Payload);
+        turn.Input.Payload = userPayload with
+        {
+            NativeInputParts =
+            [
+                new SessionWireInputPart { Type = "text", Text = nativePartSecret }
+            ]
+        };
+        turn.Items.Add(new SessionItem
+        {
+            Id = SessionIdGenerator.NewItemId(3),
+            TurnId = turn.Id,
+            Type = ItemType.ToolCall,
+            Status = ItemStatus.Completed,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow,
+            Payload = new ToolCallPayload
+            {
+                ToolName = "safe-search-tool",
+                ProviderFlatName = "safe-search-tool",
+                CallId = "call_safe_search",
+                Arguments = new JsonObject { ["password"] = argumentSecret }
+            }
+        });
+
+        await _threadStore.SaveThreadAsync(thread);
+        await _threadStore.SaveTurnAsync(thread, turn);
+        await _threadStore.AppendModelHistoryAsync(
+            thread.Id,
+            [
+                new ChatMessage(ChatRole.Assistant,
+                [
+                    new TextReasoningContent("internal reasoning")
+                    {
+                        ProtectedData = protectedDataSecret
+                    },
+                    new TextContent(modelHistorySecret)
+                ])
+            ],
+            turn.Id);
+        await _threadStore.AppendCompactionCheckpointAsync(
+            thread.Id,
+            turn.Id,
+            [new ChatMessage(ChatRole.Assistant, checkpointSecret)],
+            "manual",
+            "partial",
+            100,
+            50);
+
+        var visibleResult = await SearchAsync(visibleText);
+        var visibleHit = Assert.Single(visibleResult.Hits);
+        var rolloutEvidence = Assert.Single(visibleHit.Evidence, evidence => evidence.Source == "rollout");
+        Assert.Contains(visibleText, rolloutEvidence.Preview, StringComparison.Ordinal);
+        Assert.DoesNotContain(nativePartSecret, rolloutEvidence.Preview, StringComparison.Ordinal);
+        Assert.DoesNotContain(argumentSecret, rolloutEvidence.Preview, StringComparison.Ordinal);
+
+        var toolResult = await SearchAsync("safe-search-tool");
+        Assert.Single(toolResult.Hits);
+        Assert.Single(toolResult.Hits[0].Evidence, evidence => evidence.Source == "rollout");
+
+        Assert.Empty((await SearchAsync(nativePartSecret)).Hits);
+        Assert.Empty((await SearchAsync(argumentSecret)).Hits);
+        Assert.Empty((await SearchAsync(modelHistorySecret)).Hits);
+        Assert.Empty((await SearchAsync(protectedDataSecret)).Hits);
+        Assert.Empty((await SearchAsync(checkpointSecret)).Hits);
+
+        Task<ContextSearchResult> SearchAsync(string query) =>
+            new ContextSearchService().SearchAsync(new ContextSearchOptions
+            {
+                WorkspacePath = _workspace,
+                Query = query,
+                Limit = 5
+            });
     }
 
     [Fact]

--- a/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
+++ b/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
@@ -3,6 +3,7 @@ using DotCraft.ContextExport;
 using DotCraft.Protocol;
 using DotCraft.State;
 using DotCraft.Tracing;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.AI;
 
 namespace DotCraft.Tests.ContextExport;
@@ -29,6 +30,31 @@ public sealed class ContextExportServiceTests : IDisposable
     {
         try { Directory.Delete(_root, recursive: true); }
         catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public async Task ExportAsync_RejectsRolloutPathOutsideCraftDirectory()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "request", "answer");
+        await _threadStore.SaveThreadAsync(thread);
+
+        var statePath = Path.Combine(_craft, "state.db");
+        await using (var connection = new SqliteConnection($"Data Source={statePath}"))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "UPDATE threads SET rollout_path = $path WHERE thread_id = $threadId";
+            command.Parameters.AddWithValue("$path", Path.Combine(_root, "outside.jsonl"));
+            command.Parameters.AddWithValue("$threadId", thread.Id);
+            await command.ExecuteNonQueryAsync();
+        }
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => new ContextExportService().ExportAsync(new ContextExportOptions
+        {
+            ThreadId = thread.Id,
+            WorkspacePath = _workspace
+        }));
     }
 
     [Fact]

--- a/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
+++ b/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
@@ -179,6 +179,34 @@ public sealed class ContextExportServiceTests : IDisposable
         Assert.Contains("[reasoning omitted]", result.Markdown);
     }
 
+    [Theory]
+    [InlineData(ContextExportProfile.Handoff)]
+    [InlineData(ContextExportProfile.Transcript)]
+    public async Task ExportAsync_OmitsFreeFormThreadMetadata(ContextExportProfile profile)
+    {
+        var thread = CreateThread();
+        thread.Metadata["api_key"] = "METADATA_API_KEY_SECRET";
+        thread.Metadata["authorization"] = "Bearer METADATA_BEARER_SECRET";
+        thread.Metadata["nested"] = "{\"token\":\"METADATA_JSON_SECRET\"}";
+        thread.Metadata["dotcraft.externalCliSessions"] =
+            "[{\"sessionId\":\"METADATA_CLI_SESSION_SECRET\",\"workingDirectory\":\"C:/private\"}]";
+        thread.Metadata["ordinary"] = "METADATA_ORDINARY_VALUE";
+        AddTurnWithMessages(thread, "visible request", "visible answer");
+        await _threadStore.SaveThreadAsync(thread);
+
+        var result = await new ContextExportService().ExportAsync(new ContextExportOptions
+        {
+            ThreadId = thread.Id,
+            WorkspacePath = _workspace,
+            Profile = profile
+        });
+
+        Assert.Contains("visible request", result.Markdown);
+        Assert.DoesNotContain("METADATA_", result.Markdown);
+        Assert.DoesNotContain("dotcraft.externalCliSessions", result.Markdown);
+        Assert.DoesNotContain("- Metadata:", result.Markdown);
+    }
+
     [Fact]
     public async Task SearchAsync_TraceEventMatch_ReturnsBoundThreadEvidence()
     {

--- a/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
+++ b/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
@@ -178,6 +178,165 @@ public sealed class ContextExportServiceTests : IDisposable
         Assert.Contains("[redacted]", result.Markdown);
     }
 
+    [Theory]
+    [InlineData(ContextExportToolResultMode.Summary)]
+    [InlineData(ContextExportToolResultMode.Full)]
+    public async Task ExportAsync_OmitsRequestUserInputAnswersFromEveryProjection(ContextExportToolResultMode mode)
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "collect deployment details", "asking for input");
+        var turn = thread.Turns[0];
+        var now = turn.StartedAt;
+        turn.Items.AddRange(
+        [
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(10),
+                TurnId = turn.Id,
+                Type = ItemType.ToolCall,
+                Status = ItemStatus.Completed,
+                CreatedAt = now.AddMilliseconds(200),
+                CompletedAt = now.AddMilliseconds(200),
+                Payload = new ToolCallPayload
+                {
+                    ToolName = "RequestUserInput",
+                    ProviderFlatName = "RequestUserInput",
+                    CallId = "call_user_input",
+                    Arguments = new JsonObject { ["questionCount"] = 2 }
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(11),
+                TurnId = turn.Id,
+                Type = ItemType.UserInputRequest,
+                Status = ItemStatus.Completed,
+                CreatedAt = now.AddMilliseconds(300),
+                CompletedAt = now.AddMilliseconds(300),
+                Payload = new UserInputRequestPayload
+                {
+                    RequestId = "request_export_input",
+                    Questions =
+                    [
+                        new RequestUserInputQuestion
+                        {
+                            Id = "one_time_code",
+                            Header = "Code",
+                            Question = "Enter the one-time code",
+                            IsSecret = true
+                        },
+                        new RequestUserInputQuestion
+                        {
+                            Id = "deployment_region",
+                            Header = "Region",
+                            Question = "Choose the deployment region"
+                        }
+                    ]
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(12),
+                TurnId = turn.Id,
+                Type = ItemType.UserInputResponse,
+                Status = ItemStatus.Completed,
+                CreatedAt = now.AddMilliseconds(400),
+                CompletedAt = now.AddMilliseconds(400),
+                Payload = new UserInputResponsePayload
+                {
+                    RequestId = "request_export_input",
+                    Response = new RequestUserInputResponse
+                    {
+                        Answers = new Dictionary<string, RequestUserInputAnswer>(StringComparer.Ordinal)
+                        {
+                            ["one_time_code"] = new() { Answers = ["SESSION_SECRET_ANSWER"] },
+                            ["deployment_region"] = new() { Answers = ["SESSION_NORMAL_ANSWER"] }
+                        }
+                    }
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(13),
+                TurnId = turn.Id,
+                Type = ItemType.ToolResult,
+                Status = ItemStatus.Completed,
+                CreatedAt = now.AddMilliseconds(500),
+                CompletedAt = now.AddMilliseconds(500),
+                Payload = new ToolResultPayload
+                {
+                    CallId = "call_user_input",
+                    ProviderFlatName = "RequestUserInput",
+                    Success = true,
+                    Result = "{\"answers\":{\"one_time_code\":{\"answers\":[\"TOOL_SECRET_ANSWER\"]},\"deployment_region\":{\"answers\":[\"TOOL_NORMAL_ANSWER\"]}}}"
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(14),
+                TurnId = turn.Id,
+                Type = ItemType.ToolResult,
+                Status = ItemStatus.Completed,
+                CreatedAt = now.AddMilliseconds(600),
+                CompletedAt = now.AddMilliseconds(600),
+                Payload = new ToolResultPayload
+                {
+                    CallId = "call_unrelated",
+                    ProviderFlatName = "ReadFile",
+                    ToolName = "ReadFile",
+                    Success = true,
+                    Result = "conversation-unrelated-visible"
+                }
+            }
+        ]);
+        await _threadStore.SaveThreadAsync(thread);
+        await _threadStore.AppendModelHistoryAsync(
+            thread.Id,
+            [
+                new ChatMessage(ChatRole.Assistant,
+                [
+                    new FunctionCallContent("call_exact_input", "RequestUserInput", new Dictionary<string, object?>()),
+                    new FunctionCallContent("call_exact_unrelated", "ReadFile", new Dictionary<string, object?>())
+                ]),
+                new ChatMessage(ChatRole.Tool,
+                [
+                    new FunctionResultContent(
+                        "call_exact_input",
+                        "{\"answers\":{\"one_time_code\":{\"answers\":[\"HISTORY_SECRET_ANSWER\"]},\"deployment_region\":{\"answers\":[\"HISTORY_NORMAL_ANSWER\"]}}}"),
+                    new FunctionResultContent("call_exact_unrelated", "history-unrelated-visible")
+                ])
+            ],
+            turn.Id);
+
+        var result = await new ContextExportService().ExportAsync(new ContextExportOptions
+        {
+            ThreadId = thread.Id,
+            WorkspacePath = _workspace,
+            ToolResults = mode,
+            ToolResultPreviewChars = 10_000
+        });
+
+        foreach (var answer in new[]
+                 {
+                     "SESSION_SECRET_ANSWER",
+                     "SESSION_NORMAL_ANSWER",
+                     "TOOL_SECRET_ANSWER",
+                     "TOOL_NORMAL_ANSWER",
+                     "HISTORY_SECRET_ANSWER",
+                     "HISTORY_NORMAL_ANSWER"
+                 })
+        {
+            Assert.DoesNotContain(answer, result.Markdown);
+        }
+
+        Assert.Contains("request_export_input", result.Markdown);
+        Assert.Contains("Enter the one-time code", result.Markdown);
+        Assert.Contains("Choose the deployment region", result.Markdown);
+        Assert.Contains("omitted because user-input answers may contain secrets", result.Markdown);
+        Assert.Contains("conversation-unrelated-visible", result.Markdown);
+        Assert.Contains("history-unrelated-visible", result.Markdown);
+    }
+
     [Fact]
     public async Task ExportAsync_UsesCanonicalExactHistoryAndRedactsInternalModelMetadata()
     {

--- a/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
+++ b/tests/DotCraft.Core.Tests/ContextExport/ContextExportServiceTests.cs
@@ -134,6 +134,50 @@ public sealed class ContextExportServiceTests : IDisposable
         Assert.Contains("Compaction", result.Markdown);
     }
 
+    [Theory]
+    [InlineData(ContextExportToolResultMode.Summary)]
+    [InlineData(ContextExportToolResultMode.Full)]
+    public async Task ExportAsync_RedactsAllToolResultBodiesBeforePresentation(ContextExportToolResultMode mode)
+    {
+        var thread = CreateThread();
+        AddTurnWithSensitiveResultPaths(thread);
+        await _threadStore.SaveThreadAsync(thread);
+        await _threadStore.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.Tool,
+                [new FunctionResultContent("call_exact", "{\"cookie\":\"EXACT_RESULT_SECRET\",\"safe\":\"exact-visible\"}")])],
+            thread.Turns[0].Id);
+
+        var result = await new ContextExportService().ExportAsync(new ContextExportOptions
+        {
+            ThreadId = thread.Id,
+            WorkspacePath = _workspace,
+            ToolResults = mode,
+            ToolResultPreviewChars = 10_000
+        });
+
+        foreach (var secret in new[]
+                 {
+                     "COMMAND_RESULT_SECRET",
+                     "EXECUTION_RESULT_SECRET",
+                     "TOOL_RESULT_SECRET",
+                     "PLUGIN_RESULT_SECRET",
+                     "DYNAMIC_RESULT_SECRET",
+                     "EXACT_RESULT_SECRET"
+                 })
+        {
+            Assert.DoesNotContain(secret, result.Markdown);
+        }
+
+        Assert.Contains("command-visible", result.Markdown);
+        Assert.Contains("execution-visible", result.Markdown);
+        Assert.Contains("tool-visible", result.Markdown);
+        Assert.Contains("plugin-visible", result.Markdown);
+        Assert.Contains("dynamic-visible", result.Markdown);
+        Assert.Contains("exact-visible", result.Markdown);
+        Assert.Contains("[redacted]", result.Markdown);
+    }
+
     [Fact]
     public async Task ExportAsync_UsesCanonicalExactHistoryAndRedactsInternalModelMetadata()
     {
@@ -391,6 +435,107 @@ public sealed class ContextExportServiceTests : IDisposable
         });
         thread.Turns.Add(turn);
         thread.LastActiveAt = turn.CompletedAt.Value;
+    }
+
+    private static void AddTurnWithSensitiveResultPaths(SessionThread thread)
+    {
+        AddTurnWithMessages(thread, "run sensitive tools", "calling tools");
+        var turn = thread.Turns[0];
+        var now = turn.StartedAt;
+        turn.Items.AddRange(
+        [
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(10),
+                TurnId = turn.Id,
+                Type = ItemType.CommandExecution,
+                Status = ItemStatus.Completed,
+                CreatedAt = now,
+                CompletedAt = now,
+                Payload = new CommandExecutionPayload
+                {
+                    Command = "demo",
+                    WorkingDirectory = ".",
+                    Status = "completed",
+                    AggregatedOutput = "command-visible password=COMMAND_RESULT_SECRET"
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(11),
+                TurnId = turn.Id,
+                Type = ItemType.ToolExecution,
+                Status = ItemStatus.Completed,
+                CreatedAt = now,
+                CompletedAt = now,
+                Payload = new ToolExecutionPayload
+                {
+                    ToolName = "demo",
+                    CallId = "call_execution",
+                    Status = "completed",
+                    Success = true,
+                    ResultPreview = "execution-visible Authorization: Bearer EXECUTION_RESULT_SECRET"
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(12),
+                TurnId = turn.Id,
+                Type = ItemType.ToolResult,
+                Status = ItemStatus.Completed,
+                CreatedAt = now,
+                CompletedAt = now,
+                Payload = new ToolResultPayload
+                {
+                    CallId = "call_result",
+                    Success = true,
+                    Result = "{\"token\":\"TOOL_RESULT_SECRET\",\"safe\":\"tool-visible\"}"
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(13),
+                TurnId = turn.Id,
+                Type = ItemType.PluginFunctionCall,
+                Status = ItemStatus.Completed,
+                CreatedAt = now,
+                CompletedAt = now,
+                Payload = new PluginFunctionCallPayload
+                {
+                    PluginId = "plugin",
+                    FunctionName = "demo",
+                    CallId = "call_plugin",
+                    Success = true,
+                    StructuredResult = new JsonObject
+                    {
+                        ["api_key"] = "PLUGIN_RESULT_SECRET",
+                        ["safe"] = "plugin-visible"
+                    }
+                }
+            },
+            new SessionItem
+            {
+                Id = SessionIdGenerator.NewItemId(14),
+                TurnId = turn.Id,
+                Type = ItemType.DynamicToolCall,
+                Status = ItemStatus.Completed,
+                CreatedAt = now,
+                CompletedAt = now,
+                Payload = new DynamicToolCallPayload
+                {
+                    ToolName = "dynamic",
+                    ProviderFlatName = "dynamic",
+                    CallId = "call_dynamic",
+                    Status = "completed",
+                    Success = true,
+                    StructuredContent = new JsonObject
+                    {
+                        ["cookie"] = "DYNAMIC_RESULT_SECRET",
+                        ["safe"] = "dynamic-visible"
+                    }
+                }
+            }
+        ]);
     }
 
     private static void AddTurnWithToolResult(SessionThread thread, string resultText)

--- a/tests/DotCraft.Core.Tests/DotCraft.Core.Tests.csproj
+++ b/tests/DotCraft.Core.Tests/DotCraft.Core.Tests.csproj
@@ -32,4 +32,9 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Protocol\Fixtures\model-history-schema-v1.json"
+                      LogicalName="DotCraft.Tests.ModelHistorySchemaV1.json" />
+  </ItemGroup>
+
 </Project>

--- a/tests/DotCraft.Core.Tests/Protocol/AppServer/TestableSessionService.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/AppServer/TestableSessionService.cs
@@ -743,7 +743,6 @@ internal sealed class TestableSessionService : ISessionService, IThreadAgentRefr
         {
             _cache.Remove(id);
             _store.DeleteThread(id);
-            _store.DeleteSessionFile(id);
             ThreadDeletedForBroadcast?.Invoke(id);
         }
     }

--- a/tests/DotCraft.Core.Tests/Protocol/Fixtures/model-history-schema-v1.json
+++ b/tests/DotCraft.Core.Tests/Protocol/Fixtures/model-history-schema-v1.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": 1,
+  "turnId": "turn_fixture",
+  "role": "assistant",
+  "messageId": "message_fixture",
+  "authorName": "assistant_fixture",
+  "createdAt": "2026-01-02T03:04:05+00:00",
+  "additionalProperties": {
+    "messageMeta": { "array": [1, true, null, { "name": "value" }] },
+    "nullable": null
+  },
+  "contents": [
+    {
+      "kind": "text",
+      "payload": {
+        "text": "hello",
+        "additionalProperties": { "textMeta": { "array": [1, true, null, { "name": "value" }] } }
+      }
+    },
+    {
+      "kind": "reasoning",
+      "payload": { "text": "thinking", "protectedData": "protected", "additionalProperties": null }
+    },
+    {
+      "kind": "data",
+      "payload": { "base64Data": "AQID", "mediaType": "image/png", "name": "sample.png", "additionalProperties": null }
+    },
+    {
+      "kind": "function_call",
+      "payload": {
+        "callId": "call_1",
+        "name": "read_file",
+        "arguments": { "path": "sample.txt", "line": 7 },
+        "informationalOnly": true,
+        "namespace": "tools",
+        "providerFlatName": "tools--read_file",
+        "additionalProperties": {
+          "openai.responses.function_call.namespace": "tools",
+          "namespace": "tools",
+          "dotcraft.tool.provider_flat_name": "tools--read_file",
+          "extension": { "array": [1, true, null, { "name": "value" }] }
+        }
+      }
+    },
+    {
+      "kind": "function_result",
+      "payload": {
+        "callId": "call_1",
+        "result": { "schemaVersion": 1, "kind": "json", "json": { "ok": true, "count": 2 }, "contents": null },
+        "additionalProperties": null
+      }
+    },
+    {
+      "kind": "function_result",
+      "payload": {
+        "callId": "call_2",
+        "result": {
+          "schemaVersion": 1,
+          "kind": "contents",
+          "json": null,
+          "contents": [
+            { "kind": "text", "payload": { "text": "nested result", "additionalProperties": null } },
+            { "kind": "data", "payload": { "base64Data": "CQg=", "mediaType": "text/plain", "name": "nested.txt", "additionalProperties": null } }
+          ]
+        },
+        "additionalProperties": null
+      }
+    },
+    {
+      "kind": "hosted_image_generation",
+      "payload": {
+        "id": "image_1",
+        "status": "completed",
+        "revisedPrompt": "synthetic prompt",
+        "imageBase64": "BAUG",
+        "mediaType": "image/png",
+        "errorMessage": null,
+        "additionalProperties": null
+      }
+    },
+    {
+      "kind": "image_generation_tool_call",
+      "payload": { "callId": "image_call", "additionalProperties": null }
+    },
+    {
+      "kind": "image_generation_tool_result",
+      "payload": {
+        "callId": "image_call",
+        "outputs": [
+          { "kind": "text", "payload": { "text": "generated", "additionalProperties": null } },
+          { "kind": "uri", "payload": { "uri": "https://example.invalid/image.png", "mediaType": "image/png", "additionalProperties": null } }
+        ],
+        "additionalProperties": null
+      }
+    },
+    {
+      "kind": "error",
+      "payload": { "message": "recoverable", "errorCode": "sample_error", "details": "synthetic details", "additionalProperties": null }
+    },
+    {
+      "kind": "uri",
+      "payload": { "uri": "https://example.invalid/document.txt", "mediaType": "text/plain", "additionalProperties": null }
+    },
+    {
+      "kind": "usage",
+      "payload": {
+        "inputTokenCount": 10,
+        "outputTokenCount": 5,
+        "totalTokenCount": 15,
+        "cachedInputTokenCount": 2,
+        "reasoningTokenCount": 1,
+        "inputAudioTokenCount": 0,
+        "inputTextTokenCount": 10,
+        "outputAudioTokenCount": 0,
+        "outputTextTokenCount": 5,
+        "additionalCounts": { "acceptedPredictionTokens": 3 },
+        "additionalProperties": null
+      }
+    }
+  ]
+}

--- a/tests/DotCraft.Core.Tests/Protocol/ModelHistoryTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ModelHistoryTests.cs
@@ -111,6 +111,64 @@ public sealed class ModelHistoryTests : IDisposable
     }
 
     [Fact]
+    public void Codec_RejectsNullCollectionsAndInvalidUriAsJsonException()
+    {
+        var codec = new ModelHistoryCodec();
+
+        var nullContents = new ModelHistoryMessage
+        {
+            Role = ChatRole.Assistant.Value,
+            Contents = null!
+        };
+        Assert.Throws<JsonException>(() => codec.Decode(nullContents));
+
+        var invalidUri = new ModelHistoryMessage
+        {
+            Role = ChatRole.Assistant.Value,
+            Contents =
+            [
+                new ModelHistoryContent
+                {
+                    Kind = "uri",
+                    Payload = JsonSerializer.SerializeToElement(new
+                    {
+                        uri = "not a valid absolute uri",
+                        mediaType = "text/plain",
+                        additionalProperties = (object?)null
+                    }, JsonSerializerOptions.Web)
+                }
+            ]
+        };
+        Assert.Throws<JsonException>(() => codec.Decode(invalidUri));
+    }
+
+    [Fact]
+    public void Codec_RejectsNullContentEntriesAndMissingPayloadAsJsonException()
+    {
+        var codec = new ModelHistoryCodec();
+        var nullEntry = new ModelHistoryMessage
+        {
+            Role = ChatRole.Assistant.Value,
+            Contents = [null!]
+        };
+        Assert.Throws<JsonException>(() => codec.Decode(nullEntry));
+
+        var missingPayload = new ModelHistoryMessage
+        {
+            Role = ChatRole.Assistant.Value,
+            Contents =
+            [
+                new ModelHistoryContent
+                {
+                    Kind = "text",
+                    Payload = default
+                }
+            ]
+        };
+        Assert.Throws<JsonException>(() => codec.Decode(missingPayload));
+    }
+
+    [Fact]
     public void Codec_RejectsConflictingStrongToolIdentityAndAdditionalProperties()
     {
         var payload = new PersistedFunctionCallContent

--- a/tests/DotCraft.Core.Tests/Protocol/ModelHistoryTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ModelHistoryTests.cs
@@ -1,0 +1,482 @@
+using System.Reflection;
+using System.Text.Json;
+using DotCraft.Agents;
+using DotCraft.Protocol;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Tests.Sessions.Protocol;
+
+public sealed class ModelHistoryTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"dotcraft_model_history_{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Codec_RoundTripsAdditionalPropertiesAndReasoningProtectedData_WithoutRawRepresentation()
+    {
+        var nested = JsonSerializer.Deserialize<JsonElement>("""{"array":[1,true,null,{"name":"value"}]}""");
+        var reasoning = new TextReasoningContent("thinking")
+        {
+            ProtectedData = "encrypted-replay-token",
+            RawRepresentation = new object(),
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["provider"] = "openai-responses",
+                ["nested"] = nested
+            }
+        };
+        var message = new ChatMessage(ChatRole.Assistant, [reasoning])
+        {
+            MessageId = "message-1",
+            AuthorName = "assistant-name",
+            CreatedAt = DateTimeOffset.Parse("2026-07-20T12:00:00Z"),
+            RawRepresentation = new object(),
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["messageNested"] = nested,
+                ["number"] = 42
+            }
+        };
+
+        var codec = new ModelHistoryCodec();
+        var encoded = codec.Encode(message, "turn_001");
+        var serialized = JsonSerializer.Serialize(encoded, SessionJsonOptions.Default);
+        var restored = codec.Decode(
+            JsonSerializer.Deserialize<ModelHistoryMessage>(serialized, SessionJsonOptions.Default)!);
+
+        Assert.DoesNotContain("RawRepresentation", serialized, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("$type", serialized, StringComparison.Ordinal);
+        Assert.Null(restored.RawRepresentation);
+        Assert.Equal("message-1", restored.MessageId);
+        Assert.Equal("assistant-name", restored.AuthorName);
+        Assert.Equal(message.CreatedAt, restored.CreatedAt);
+        Assert.Equal(
+            encoded.AdditionalProperties!.Value.GetRawText(),
+            JsonSerializer.SerializeToElement(restored.AdditionalProperties, SessionPersistenceJsonOptions.Default).GetRawText());
+
+        var restoredReasoning = Assert.IsType<TextReasoningContent>(Assert.Single(restored.Contents));
+        Assert.Equal("thinking", restoredReasoning.Text);
+        Assert.Equal("encrypted-replay-token", restoredReasoning.ProtectedData);
+        Assert.Null(restoredReasoning.RawRepresentation);
+        Assert.Equal(
+            reasoning.AdditionalProperties!.Count,
+            restoredReasoning.AdditionalProperties!.Count);
+        Assert.IsType<string>(restoredReasoning.AdditionalProperties["provider"]);
+        Assert.IsType<long>(restored.AdditionalProperties!["number"]);
+    }
+
+    [Fact]
+    public void Codec_UsesOwnedSchemaFixtureForEveryDurableContentKind()
+    {
+        var codec = new ModelHistoryCodec();
+        var encoded = codec.Encode(CreateComprehensiveMessage(), "turn_fixture");
+        var actual = JsonSerializer.SerializeToElement(encoded, SessionJsonOptions.Default);
+        var expected = ReadSchemaFixture();
+        var actualJson = actual.GetRawText();
+
+        Assert.True(JsonElement.DeepEquals(expected, actual),
+            $"Persisted model-history schema changed.\nExpected: {expected}\nActual: {actual}");
+        Assert.DoesNotContain("$type", actualJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("rawRepresentation", actualJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("not persisted", actualJson, StringComparison.Ordinal);
+
+        var decodedFixture = expected.Deserialize<ModelHistoryMessage>(SessionJsonOptions.Default)!;
+        var restored = codec.Decode(decodedFixture);
+        var reencoded = JsonSerializer.SerializeToElement(codec.Encode(restored, "turn_fixture"), SessionJsonOptions.Default);
+
+        Assert.True(JsonElement.DeepEquals(expected, reencoded));
+        Assert.Equal(12, restored.Contents.Count);
+        Assert.DoesNotContain(restored.Contents, static content => content is ToolCallArgumentsDeltaContent);
+        var data = Assert.IsType<DataContent>(restored.Contents[2]);
+        Assert.Equal("AQID", data.Base64Data.ToString());
+        Assert.Equal("sample.png", data.Name);
+        var functionCall = Assert.IsType<FunctionCallContent>(restored.Contents[3]);
+        Assert.Equal("tools", functionCall.AdditionalProperties!["openai.responses.function_call.namespace"]);
+        Assert.Equal("tools--read_file", functionCall.AdditionalProperties["dotcraft.tool.provider_flat_name"]);
+        Assert.Equal("sample.txt", Assert.IsType<string>(functionCall.Arguments!["path"]));
+        var jsonResult = Assert.IsType<FunctionResultContent>(restored.Contents[4]);
+        Assert.True(Assert.IsType<JsonElement>(jsonResult.Result).GetProperty("ok").GetBoolean());
+        var contentResult = Assert.IsType<FunctionResultContent>(restored.Contents[5]);
+        var nestedContents = Assert.IsAssignableFrom<IList<AIContent>>(contentResult.Result);
+        Assert.Collection(
+            nestedContents,
+            content => Assert.Equal("nested result", Assert.IsType<TextContent>(content).Text),
+            content => Assert.Equal("text/plain", Assert.IsType<DataContent>(content).MediaType));
+        var hostedImage = Assert.IsType<HostedImageGenerationContent>(restored.Contents[6]);
+        Assert.Equal(new byte[] { 4, 5, 6 }, hostedImage.ImageBytes);
+        var imageResult = Assert.IsType<ImageGenerationToolResultContent>(restored.Contents[8]);
+        Assert.Equal("https://example.invalid/image.png", Assert.IsType<UriContent>(imageResult.Outputs![1]).Uri.ToString());
+        var usage = Assert.IsType<UsageContent>(restored.Contents[11]);
+        Assert.Equal(15, usage.Details.TotalTokenCount);
+    }
+
+    [Fact]
+    public void Codec_RejectsConflictingStrongToolIdentityAndAdditionalProperties()
+    {
+        var payload = new PersistedFunctionCallContent
+        {
+            CallId = "call_conflict",
+            Name = "read_file",
+            Arguments = JsonSerializer.SerializeToElement(new { path = "sample.txt" }),
+            InformationalOnly = false,
+            Namespace = "tools",
+            ProviderFlatName = null,
+            AdditionalProperties = JsonSerializer.SerializeToElement(new Dictionary<string, object?>
+            {
+                ["openai.responses.function_call.namespace"] = "different"
+            })
+        };
+        var message = new ModelHistoryMessage
+        {
+            Role = ChatRole.Assistant.Value,
+            Contents =
+            [
+                new ModelHistoryContent
+                {
+                    Kind = "function_call",
+                    Payload = JsonSerializer.SerializeToElement(payload, JsonSerializerOptions.Web)
+                }
+            ]
+        };
+
+        Assert.Throws<JsonException>(() => new ModelHistoryCodec().Decode(message));
+    }
+
+    [Fact]
+    public async Task ThreadStore_PersistsAndHydratesModelHistoryWithoutFrameworkSessionBlob()
+    {
+        Directory.CreateDirectory(_root);
+        var store = new ThreadStore(_root);
+        var thread = new SessionThread
+        {
+            Id = "thread_model_history",
+            WorkspacePath = _root,
+            OriginChannel = "test",
+            CreatedAt = DateTimeOffset.UtcNow,
+            LastActiveAt = DateTimeOffset.UtcNow,
+            Turns =
+            [
+                new SessionTurn
+                {
+                    Id = "turn_001",
+                    ThreadId = "thread_model_history",
+                    Status = TurnStatus.Completed,
+                    StartedAt = DateTimeOffset.UtcNow,
+                    CompletedAt = DateTimeOffset.UtcNow
+                }
+            ]
+        };
+        await store.SaveThreadAsync(thread);
+
+        using var client = new PassiveChatClient();
+        var agent = client.AsAIAgent(new ChatClientAgentOptions());
+        var session = await agent.CreateSessionAsync();
+        session.SetInMemoryChatHistory(
+            [
+                new ChatMessage(ChatRole.User, "hello"),
+                new ChatMessage(ChatRole.Assistant,
+                [
+                    new TextReasoningContent("think") { ProtectedData = "protected" },
+                    new TextContent("answer")
+                ])
+            ],
+            jsonSerializerOptions: SessionPersistenceJsonOptions.Default);
+
+        await store.PersistModelHistoryAsync(session, thread.Id, "turn_001", persistedPrefixLength: 0);
+
+        var rollout = await File.ReadAllTextAsync(
+            Path.Combine(_root, "threads", "active", "thread_model_history.jsonl"));
+        var historyRecord = Assert.Single(
+            rollout.Split('\n', StringSplitOptions.RemoveEmptyEntries),
+            line => line.Contains("model_history_messages_appended", StringComparison.Ordinal));
+        using (var historyJson = JsonDocument.Parse(historyRecord))
+        {
+            Assert.Equal(
+                2,
+                historyJson.RootElement
+                    .GetProperty("modelHistoryMessagesAppended")
+                    .GetProperty("messages")
+                    .GetArrayLength());
+        }
+
+        var coldSession = await new ThreadStore(_root).LoadOrCreateSessionAsync(agent, thread.Id);
+        Assert.True(coldSession.TryGetInMemoryChatHistory(
+            out var history,
+            jsonSerializerOptions: SessionPersistenceJsonOptions.Default));
+        Assert.Equal(2, history.Count);
+        Assert.Equal("hello", history[0].Text);
+        var restoredReasoning = Assert.IsType<TextReasoningContent>(history[1].Contents[0]);
+        Assert.Equal("protected", restoredReasoning.ProtectedData);
+
+        using (var connection = store.StateRuntime.OpenConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'thread_sessions'";
+            Assert.Equal(0L, (long)(command.ExecuteScalar() ?? 0L));
+        }
+    }
+
+    [Fact]
+    public async Task OrderedWriter_PreservesRecordOrderAcrossCapacityBoundary()
+    {
+        var observed = new List<int>();
+        var writer = new OrderedRolloutWriter((_, batch, _) =>
+        {
+            observed.AddRange(batch.Select(record => int.Parse(record.Kind, System.Globalization.CultureInfo.InvariantCulture)));
+            return Task.FromResult(new RolloutWriteReceipt(
+                observed.Count,
+                batch.Count,
+                new Dictionary<string, long>()));
+        });
+        var records = Enumerable.Range(0, 300)
+            .Select(index => new ThreadRolloutRecord { Kind = index.ToString(System.Globalization.CultureInfo.InvariantCulture) })
+            .ToList();
+
+        await writer.AddBatchAsync("thread", "unused", records);
+        await writer.FlushAsync("thread");
+        await writer.CloseAsync("thread");
+
+        Assert.Equal(Enumerable.Range(0, 300), observed);
+    }
+
+    [Fact]
+    public async Task OrderedWriter_DoesNotAppendSuffixAfterPersistentFailure()
+    {
+        var attempts = new List<IReadOnlyList<string>>();
+        var writer = new OrderedRolloutWriter((_, batch, _) =>
+        {
+            attempts.Add(batch.Select(static record => record.Kind).ToList());
+            return Task.FromException<RolloutWriteReceipt>(new IOException("persistent write failure"));
+        });
+
+        await writer.AddBatchAsync(
+            "thread",
+            "unused",
+            [
+                new ThreadRolloutRecord { Kind = "confirmed" },
+                new ThreadRolloutRecord { Kind = "fail" },
+                new ThreadRolloutRecord { Kind = "must-not-append" }
+            ]);
+        await Assert.ThrowsAsync<RolloutPersistenceException>(() => writer.FlushAsync("thread"));
+        await Assert.ThrowsAsync<RolloutPersistenceException>(() => writer.CloseAsync("thread"));
+
+        Assert.NotEmpty(attempts);
+        Assert.All(attempts, attempt => Assert.Equal(["confirmed", "fail", "must-not-append"], attempt));
+    }
+
+    [Fact]
+    public async Task OrderedWriter_FlushesOneQueuedBatchOnce()
+    {
+        var flushes = 0;
+        IReadOnlyList<string>? observed = null;
+        var writer = new OrderedRolloutWriter((_, batch, _) =>
+        {
+            flushes++;
+            observed = batch.Select(static record => record.Kind).ToList();
+            return Task.FromResult(new RolloutWriteReceipt(
+                123,
+                batch.Count,
+                batch.GroupBy(static record => record.Kind)
+                    .ToDictionary(static group => group.Key, static group => (long)group.Count())));
+        });
+
+        await writer.AddBatchAsync(
+            "thread",
+            "unused",
+            [
+                new ThreadRolloutRecord { Kind = "turn_state_replaced" },
+                new ThreadRolloutRecord { Kind = "context_compacted" },
+                new ThreadRolloutRecord { Kind = "model_history_messages_appended" }
+            ]);
+        var receipt = await writer.FlushAsync("thread");
+        await writer.CloseAsync("thread");
+
+        Assert.Equal(1, flushes);
+        Assert.Equal(
+            ["turn_state_replaced", "context_compacted", "model_history_messages_appended"],
+            observed);
+        Assert.Equal(3, receipt.RecordCount);
+    }
+
+    [Fact]
+    public async Task OrderedWriter_PreservesDamagedTailAndResumesOnNextLine()
+    {
+        Directory.CreateDirectory(_root);
+        var path = Path.Combine(_root, "damaged-tail.jsonl");
+        var writer = new OrderedRolloutWriter();
+        await writer.AddBatchAsync(
+            "thread",
+            path,
+            [new ThreadRolloutRecord { Kind = "before_damage" }]);
+        await writer.FlushAsync("thread");
+
+        await File.AppendAllTextAsync(path, "{\"kind\":");
+        await writer.AddBatchAsync(
+            "thread",
+            path,
+            [new ThreadRolloutRecord { Kind = "after_damage" }]);
+        await writer.FlushAsync("thread");
+        await writer.CloseAsync("thread");
+
+        var validKinds = File.ReadLines(path)
+            .Select(line =>
+            {
+                try
+                {
+                    return JsonSerializer.Deserialize<ThreadRolloutRecord>(line, SessionJsonOptions.Default)?.Kind;
+                }
+                catch (JsonException)
+                {
+                    return null;
+                }
+            })
+            .Where(static kind => kind != null)
+            .ToList();
+        Assert.Equal(["before_damage", "after_damage"], validKinds);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; SQLite pooling can briefly retain the file on Windows.
+        }
+    }
+
+    private static ChatMessage CreateComprehensiveMessage()
+    {
+        var nestedProperties = JsonSerializer.Deserialize<JsonElement>("""{"array":[1,true,null,{"name":"value"}]}""");
+        var functionCall = new FunctionCallContent(
+            "call_1",
+            "read_file",
+            new Dictionary<string, object?> { ["path"] = "sample.txt", ["line"] = 7 })
+        {
+            InformationalOnly = true,
+            Exception = new InvalidOperationException("not persisted"),
+            RawRepresentation = new object(),
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["openai.responses.function_call.namespace"] = "tools",
+                ["namespace"] = "tools",
+                ["dotcraft.tool.provider_flat_name"] = "tools--read_file",
+                ["extension"] = nestedProperties
+            }
+        };
+        var functionResult = new FunctionResultContent(
+            "call_1",
+            JsonSerializer.Deserialize<JsonElement>("""{"ok":true,"count":2}"""))
+        {
+            Exception = new InvalidOperationException("not persisted"),
+            RawRepresentation = new object()
+        };
+        var contentResult = new FunctionResultContent(
+            "call_2",
+            new List<AIContent>
+            {
+                new TextContent("nested result"),
+                new DataContent(new byte[] { 9, 8 }, "text/plain") { Name = "nested.txt" }
+            });
+        var additionalCounts = new AdditionalPropertiesDictionary<long> { ["acceptedPredictionTokens"] = 3 };
+
+        return new ChatMessage(ChatRole.Assistant,
+        [
+            new TextContent("hello")
+            {
+                AdditionalProperties = new AdditionalPropertiesDictionary { ["textMeta"] = nestedProperties }
+            },
+            new TextReasoningContent("thinking") { ProtectedData = "protected" },
+            new DataContent(new byte[] { 1, 2, 3 }, "image/png") { Name = "sample.png" },
+            functionCall,
+            functionResult,
+            contentResult,
+            new HostedImageGenerationContent
+            {
+                Id = "image_1",
+                Status = "completed",
+                RevisedPrompt = "synthetic prompt",
+                ImageBytes = new byte[] { 4, 5, 6 },
+                MediaType = "image/png"
+            },
+            new ImageGenerationToolCallContent("image_call"),
+            new ImageGenerationToolResultContent("image_call")
+            {
+                Outputs =
+                [
+                    new TextContent("generated"),
+                    new UriContent("https://example.invalid/image.png", "image/png")
+                ]
+            },
+            new ErrorContent("recoverable") { ErrorCode = "sample_error", Details = "synthetic details" },
+            new UriContent("https://example.invalid/document.txt", "text/plain"),
+            new UsageContent(new UsageDetails
+            {
+                InputTokenCount = 10,
+                OutputTokenCount = 5,
+                TotalTokenCount = 15,
+                CachedInputTokenCount = 2,
+                ReasoningTokenCount = 1,
+#pragma warning disable MEAI001
+                InputAudioTokenCount = 0,
+                InputTextTokenCount = 10,
+                OutputAudioTokenCount = 0,
+                OutputTextTokenCount = 5,
+#pragma warning restore MEAI001
+                AdditionalCounts = additionalCounts
+            }),
+            new ToolCallArgumentsDeltaContent
+            {
+                ToolCallIndex = 0,
+                ToolName = "read_file",
+                CallId = "call_1",
+                ArgumentsDelta = "{"
+            }
+        ])
+        {
+            MessageId = "message_fixture",
+            AuthorName = "assistant_fixture",
+            CreatedAt = DateTimeOffset.Parse("2026-01-02T03:04:05Z"),
+            RawRepresentation = new object(),
+            AdditionalProperties = new AdditionalPropertiesDictionary
+            {
+                ["messageMeta"] = nestedProperties,
+                ["nullable"] = null
+            }
+        };
+    }
+
+    private static JsonElement ReadSchemaFixture()
+    {
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("DotCraft.Tests.ModelHistorySchemaV1.json")
+            ?? throw new InvalidOperationException("Embedded model-history schema fixture was not found.");
+        using var document = JsonDocument.Parse(stream);
+        return document.RootElement.Clone();
+    }
+
+    private sealed class PassiveChatClient : IChatClient
+    {
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")]));
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            AsyncEnumerable.Empty<ChatResponseUpdate>();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType.IsInstanceOfType(this) ? this : null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/DotCraft.Core.Tests/Protocol/ReplSessionBehaviorTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ReplSessionBehaviorTests.cs
@@ -352,36 +352,13 @@ public sealed class ReplSessionBehaviorTests : IDisposable
         Assert.Equal(1, index.First(e => e.Id == t1.Id).TurnCount);
     }
 
-    // -------------------------------------------------------------------------
-    // Session file (agent chat history) persistence
-    // -------------------------------------------------------------------------
-
     [Fact]
-    public async Task SessionState_NotCreated_UntilTurnCompletes()
+    public void StateDatabase_DoesNotCreateThreadSessionsTable()
     {
-        // ThreadStore only writes thread_sessions rows during SaveSessionAsync
-        // (called by SessionService after the agent finishes).
-        // Simply creating a thread should NOT produce persisted session state.
-
-        var thread = await _svc.CreateThreadAsync(_cliIdentity);
-
-        Assert.False(_store.SessionFileExists(thread.Id),
-            "thread_sessions state should not exist before any turn completes.");
-    }
-
-    [Fact]
-    public async Task SessionState_ExistsAfterPersistingSessionRow()
-    {
-        // Simulates what SessionService does after a turn: persists serialized AgentSession
-        // into the thread_sessions table.
-
-        var thread = await _svc.CreateThreadAsync(_cliIdentity);
-
-        Assert.False(_store.SessionFileExists(thread.Id));
-
-        InsertThreadSession(thread.Id, """{"chatHistory":[],"type":"chatHistory"}""");
-
-        Assert.True(_store.SessionFileExists(thread.Id));
+        using var connection = OpenStateConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'thread_sessions'";
+        Assert.Equal(0L, (long)(command.ExecuteScalar() ?? 0L));
     }
 
     // -------------------------------------------------------------------------
@@ -443,20 +420,6 @@ public sealed class ReplSessionBehaviorTests : IDisposable
         }
 
         return turn;
-    }
-
-    private void InsertThreadSession(string threadId, string sessionJson)
-    {
-        using var connection = OpenStateConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO thread_sessions(thread_id, session_json, updated_at)
-            VALUES ($thread_id, $session_json, $updated_at)
-            """;
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.Parameters.AddWithValue("$session_json", sessionJson);
-        command.Parameters.AddWithValue("$updated_at", DateTimeOffset.UtcNow.UtcDateTime.ToString("O"));
-        command.ExecuteNonQuery();
     }
 
     private SqliteConnection OpenStateConnection()

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceForkTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceForkTests.cs
@@ -152,7 +152,6 @@ public sealed class SessionServiceForkTests : IDisposable
 
         var fork = await service.ForkThreadAsync(source.Id);
 
-        Assert.True(_store.SessionFileExists(fork.Id));
         var checkpoints = await _store.LoadCompactionCheckpointsAsync(fork.Id);
         var checkpoint = Assert.Single(checkpoints);
         Assert.Equal(fork.Id, checkpoint.ThreadId);
@@ -215,7 +214,6 @@ public sealed class SessionServiceForkTests : IDisposable
             });
 
         Assert.Empty(await _store.LoadCompactionCheckpointsAsync(fork.Id));
-        Assert.True(_store.SessionFileExists(fork.Id));
         var usage = _store.LoadContextUsageSnapshot(fork.Id);
         Assert.NotNull(usage);
         Assert.Equal("history_estimate", usage!.Source);

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceLifecycleTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceLifecycleTests.cs
@@ -1052,7 +1052,6 @@ internal sealed class FakeSessionService : ISessionService, ISubAgentThreadLifec
         {
             _threads.Remove(id);
             _store.DeleteThread(id);
-            _store.DeleteSessionFile(id);
             ThreadDeletedForBroadcast?.Invoke(id);
         }
     }

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceManualCompactionTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceManualCompactionTests.cs
@@ -191,8 +191,6 @@ public sealed class SessionServiceManualCompactionTests : IDisposable
             secondCompactRequest);
 
         var store = new ThreadStore(_tempDir);
-        Assert.True(store.SessionFileExists(fork.Id));
-        store.DeleteSessionFile(fork.Id);
         var session = await store.LoadOrCreateSessionAsync(CreateAgent(), fork.Id);
         var restored = FormatHistory(session);
         Assert.Contains(restored, text => text.Contains("fork compacted history", StringComparison.Ordinal));

--- a/tests/DotCraft.Core.Tests/Protocol/SessionServiceRuntimeSignalTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/SessionServiceRuntimeSignalTests.cs
@@ -378,7 +378,9 @@ public sealed class SessionServiceRuntimeSignalTests : IDisposable
         var failedThread = await firstService.GetThreadAsync(thread.Id);
         var failedTurn = failedThread.Turns.Last();
         Assert.Equal(TurnStatus.Failed, failedTurn.Status);
-        Assert.True(new ThreadStore(_tempDir).SessionFileExists(thread.Id));
+        var rollout = await File.ReadAllTextAsync(
+            Path.Combine(_tempDir, "threads", "active", $"{thread.Id}.jsonl"));
+        Assert.Contains("model_history_messages_appended", rollout, StringComparison.Ordinal);
 
         var secondChatClient = new RecordingChatClient("second answer");
         await using var secondFactory = CreateAgentFactory(secondChatClient);
@@ -2085,13 +2087,14 @@ public sealed class SessionServiceRuntimeSignalTests : IDisposable
         var rolledBackTurnService = CreateService(rolledBackTurnFactory, rolledBackTurnChatClient);
         await rolledBackTurnService.ResumeThreadAsync(thread.Id);
         await DrainAsync(rolledBackTurnService.SubmitInputAsync(thread.Id, [new TextContent("rolled back request")]));
-        await SaveSyntheticSessionAsync(
+        await new ThreadStore(_tempDir).AppendCompactionCheckpointAsync(
             thread.Id,
-            [
-                new ChatMessage(ChatRole.Assistant, "<summary>legacy compacted context</summary>"),
-                new ChatMessage(ChatRole.User, "rolled back request"),
-                new ChatMessage(ChatRole.Assistant, "rolled back answer")
-            ]);
+            thread.Turns[0].Id,
+            [new ChatMessage(ChatRole.Assistant, "<summary>legacy compacted context</summary>")],
+            "manual",
+            "partial",
+            1_000,
+            100);
 
         var rollbackChatClient = new RecordingChatClient("unused");
         await using var rollbackFactory = CreateAgentFactory(rollbackChatClient);
@@ -2137,7 +2140,6 @@ public sealed class SessionServiceRuntimeSignalTests : IDisposable
         var compactResult = await compactService.CompactThreadAsync(thread.Id);
         Assert.Equal("partial", compactResult.Outcome);
 
-        DeleteSessionRow(thread.Id);
 
         var followUpChatClient = new RecordingChatClient("follow answer");
         await using var followUpFactory = CreateAgentFactory(followUpChatClient);
@@ -2185,7 +2187,9 @@ public sealed class SessionServiceRuntimeSignalTests : IDisposable
 
         var store = new ThreadStore(_tempDir);
         Assert.NotNull(await store.LoadThreadAsync(thread.Id));
-        Assert.True(store.SessionFileExists(thread.Id));
+        var rollout = await File.ReadAllTextAsync(
+            Path.Combine(_tempDir, "threads", "active", $"{thread.Id}.jsonl"));
+        Assert.Contains("model_history_messages_appended", rollout, StringComparison.Ordinal);
         Assert.True(ThreadRowExists(thread.Id));
     }
 
@@ -2220,7 +2224,6 @@ public sealed class SessionServiceRuntimeSignalTests : IDisposable
         var thread = await firstService.CreateThreadAsync(MakeIdentity());
 
         await DrainAsync(firstService.SubmitInputAsync(thread.Id, [new TextContent("hello")]));
-        DeleteSessionRow(thread.Id);
 
         var secondChatClient = new RecordingChatClient("second answer");
         await using var secondFactory = CreateAgentFactory(secondChatClient);
@@ -2453,23 +2456,6 @@ public sealed class SessionServiceRuntimeSignalTests : IDisposable
         config.Compaction.KeepRecentMinGroups = 1;
         config.Compaction.KeepRecentMaxTokens = 500;
         config.Compaction.MicrocompactEnabled = false;
-    }
-
-    private void DeleteSessionRow(string threadId)
-    {
-        using var connection = OpenStateConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = "DELETE FROM thread_sessions WHERE thread_id = $thread_id";
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.ExecuteNonQuery();
-    }
-
-    private async Task SaveSyntheticSessionAsync(string threadId, IReadOnlyList<ChatMessage> history)
-    {
-        var agent = new RecordingChatClient("unused").AsAIAgent(new ChatClientAgentOptions());
-        var session = await agent.CreateSessionAsync();
-        session.SetInMemoryChatHistory([.. history], jsonSerializerOptions: SessionPersistenceJsonOptions.Default);
-        await new ThreadStore(_tempDir).SaveSessionAsync(agent, session, threadId);
     }
 
     private SqliteConnection OpenStateConnection()

--- a/tests/DotCraft.Core.Tests/Protocol/ThreadStoreSerializationTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ThreadStoreSerializationTests.cs
@@ -10,36 +10,24 @@ namespace DotCraft.Tests.Sessions.Protocol;
 public sealed class ThreadStoreSerializationTests
 {
     [Fact]
-    public async Task AgentSession_RoundTrip_RestoresFunctionResultAsJsonArrayWithoutFlatteningImage()
+    public void ModelHistory_RoundTrip_RestoresFunctionResultAsOwnedContentsWithoutFlatteningImage()
     {
-        using var client = new PassiveChatClient();
-        var agent = client.AsAIAgent(new ChatClientAgentOptions());
-        var session = await agent.CreateSessionAsync();
-        session.SetInMemoryChatHistory(
-        [
-            new ChatMessage(ChatRole.Tool, (IList<AIContent>)
+        var message = new ChatMessage(ChatRole.Tool, (IList<AIContent>)
             [
                 new FunctionResultContent("call-1", new List<AIContent>
                 {
                     new TextContent("screenshot"),
                     new DataContent(new byte[250_000], "image/png")
                 })
-            ])
-        ], jsonSerializerOptions: SessionPersistenceJsonOptions.Default);
+            ]);
+        var codec = new ModelHistoryCodec();
+        var serialized = JsonSerializer.Serialize(codec.Encode(message), SessionJsonOptions.Default);
+        var restored = codec.Decode(JsonSerializer.Deserialize<ModelHistoryMessage>(serialized, SessionJsonOptions.Default)!);
 
-        var serialized = await agent.SerializeSessionAsync(session, SessionPersistenceJsonOptions.Default);
-        var restored = await agent.DeserializeSessionAsync(serialized, SessionPersistenceJsonOptions.Default);
-
-        Assert.True(restored.TryGetInMemoryChatHistory(
-            out var history,
-            jsonSerializerOptions: SessionPersistenceJsonOptions.Default));
-        var toolResult = Assert.Single(Assert.Single(history).Contents.OfType<FunctionResultContent>());
-        var jsonResult = Assert.IsType<JsonElement>(toolResult.Result);
-        Assert.Equal(JsonValueKind.Array, jsonResult.ValueKind);
-        var restoredContents = jsonResult.Deserialize<List<AIContent>>(SessionPersistenceJsonOptions.Default);
-        Assert.NotNull(restoredContents);
-        Assert.IsType<DataContent>(restoredContents![1]);
-        var restoredEstimate = MessageTokenEstimator.Estimate(history.ToList());
+        var toolResult = Assert.Single(restored.Contents.OfType<FunctionResultContent>());
+        var restoredContents = Assert.IsAssignableFrom<IList<AIContent>>(toolResult.Result);
+        Assert.IsType<DataContent>(restoredContents[1]);
+        var restoredEstimate = MessageTokenEstimator.Estimate([restored]);
         Assert.InRange(restoredEstimate, 2_000, 20_000);
     }
 
@@ -153,25 +141,4 @@ public sealed class ThreadStoreSerializationTests
         public string Name { get; init; } = string.Empty;
     }
 
-    private sealed class PassiveChatClient : IChatClient
-    {
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> chatMessages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default) =>
-            Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")]));
-
-        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> chatMessages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default) =>
-            AsyncEnumerable.Empty<ChatResponseUpdate>();
-
-        public object? GetService(Type serviceType, object? serviceKey = null) =>
-            serviceType.IsInstanceOfType(this) ? this : null;
-
-        public void Dispose()
-        {
-        }
-    }
 }

--- a/tests/DotCraft.Core.Tests/Protocol/ThreadStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ThreadStoreTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using DotCraft.Agents;
@@ -55,23 +54,203 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public void CloneThreadSnapshot_DeepCopiesWithSerializedShape()
+    public async Task SaveThread_CompleteSubAgentSource_RoundTripsThroughRolloutAndIndex()
     {
         var thread = CreateThread();
-        thread.Metadata["custom"] = "before";
-        AddTurnWithMessages(thread, "hello", "reply");
+        thread.OriginChannel = SubAgentThreadOrigin.ChannelName;
+        thread.Source = ThreadSource.ForSubAgent(new SubAgentThreadSource
+        {
+            ParentThreadId = "thread_parent",
+            ParentTurnId = "turn_parent",
+            SpawnCallId = "call_spawn",
+            RootThreadId = "thread_root",
+            Depth = 3,
+            AgentPath = "root/reviewer",
+            TaskName = "review",
+            AgentNickname = "reviewer",
+            AgentRole = "critic",
+            ProfileName = "strict",
+            RuntimeType = "process",
+            SupportsSendInput = true,
+            SupportsResume = true,
+            SupportsSendMessage = true,
+            SupportsFollowupTask = true,
+            SupportsClose = false
+        });
 
-        var clone = CloneThreadSnapshotForTest(thread);
+        await _store.SaveThreadAsync(thread);
 
+        var loaded = Assert.IsType<SessionThread>(await _store.LoadThreadAsync(thread.Id));
         Assert.Equal(
-            JsonSerializer.Serialize(thread, SessionJsonOptions.Default),
-            JsonSerializer.Serialize(clone, SessionJsonOptions.Default));
+            JsonSerializer.Serialize(thread.Source, SessionJsonOptions.Default),
+            JsonSerializer.Serialize(loaded.Source, SessionJsonOptions.Default));
+        var summary = Assert.Single(await _store.LoadIndexAsync(), item => item.Id == thread.Id);
+        Assert.Equal(
+            JsonSerializer.Serialize(thread.Source, SessionJsonOptions.Default),
+            JsonSerializer.Serialize(summary.Source, SessionJsonOptions.Default));
+    }
 
-        clone.Metadata["custom"] = "after";
-        clone.Turns[0].Items[0].Payload = new UserMessagePayload { Text = "changed" };
+    [Fact]
+    public async Task SaveThread_SpawnedUserSource_RoundTrips()
+    {
+        var thread = CreateThread();
+        thread.Source = ThreadSource.SpawnedFromThread("thread_parent");
 
-        Assert.Equal("before", thread.Metadata["custom"]);
-        Assert.Equal("hello", Assert.IsType<UserMessagePayload>(thread.Turns[0].Items[0].Payload).Text);
+        await _store.SaveThreadAsync(thread);
+
+        var loaded = Assert.IsType<SessionThread>(await _store.LoadThreadAsync(thread.Id));
+        Assert.Equal(ThreadSourceKinds.User, loaded.Source.Kind);
+        Assert.Equal("thread_parent", loaded.Source.SpawnedFromThreadId);
+        Assert.Null(loaded.Source.SubAgent);
+    }
+
+    [Fact]
+    public async Task SaveThread_WhenSourceChanges_AppendsNewCanonicalBaseline()
+    {
+        var thread = CreateThread();
+        await _store.SaveThreadAsync(thread);
+        thread.Source = ThreadSource.SpawnedFromThread("thread_parent");
+
+        await _store.SaveThreadAsync(thread);
+
+        var records = await File.ReadAllLinesAsync(GetCanonicalPath(thread.Id, archived: false));
+        Assert.Equal(2, records.Count(line => line.Contains("\"kind\":\"thread_opened\"", StringComparison.Ordinal)));
+        var loaded = Assert.IsType<SessionThread>(await _store.LoadThreadAsync(thread.Id));
+        Assert.Equal("thread_parent", loaded.Source.SpawnedFromThreadId);
+    }
+
+    [Fact]
+    public async Task LoadThread_UnknownSourceSchema_FailsExplicitly()
+    {
+        var thread = CreateThread();
+        await _store.SaveThreadAsync(thread);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        var lines = await File.ReadAllLinesAsync(path);
+        var header = JsonNode.Parse(lines[0])!.AsObject();
+        header["threadOpened"]!["source"]!["schemaVersion"] = 99;
+        lines[0] = header.ToJsonString(SessionJsonOptions.Default);
+        await File.WriteAllLinesAsync(path, lines);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => new ThreadStore(_root).LoadThreadAsync(thread.Id));
+    }
+
+    [Fact]
+    public async Task Projection_WhenAttachmentUpdateFails_DoesNotAdvanceOffsetAndRepairsLater()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "request", "answer");
+        await _store.SaveThreadAsync(thread);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        long confirmedBefore;
+        using (var connection = OpenStateConnection())
+        {
+            using var read = connection.CreateCommand();
+            read.CommandText = "SELECT projected_rollout_offset FROM threads WHERE thread_id = $id";
+            read.Parameters.AddWithValue("$id", thread.Id);
+            confirmedBefore = (long)read.ExecuteScalar()!;
+
+            using var trigger = connection.CreateCommand();
+            trigger.CommandText = """
+                CREATE TRIGGER fail_thread_attachment_projection
+                BEFORE INSERT ON thread_attachments
+                BEGIN
+                    SELECT RAISE(ABORT, 'injected attachment projection failure');
+                END;
+                """;
+            trigger.ExecuteNonQuery();
+        }
+
+        var imageDir = Path.Combine(_root, "attachments", "images");
+        Directory.CreateDirectory(imageDir);
+        var imagePath = Path.Combine(imageDir, "projection.png");
+        await File.WriteAllBytesAsync(imagePath, [1, 2, 3]);
+        var user = Assert.IsType<UserMessagePayload>(thread.Turns[0].Input!.Payload);
+        thread.Turns[0].Input!.Payload = user with
+        {
+            MaterializedInputParts = [new SessionWireInputPart { Type = "localImage", Path = imagePath }]
+        };
+        await _store.SaveThreadAsync(thread);
+
+        using (var connection = OpenStateConnection())
+        {
+            using var read = connection.CreateCommand();
+            read.CommandText = "SELECT projected_rollout_offset FROM threads WHERE thread_id = $id";
+            read.Parameters.AddWithValue("$id", thread.Id);
+            Assert.Equal(confirmedBefore, (long)read.ExecuteScalar()!);
+
+            using var drop = connection.CreateCommand();
+            drop.CommandText = "DROP TRIGGER fail_thread_attachment_projection";
+            drop.ExecuteNonQuery();
+        }
+
+        await _store.LoadIndexAsync();
+
+        using (var connection = OpenStateConnection())
+        {
+            using var read = connection.CreateCommand();
+            read.CommandText = """
+                SELECT projected_rollout_offset,
+                       (SELECT COUNT(*) FROM thread_attachments WHERE thread_id = $id)
+                FROM threads
+                WHERE thread_id = $id
+                """;
+            read.Parameters.AddWithValue("$id", thread.Id);
+            using var reader = read.ExecuteReader();
+            Assert.True(reader.Read());
+            Assert.Equal(new FileInfo(path).Length, reader.GetInt64(0));
+            Assert.Equal(1, reader.GetInt64(1));
+        }
+    }
+
+    [Fact]
+    public async Task LoadIndex_ReadRepair_DoesNotOverwriteAuthoritativeGoal()
+    {
+        var thread = CreateThread();
+        await _store.SaveThreadAsync(thread);
+        var goal = NewGoal(ThreadGoalStatus.Active) with { ThreadId = thread.Id };
+        await _store.UpsertThreadGoalAsync(goal);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        await File.AppendAllTextAsync(path, "{}" + Environment.NewLine);
+
+        await _store.LoadIndexAsync();
+
+        var restored = await _store.GetThreadGoalAsync(thread.Id);
+        Assert.NotNull(restored);
+        Assert.Equal(goal.GoalId, restored.GoalId);
+        Assert.Equal(goal.Objective, restored.Objective);
+    }
+
+    [Fact]
+    public async Task DeleteThread_WhenRolloutDeleteFails_PreservesDatabaseStateAndAttachments()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "request", "answer");
+        var imageDir = Path.Combine(_root, "attachments", "images");
+        Directory.CreateDirectory(imageDir);
+        var imagePath = Path.Combine(imageDir, "preserved.png");
+        await File.WriteAllBytesAsync(imagePath, [1, 2, 3]);
+        var user = Assert.IsType<UserMessagePayload>(thread.Turns[0].Input!.Payload);
+        thread.Turns[0].Input!.Payload = user with
+        {
+            MaterializedInputParts = [new SessionWireInputPart { Type = "localImage", Path = imagePath }]
+        };
+        await _store.SaveThreadAsync(thread);
+        var goal = NewGoal(ThreadGoalStatus.Active) with { ThreadId = thread.Id };
+        await _store.UpsertThreadGoalAsync(goal);
+        var rolloutPath = GetCanonicalPath(thread.Id, archived: false);
+        var failingStore = new ThreadStore(
+            _root,
+            _store.StateRuntime,
+            (_, _) => throw new IOException("injected rollout delete failure"));
+
+        var error = Assert.Throws<IOException>(() => failingStore.DeleteThread(thread.Id));
+
+        Assert.Contains("injected rollout delete failure", error.Message);
+        Assert.True(File.Exists(rolloutPath));
+        Assert.True(File.Exists(imagePath));
+        Assert.NotNull(await _store.GetThreadGoalAsync(thread.Id));
+        Assert.Contains(await _store.LoadIndexAsync(), summary => summary.Id == thread.Id);
+        await failingStore.DisposeAsync();
     }
 
     [Fact]
@@ -654,7 +833,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_IncludesPairedToolCallAndResult()
+    public async Task LoadOrCreateSessionAsync_IncludesPairedToolCallAndResult()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "before tool", TurnStatus.Failed);
@@ -705,7 +884,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.Equal(
@@ -719,7 +897,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_RestoresToolImageAsStructuredContent()
+    public async Task LoadOrCreateSessionAsync_RestoresToolImageAsStructuredContent()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "inspect", "before tool", TurnStatus.Completed);
@@ -768,7 +946,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.True(session.TryGetInMemoryChatHistory(
@@ -776,8 +953,12 @@ public sealed class ThreadStoreTests : IDisposable
             jsonSerializerOptions: SessionPersistenceJsonOptions.Default));
         var functionResult = Assert.Single(
             history.SelectMany(message => message.Contents).OfType<FunctionResultContent>());
-        var json = Assert.IsType<JsonElement>(functionResult.Result);
-        var modelContents = json.Deserialize<List<AIContent>>(SessionPersistenceJsonOptions.Default);
+        var modelContents = functionResult.Result switch
+        {
+            IList<AIContent> contents => contents.ToList(),
+            JsonElement json => json.Deserialize<List<AIContent>>(SessionPersistenceJsonOptions.Default),
+            _ => null
+        };
         Assert.NotNull(modelContents);
         Assert.IsType<TextContent>(modelContents![0]);
         Assert.IsType<DataContent>(modelContents[1]);
@@ -786,7 +967,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_ReplaysHostedImageGenerationAsAssistantContent()
+    public async Task LoadOrCreateSessionAsync_ReplaysHostedImageGenerationAsAssistantContent()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "before image", TurnStatus.Completed);
@@ -835,7 +1016,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.True(session.TryGetInMemoryChatHistory(
@@ -854,7 +1034,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_ReplaysImageGenerationItemAsAssistantContent()
+    public async Task LoadOrCreateSessionAsync_ReplaysImageGenerationItemAsAssistantContent()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "before image", TurnStatus.Completed);
@@ -880,7 +1060,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.True(session.TryGetInMemoryChatHistory(
@@ -899,7 +1078,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_SubAgentMailboxUserItem_ReplaysAsUserMessage()
+    public async Task LoadOrCreateSessionAsync_SubAgentMailboxUserItem_ReplaysAsUserMessage()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "before mailbox", TurnStatus.Completed);
@@ -923,7 +1102,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.Equal(
@@ -936,7 +1114,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_EmptyToolArgumentsBecomeEmptyDictionary()
+    public async Task LoadOrCreateSessionAsync_EmptyToolArgumentsBecomeEmptyDictionary()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "before tool", TurnStatus.Failed);
@@ -975,7 +1153,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.True(session.TryGetInMemoryChatHistory(
@@ -990,7 +1167,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_MergesReasoningTextAndToolCallIntoOneAssistantMessage()
+    public async Task LoadOrCreateSessionAsync_MergesReasoningTextAndToolCallIntoOneAssistantMessage()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "I will inspect.");
@@ -1039,7 +1216,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await new ThreadStore(_root).LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.Equal(
@@ -1134,7 +1310,7 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task RebuildAndSaveSessionFromThreadAsync_SkipsDanglingToolPairs()
+    public async Task LoadOrCreateSessionAsync_SkipsDanglingToolPairs()
     {
         var thread = CreateThread();
         AddTurnWithMessages(thread, "hello", "before", TurnStatus.Failed);
@@ -1173,7 +1349,6 @@ public sealed class ThreadStoreTests : IDisposable
         await _store.SaveThreadAsync(thread);
 
         var agent = CreateAgent();
-        await _store.RebuildAndSaveSessionFromThreadAsync(agent, thread.Id);
         var session = await _store.LoadOrCreateSessionAsync(agent, thread.Id);
 
         Assert.Equal(["user:hello", "assistant:before"], FormatHistoryWithContents(session));
@@ -1397,15 +1572,64 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task LoadIndex_IgnoresThreadSessionsStoredInDb()
+    public async Task LoadIndex_WhenProjectionRowIsMissing_RepairsFromRolloutImmediately()
     {
         var thread = CreateThread();
+        thread.DisplayName = "Recovered thread";
+        AddTurnWithMessages(thread, "first request", "answer");
         await _store.SaveThreadAsync(thread);
-        InsertThreadSession(thread.Id, """{"chatHistory":[],"type":"chatHistory"}""");
+        var path = GetCanonicalPath(thread.Id, archived: false);
 
-        var index = await _store.LoadIndexAsync();
-        Assert.Single(index);
-        Assert.Equal(thread.Id, index[0].Id);
+        using (var connection = OpenStateConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "DELETE FROM threads WHERE thread_id = $thread_id";
+            command.Parameters.AddWithValue("$thread_id", thread.Id);
+            command.ExecuteNonQuery();
+        }
+
+        var summary = Assert.Single(await _store.LoadIndexAsync());
+        Assert.Equal(thread.Id, summary.Id);
+        Assert.Equal("Recovered thread", summary.DisplayName);
+        Assert.Equal(1, summary.TurnCount);
+
+        using var repairedConnection = OpenStateConnection();
+        using var repairedCommand = repairedConnection.CreateCommand();
+        repairedCommand.CommandText = "SELECT projected_rollout_offset FROM threads WHERE thread_id = $thread_id";
+        repairedCommand.Parameters.AddWithValue("$thread_id", thread.Id);
+        Assert.Equal(new FileInfo(path).Length, (long)repairedCommand.ExecuteScalar()!);
+    }
+
+    [Fact]
+    public async Task LoadIndex_WhenProjectionOffsetIsStale_RebuildsLatestMetadata()
+    {
+        var thread = CreateThread();
+        thread.DisplayName = "Latest name";
+        AddTurnWithMessages(thread, "first request", "answer");
+        await _store.SaveThreadAsync(thread);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+
+        using (var connection = OpenStateConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                UPDATE threads
+                SET display_name = 'stale name', turn_count = 0, projected_rollout_offset = 0
+                WHERE thread_id = $thread_id
+                """;
+            command.Parameters.AddWithValue("$thread_id", thread.Id);
+            command.ExecuteNonQuery();
+        }
+
+        var summary = Assert.Single(await _store.LoadIndexAsync());
+        Assert.Equal("Latest name", summary.DisplayName);
+        Assert.Equal(1, summary.TurnCount);
+
+        using var repairedConnection = OpenStateConnection();
+        using var repairedCommand = repairedConnection.CreateCommand();
+        repairedCommand.CommandText = "SELECT projected_rollout_offset FROM threads WHERE thread_id = $thread_id";
+        repairedCommand.Parameters.AddWithValue("$thread_id", thread.Id);
+        Assert.Equal(new FileInfo(path).Length, (long)repairedCommand.ExecuteScalar()!);
     }
 
     [Fact]
@@ -1422,24 +1646,6 @@ public sealed class ThreadStoreTests : IDisposable
 
         Assert.Equal(
             ["user:hello", "assistant:world"],
-            await ExtractHistoryAsync(agent, session));
-    }
-
-    [Fact]
-    public async Task LoadOrCreateSessionAsync_WhenSessionRowIsInvalid_FallsBackToRolloutHistory()
-    {
-        var thread = CreateThread();
-        AddTurnWithMessages(thread, "Need context", "Here is the context.");
-        await _store.SaveThreadAsync(thread);
-        InsertInvalidThreadSession(thread.Id, "{not valid json");
-
-        var store = new ThreadStore(_root);
-        var agent = CreateAgent();
-
-        var session = await store.LoadOrCreateSessionAsync(agent, thread.Id);
-
-        Assert.Equal(
-            ["user:Need context", "assistant:Here is the context."],
             await ExtractHistoryAsync(agent, session));
     }
 
@@ -1504,6 +1710,268 @@ public sealed class ThreadStoreTests : IDisposable
         Assert.Equal(
             ["assistant:compacted summary", "user:recent request", "assistant:recent answer"],
             await ExtractHistoryAsync(CreateAgent(), session));
+    }
+
+    [Fact]
+    public async Task ReplayModelHistory_WithLargeCoveredPrefix_ReadsOnlyCheckpointTail()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "old request", new string('x', 512 * 1024));
+        AddTurnWithMessages(thread, "recent request", "recent projected answer");
+        await _store.SaveThreadAsync(thread);
+        await _store.AppendCompactionCheckpointAsync(
+            thread.Id,
+            thread.Turns[0].Id,
+            [new ChatMessage(ChatRole.Assistant, "compacted summary")],
+            "manual",
+            "partial",
+            1000,
+            100);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.User, "recent exact request"), new ChatMessage(ChatRole.Assistant, "recent exact answer")],
+            thread.Turns[1].Id);
+
+        var replay = await new ThreadRolloutStore(_root).ReplayModelHistoryAsync(thread.Id, thread);
+        var pathLength = new FileInfo(GetCanonicalPath(thread.Id, archived: false)).Length;
+
+        Assert.Equal(
+            ["compacted summary", "recent exact request", "recent exact answer"],
+            replay.Messages.Select(static message => message.Text));
+        Assert.True(replay.BytesRead < pathLength / 2, $"Expected bounded tail scan, read {replay.BytesRead} of {pathLength} bytes.");
+        Assert.InRange(replay.RecordsDecoded, 2, 3);
+    }
+
+    [Fact]
+    public async Task ReplayModelHistory_InvalidBatchFallsBackWholeTurnAndPreservesOtherExactTurns()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "projected first request", "projected first answer");
+        AddTurnWithMessages(thread, "projected second request", "projected second answer");
+        await _store.SaveThreadAsync(thread);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.User, "exact first request"), new ChatMessage(ChatRole.Assistant, "exact first answer")],
+            thread.Turns[0].Id);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.User, "exact second request"), new ChatMessage(ChatRole.Assistant, "exact second answer")],
+            thread.Turns[1].Id);
+
+        var invalidBatch = new
+        {
+            kind = "model_history_messages_appended",
+            timestamp = DateTimeOffset.UtcNow,
+            modelHistoryMessagesAppended = new
+            {
+                threadId = thread.Id,
+                turnId = thread.Turns[0].Id,
+                messages = new[]
+                {
+                    new { schemaVersion = 99, turnId = thread.Turns[0].Id, role = "assistant", contents = Array.Empty<object>() }
+                }
+            }
+        };
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        await File.AppendAllTextAsync(path, JsonSerializer.Serialize(invalidBatch, SessionJsonOptions.Default) + Environment.NewLine);
+
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(path, thread.Turns);
+
+        Assert.Equal(
+            ["projected first request", "projected first answer", "exact second request", "exact second answer"],
+            replay.Messages.Select(static message => message.Text));
+        Assert.Equal(1, replay.RejectedRecords);
+        Assert.Contains(thread.Turns[0].Id, Assert.IsAssignableFrom<IReadOnlySet<string>>(replay.FallbackTurnIds));
+        Assert.DoesNotContain(thread.Turns[1].Id, replay.FallbackTurnIds!);
+        Assert.Contains(replay.Warnings!, warning =>
+            warning.Code == "invalid_model_batch" && warning.TurnId == thread.Turns[0].Id);
+    }
+
+    [Fact]
+    public async Task ReplayModelHistory_ConflictingToolIdentityFallsBackWholeTurn()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "projected first request", "projected first answer");
+        AddTurnWithMessages(thread, "projected second request", "projected second answer");
+        await _store.SaveThreadAsync(thread);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.User, "exact first request")],
+            thread.Turns[0].Id);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.User, "exact second request")],
+            thread.Turns[1].Id);
+
+        var conflictingBatch = new
+        {
+            kind = "model_history_messages_appended",
+            timestamp = DateTimeOffset.UtcNow,
+            modelHistoryMessagesAppended = new
+            {
+                threadId = thread.Id,
+                turnId = thread.Turns[0].Id,
+                messages = new[]
+                {
+                    new
+                    {
+                        schemaVersion = 1,
+                        turnId = thread.Turns[0].Id,
+                        role = "assistant",
+                        contents = new[]
+                        {
+                            new
+                            {
+                                kind = "function_call",
+                                payload = new
+                                {
+                                    callId = "call_conflict",
+                                    name = "read_file",
+                                    arguments = new { path = "sample.txt" },
+                                    informationalOnly = false,
+                                    @namespace = "tools",
+                                    providerFlatName = (string?)null,
+                                    additionalProperties = new Dictionary<string, object?>
+                                    {
+                                        ["openai.responses.function_call.namespace"] = "different"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        await File.AppendAllTextAsync(
+            path,
+            JsonSerializer.Serialize(conflictingBatch, SessionJsonOptions.Default) + Environment.NewLine);
+
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(path, thread.Turns);
+
+        Assert.Equal(
+            ["projected first request", "projected first answer", "exact second request"],
+            replay.Messages.Select(static message => message.Text));
+        Assert.Equal(1, replay.RejectedRecords);
+        Assert.Contains(thread.Turns[0].Id, Assert.IsAssignableFrom<IReadOnlySet<string>>(replay.FallbackTurnIds));
+        Assert.Contains(replay.Warnings!, warning =>
+            warning.Code == "invalid_model_batch" && warning.TurnId == thread.Turns[0].Id);
+    }
+
+    [Fact]
+    public async Task ReplayModelHistory_MalformedOrdinaryLineReportsWarningAndContinues()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "projected request", "projected answer");
+        await _store.SaveThreadAsync(thread);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.User, "exact request"), new ChatMessage(ChatRole.Assistant, "exact answer")],
+            thread.Turns[0].Id);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        await File.AppendAllTextAsync(path, "{ invalid json" + Environment.NewLine);
+
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(path, thread.Turns);
+
+        Assert.Equal(["exact request", "exact answer"], replay.Messages.Select(static message => message.Text));
+        Assert.Equal(1, replay.RejectedRecords);
+        Assert.Contains(replay.Warnings!, warning => warning.Code == "malformed_json");
+    }
+
+    [Fact]
+    public async Task LoadOrCreateSessionAsync_WhenCoveredTurnHasPostCheckpointSuffix_AppendsThatSuffix()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "raw request", "raw answer");
+        await _store.SaveThreadAsync(thread);
+        await _store.AppendCompactionCheckpointAsync(
+            thread.Id,
+            thread.Turns[0].Id,
+            [new ChatMessage(ChatRole.Assistant, "compacted summary")],
+            "auto",
+            "partial",
+            1000,
+            100);
+        await _store.AppendModelHistoryAsync(
+            thread.Id,
+            [new ChatMessage(ChatRole.Assistant, "same-turn suffix")],
+            thread.Turns[0].Id);
+
+        var session = await new ThreadStore(_root).LoadOrCreateSessionAsync(CreateAgent(), thread.Id);
+
+        Assert.Equal(
+            ["assistant:compacted summary", "assistant:same-turn suffix"],
+            await ExtractHistoryAsync(CreateAgent(), session));
+    }
+
+    [Fact]
+    public async Task LoadOrCreateSessionAsync_WhenNewestCheckpointSchemaIsUnsupported_UsesOlderCheckpoint()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "seed", "answer");
+        await _store.SaveThreadAsync(thread);
+        await _store.AppendCompactionCheckpointAsync(
+            thread.Id,
+            thread.Turns[0].Id,
+            [new ChatMessage(ChatRole.Assistant, "older valid summary")],
+            "manual",
+            "partial",
+            1000,
+            100);
+        var unsupportedCheckpoint = new
+        {
+            kind = "context_compacted",
+            timestamp = DateTimeOffset.UtcNow,
+            contextCompacted = new
+            {
+                threadId = thread.Id,
+                coveredThroughTurnId = thread.Turns[0].Id,
+                checkpointId = "unsupported_checkpoint",
+                trigger = "manual",
+                mode = "partial",
+                tokensBefore = 1000,
+                tokensAfter = 100,
+                createdAt = DateTimeOffset.UtcNow,
+                replacementHistory = new[]
+                {
+                    new
+                    {
+                        schemaVersion = 2,
+                        role = "assistant",
+                        contents = Array.Empty<object>()
+                    }
+                }
+            }
+        };
+        await File.AppendAllTextAsync(
+            GetCanonicalPath(thread.Id, archived: false),
+            JsonSerializer.Serialize(unsupportedCheckpoint, SessionJsonOptions.Default) + Environment.NewLine);
+
+        var session = await new ThreadStore(_root).LoadOrCreateSessionAsync(CreateAgent(), thread.Id);
+
+        Assert.Equal(
+            ["assistant:older valid summary"],
+            await ExtractHistoryAsync(CreateAgent(), session));
+    }
+
+    [Fact]
+    public async Task SaveTurnAsync_AppendsSingleAtomicReplacement_AndColdReplayUsesIt()
+    {
+        var thread = CreateThread();
+        await _store.SaveThreadAsync(thread);
+        AddTurnWithMessages(thread, "atomic request", "atomic answer");
+        var turn = Assert.Single(thread.Turns);
+        thread.LastActiveAt = turn.CompletedAt ?? turn.StartedAt;
+
+        await _store.SaveTurnAsync(thread, turn);
+
+        var records = File.ReadAllLines(GetCanonicalPath(thread.Id, archived: false));
+        Assert.Single(records, line => line.Contains("\"kind\":\"turn_state_replaced\"", StringComparison.Ordinal));
+        var loaded = await new ThreadStore(_root).LoadThreadAsync(thread.Id);
+        var loadedTurn = Assert.Single(Assert.IsType<SessionThread>(loaded).Turns);
+        Assert.Equal(TurnStatus.Completed, loadedTurn.Status);
+        Assert.Equal("atomic request", loadedTurn.Input?.AsUserMessage?.Text);
+        Assert.Equal("atomic answer", loadedTurn.Items.Last().AsAgentMessage?.Text);
     }
 
     [Fact]
@@ -1616,18 +2084,6 @@ public sealed class ThreadStoreTests : IDisposable
             "partial",
             10_000,
             100);
-        var agent = CreateAgent();
-        await _store.SaveSessionFromHistoryAsync(
-            agent,
-            thread.Id,
-            [
-                .. replacementHistory,
-                new ChatMessage(ChatRole.User, "after compact"),
-                new ChatMessage(ChatRole.Assistant, "after answer")
-            ]);
-        Assert.True(_store.SessionFileExists(thread.Id));
-        _store.DeleteSessionFile(thread.Id);
-
         var session = await new ThreadStore(_root).LoadOrCreateSessionAsync(CreateAgent(), thread.Id);
 
         Assert.Equal(
@@ -1777,11 +2233,8 @@ public sealed class ThreadStoreTests : IDisposable
 
     private static SessionThread CloneThreadSnapshotForTest(SessionThread thread)
     {
-        var method = typeof(ThreadStore).GetMethod(
-            "CloneThreadSnapshot",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-        return (SessionThread)method.Invoke(null, [thread])!;
+        var json = JsonSerializer.Serialize(thread, SessionJsonOptions.Default);
+        return JsonSerializer.Deserialize<SessionThread>(json, SessionJsonOptions.Default)!;
     }
 
     private static AIAgent CreateAgent()
@@ -1893,37 +2346,6 @@ public sealed class ThreadStoreTests : IDisposable
 
     private string GetCanonicalPath(string threadId, bool archived)
         => Path.Combine(_root, "threads", archived ? "archived" : "active", $"{threadId}.jsonl");
-
-    private void InsertThreadSession(string threadId, string sessionJson)
-    {
-        using var connection = OpenStateConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO thread_sessions(thread_id, session_json, updated_at)
-            VALUES ($thread_id, $session_json, $updated_at)
-            """;
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.Parameters.AddWithValue("$session_json", sessionJson);
-        command.Parameters.AddWithValue("$updated_at", DateTimeOffset.UtcNow.UtcDateTime.ToString("O"));
-        command.ExecuteNonQuery();
-    }
-
-    private void InsertInvalidThreadSession(string threadId, string sessionJson)
-    {
-        using var connection = OpenStateConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO thread_sessions(thread_id, session_json, updated_at)
-            VALUES ($thread_id, $session_json, $updated_at)
-            ON CONFLICT(thread_id) DO UPDATE SET
-                session_json = excluded.session_json,
-                updated_at = excluded.updated_at
-            """;
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.Parameters.AddWithValue("$session_json", sessionJson);
-        command.Parameters.AddWithValue("$updated_at", DateTimeOffset.UtcNow.UtcDateTime.ToString("O"));
-        command.ExecuteNonQuery();
-    }
 
     private SqliteConnection OpenStateConnection()
     {

--- a/tests/DotCraft.Core.Tests/Protocol/ThreadStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/ThreadStoreTests.cs
@@ -54,6 +54,27 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task RolloutPaths_ForSanitizedNameCollisions_AreDistinct()
+    {
+        var first = CreateThread();
+        first.Id = "a:b";
+        var second = CreateThread();
+        second.Id = "ab";
+
+        await _store.SaveThreadAsync(first);
+        await _store.SaveThreadAsync(second);
+
+        var rolloutStore = new ThreadRolloutStore(_root);
+        var firstPath = rolloutStore.GetExpectedPath(first.Id, archived: false);
+        var secondPath = rolloutStore.GetExpectedPath(second.Id, archived: false);
+        Assert.NotEqual(firstPath, secondPath);
+        Assert.True(File.Exists(firstPath));
+        Assert.True(File.Exists(secondPath));
+        Assert.Equal(first.Id, (await _store.LoadThreadAsync(first.Id))?.Id);
+        Assert.Equal(second.Id, (await _store.LoadThreadAsync(second.Id))?.Id);
+    }
+
+    [Fact]
     public async Task SaveThread_CompleteSubAgentSource_RoundTripsThroughRolloutAndIndex()
     {
         var thread = CreateThread();
@@ -1859,6 +1880,51 @@ public sealed class ThreadStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReplayModelHistory_CrossThreadBatchFallsBackToCanonicalTurn()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "projected request", "projected answer");
+        await _store.SaveThreadAsync(thread);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        var foreignBatch = new
+        {
+            kind = "model_history_messages_appended",
+            timestamp = DateTimeOffset.UtcNow,
+            modelHistoryMessagesAppended = new
+            {
+                threadId = "different-thread",
+                turnId = thread.Turns[0].Id,
+                messages = new[]
+                {
+                    new
+                    {
+                        schemaVersion = 1,
+                        turnId = thread.Turns[0].Id,
+                        role = "assistant",
+                        contents = new[]
+                        {
+                            new { kind = "text", payload = new { text = "foreign answer" } }
+                        }
+                    }
+                }
+            }
+        };
+        await File.AppendAllTextAsync(
+            path,
+            JsonSerializer.Serialize(foreignBatch, SessionJsonOptions.Default) + Environment.NewLine);
+
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(
+            path,
+            thread.Turns,
+            expectedThreadId: thread.Id);
+
+        Assert.Equal(["projected request", "projected answer"], replay.Messages.Select(static message => message.Text));
+        Assert.Contains(replay.Warnings!, warning =>
+            warning.Code == "cross_thread_record" && warning.TurnId == thread.Turns[0].Id);
+        Assert.Contains(thread.Turns[0].Id, Assert.IsAssignableFrom<IReadOnlySet<string>>(replay.FallbackTurnIds));
+    }
+
+    [Fact]
     public async Task ReplayModelHistory_MalformedOrdinaryLineReportsWarningAndContinues()
     {
         var thread = CreateThread();
@@ -1876,6 +1942,62 @@ public sealed class ThreadStoreTests : IDisposable
         Assert.Equal(["exact request", "exact answer"], replay.Messages.Select(static message => message.Text));
         Assert.Equal(1, replay.RejectedRecords);
         Assert.Contains(replay.Warnings!, warning => warning.Code == "malformed_json");
+    }
+
+    [Fact]
+    public async Task ReplayModelHistory_NullMessagesFallsBackWholeTurnAndContinues()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "projected request", "projected answer");
+        await _store.SaveThreadAsync(thread);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        var invalidBatch = new
+        {
+            kind = "model_history_messages_appended",
+            timestamp = DateTimeOffset.UtcNow,
+            modelHistoryMessagesAppended = new
+            {
+                threadId = thread.Id,
+                turnId = thread.Turns[0].Id,
+                messages = (object?)null
+            }
+        };
+        await File.AppendAllTextAsync(path, JsonSerializer.Serialize(invalidBatch, SessionJsonOptions.Default) + Environment.NewLine);
+
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(path, thread.Turns);
+
+        Assert.Equal(["projected request", "projected answer"], replay.Messages.Select(static message => message.Text));
+        Assert.Equal(1, replay.RejectedRecords);
+        Assert.Contains(thread.Turns[0].Id, replay.FallbackTurnIds!);
+        Assert.Contains(replay.Warnings!, warning => warning.Code == "invalid_model_batch");
+    }
+
+    [Fact]
+    public async Task ReplayModelHistory_InconsistentEnvelopeFallsBackWholeTurn()
+    {
+        var thread = CreateThread();
+        AddTurnWithMessages(thread, "projected request", "projected answer");
+        await _store.SaveThreadAsync(thread);
+        var path = GetCanonicalPath(thread.Id, archived: false);
+        var inconsistentRecord = new
+        {
+            kind = "model_history_messages_appended",
+            timestamp = DateTimeOffset.UtcNow,
+            contextCompacted = new
+            {
+                threadId = thread.Id,
+                coveredThroughTurnId = thread.Turns[0].Id,
+                replacementHistory = Array.Empty<object>()
+            }
+        };
+        await File.AppendAllTextAsync(path, JsonSerializer.Serialize(inconsistentRecord, SessionJsonOptions.Default) + Environment.NewLine);
+
+        var replay = await new RolloutReplayer().ReplayModelHistoryAsync(path, thread.Turns);
+
+        Assert.Equal(["projected request", "projected answer"], replay.Messages.Select(static message => message.Text));
+        Assert.Equal(1, replay.RejectedRecords);
+        Assert.Contains(thread.Turns[0].Id, replay.FallbackTurnIds!);
+        Assert.Contains(replay.Warnings!, warning => warning.Code == "malformed_record");
     }
 
     [Fact]

--- a/tests/DotCraft.Core.Tests/Tools/BackgroundTerminalServiceTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/BackgroundTerminalServiceTests.cs
@@ -243,6 +243,67 @@ public sealed class BackgroundTerminalServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task CleanThreadAsync_StopsActiveTerminalButPreservesArtifacts()
+    {
+        var started = await Service.StartAsync(new BackgroundTerminalStartRequest
+        {
+            ThreadId = "thread_archive",
+            Command = SleepCommand(),
+            WorkingDirectory = _tempDir,
+            RunInBackground = true,
+            YieldTimeMs = 100,
+            MaxOutputChars = 1000
+        });
+
+        await WaitForFileAsync(Path.ChangeExtension(started.OutputPath, ".json"));
+        await Service.CleanThreadAsync("thread_archive");
+
+        Assert.True(File.Exists(Path.ChangeExtension(started.OutputPath, ".json")));
+    }
+
+    [Fact]
+    public async Task DeleteThreadArtifactsAsync_StopsAndRemovesCurrentThreadDirectory()
+    {
+        var started = await Service.StartAsync(new BackgroundTerminalStartRequest
+        {
+            ThreadId = "thread:with-invalid-path",
+            Command = EchoCommand("delete-me"),
+            WorkingDirectory = _tempDir,
+            MaxOutputChars = 1000
+        });
+
+        var failures = await Service.DeleteThreadArtifactsAsync("thread:with-invalid-path");
+
+        Assert.Empty(failures);
+        Assert.False(File.Exists(started.OutputPath));
+        Assert.Empty(await Service.ListAsync("thread:with-invalid-path"));
+        Assert.Equal(
+            "thread-" + Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes("thread:with-invalid-path"))).ToLowerInvariant(),
+            BackgroundTerminalService.GetCanonicalThreadDirectoryName("thread:with-invalid-path"));
+    }
+
+    [Fact]
+    public async Task CleanupExpiredArtifactsAsync_DoesNotRemoveActiveTerminal()
+    {
+        var started = await Service.StartAsync(new BackgroundTerminalStartRequest
+        {
+            ThreadId = "thread_retention",
+            Command = SleepCommand(),
+            WorkingDirectory = _tempDir,
+            RunInBackground = true,
+            YieldTimeMs = 100,
+            MaxOutputChars = 1000
+        });
+
+        await WaitForFileAsync(Path.ChangeExtension(started.OutputPath, ".json"));
+        var removed = await Service.CleanupExpiredArtifactsAsync();
+
+        Assert.Equal(0, removed);
+        Assert.True(File.Exists(Path.ChangeExtension(started.OutputPath, ".json")));
+        await Service.StopAsync(started.SessionId);
+    }
+
+    [Fact]
     public async Task Constructor_MarksPersistedRunningSessionsAsLost()
     {
         var started = await Service.StartAsync(new BackgroundTerminalStartRequest
@@ -296,6 +357,15 @@ public sealed class BackgroundTerminalServiceTests : IAsyncLifetime
         OperatingSystem.IsWindows()
             ? $"Write-Output {QuotePowerShell(text)}; Start-Sleep -Seconds 5"
             : $"echo {QuoteBash(text)}; sleep 5";
+
+    private static async Task WaitForFileAsync(string path)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!File.Exists(path) && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(20);
+
+        Assert.True(File.Exists(path), $"Expected artifact file to be created: {path}");
+    }
 
     private static async Task<string> ReadUntilContainsAsync(
         string path,

--- a/tests/DotCraft.Core.Tests/Tools/ShellToolsCommandExecutionTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/ShellToolsCommandExecutionTests.cs
@@ -283,5 +283,13 @@ public sealed class ShellToolsCommandExecutionTests : IDisposable
             string threadId,
             CancellationToken ct = default) =>
             throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> DeleteThreadArtifactsAsync(
+            string threadId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<int> CleanupExpiredArtifactsAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/DotCraft.Core.Tests/Tools/ToolResultProcessorTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/ToolResultProcessorTests.cs
@@ -56,7 +56,7 @@ public class ToolResultProcessorTests
 
             var spillDir = Path.Combine(workspace, ".craft", "tool-results", "thread-1");
             Assert.True(Directory.Exists(spillDir));
-            var files = Directory.GetFiles(spillDir, "GrepFiles_*.txt");
+            var files = Directory.GetFiles(spillDir, "GrepFiles_call-*.txt");
             Assert.Single(files);
             Assert.Equal(text, File.ReadAllText(files[0]));
         }
@@ -82,7 +82,7 @@ public class ToolResultProcessorTests
             Assert.True(r.Length <= limit + 200, $"Preview length {r.Length} should not far exceed limit + footer.");
 
             var spillDir = Path.Combine(workspace, ".craft", "tool-results", "s1");
-            var files = Directory.GetFiles(spillDir, "Exec_*.txt");
+            var files = Directory.GetFiles(spillDir, "Exec_call-*.txt");
             Assert.Single(files);
             Assert.Equal(text, File.ReadAllText(files[0]));
         }
@@ -149,6 +149,59 @@ public class ToolResultProcessorTests
         var expectedTail = string.Join("\n", new[] { longLine, longLine });
         Assert.Equal(expectedHead, headPart);
         Assert.Equal(expectedTail, tailPart);
+    }
+
+    [Fact]
+    public void SpillToDisk_WithCallId_IsDeterministicAndIdempotent()
+    {
+        var workspace = Path.Combine(Path.GetTempPath(), "dotcraft-trp-idempotent-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var text = string.Join("\\n", Enumerable.Range(0, 100).Select(i => $"line-{i}"));
+            var first = ToolResultProcessor.SpillToDisk(text, workspace, "thread/one", "GrepFiles", "call/one");
+            var second = ToolResultProcessor.SpillToDisk(text, workspace, "thread/one", "GrepFiles", "call/one");
+
+            Assert.Equal(first, second);
+            var directory = Path.Combine(workspace, ".craft", "tool-results", ThreadArtifactPathResolver.GetCanonicalThreadSegment("thread/one"));
+            var files = Directory.GetFiles(directory);
+            Assert.Single(files);
+            Assert.Equal(text, File.ReadAllText(files[0]));
+        }
+        finally
+        {
+            try { Directory.Delete(workspace, recursive: true); } catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public void CanonicalThreadSegment_DoesNotCollideForSanitizedIds()
+    {
+        var first = ThreadArtifactPathResolver.GetCanonicalThreadSegment("a/b");
+        var second = ThreadArtifactPathResolver.GetCanonicalThreadSegment("a\\b");
+
+        Assert.StartsWith("thread-", first, StringComparison.Ordinal);
+        Assert.StartsWith("thread-", second, StringComparison.Ordinal);
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void CleanupThreadArtifacts_IsIdempotent()
+    {
+        var workspace = Path.Combine(Path.GetTempPath(), "dotcraft-trp-cleanup-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            _ = ToolResultProcessor.SpillToDisk("large output", workspace, "thread-cleanup", "Exec", "call-cleanup");
+            var first = ToolResultProcessor.CleanupThreadArtifacts(workspace, "thread-cleanup");
+            var second = ToolResultProcessor.CleanupThreadArtifacts(workspace, "thread-cleanup");
+
+            Assert.Equal(1, first.DirectoriesDeleted);
+            Assert.Equal(0, first.Errors);
+            Assert.Equal(ArtifactCleanupResult.Empty, second);
+        }
+        finally
+        {
+            try { Directory.Delete(workspace, recursive: true); } catch { /* ignore */ }
+        }
     }
 
     [Fact]

--- a/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Tracing/StateBackedStoreTests.cs
@@ -1063,7 +1063,6 @@ public sealed class StateBackedStoreTests : IDisposable
         var thread = CreateThread();
         await threadStore.SaveThreadAsync(thread);
 
-        InsertThreadSession(thread.Id);
         InsertThreadContextUsage(thread.Id);
         tokenUsageStore.Record(CreateUsageRecord(thread.Id, thread.Id));
         tokenUsageStore.Record(CreateUsageRecord(thread.Id, $"{thread.Id}:sub:child1"));
@@ -1086,7 +1085,6 @@ public sealed class StateBackedStoreTests : IDisposable
         await persistence.DeleteThreadCascadeAsync(thread.Id);
 
         Assert.Null(await threadStore.LoadThreadAsync(thread.Id));
-        Assert.False(persistence.SessionFileExists(thread.Id));
         Assert.Null(traceStore.GetSession(thread.Id));
         Assert.Null(traceStore.GetSession($"{thread.Id}:sub:child1"));
         Assert.Equal("unbound", traceStore.DescribeSessionDeletion(thread.Id).BindingKind);
@@ -1102,7 +1100,6 @@ public sealed class StateBackedStoreTests : IDisposable
         eventCommand.CommandText = "SELECT COUNT(*) FROM trace_events WHERE session_key LIKE $session_key";
         eventCommand.Parameters.AddWithValue("$session_key", $"{thread.Id}%");
         Assert.Equal(0L, (long)(eventCommand.ExecuteScalar() ?? 0L));
-        Assert.Equal(0L, CountRows("thread_sessions", $"thread_id = '{thread.Id}'"));
         Assert.Equal(0L, CountRows("thread_context_usage", $"thread_id = '{thread.Id}'"));
         Assert.Equal(0L, CountRows("trace_session_bindings", $"root_thread_id = '{thread.Id}'"));
         Assert.Equal(0L, CountRows("dashboard_usage_records", $"thread_id = '{thread.Id}' OR session_key = '{thread.Id}' OR session_key = '{thread.Id}:sub:child1'"));
@@ -1253,20 +1250,6 @@ public sealed class StateBackedStoreTests : IDisposable
 
         Assert.True(compacted);
         Assert.True(ReadPragmaLong("freelist_count") <= beforeFreelist);
-    }
-
-    private void InsertThreadSession(string threadId)
-    {
-        using var connection = _stateRuntime.OpenConnection();
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO thread_sessions(thread_id, session_json, updated_at)
-            VALUES ($thread_id, $session_json, $updated_at)
-            """;
-        command.Parameters.AddWithValue("$thread_id", threadId);
-        command.Parameters.AddWithValue("$session_json", "{}");
-        command.Parameters.AddWithValue("$updated_at", DateTimeOffset.UtcNow.UtcDateTime.ToString("O"));
-        command.ExecuteNonQuery();
     }
 
     private void InsertThreadContextUsage(string threadId)


### PR DESCRIPTION
## Summary

Introduce the current unified rollout/model-history serialization protocol for sessions.

This hardens replay with thread ownership and path validation, handles malformed records safely, and removes legacy path/schema fallback behavior for the internal development protocol.

Also improves Context Export/Search privacy, read-only state handling, diagnostics resilience, and updates the session architecture specification and tests.
