### PR TITLE
fix(openai): preserve responses history across tool turns

### DIFF
--- a/specs/architecture/responses-provider-history.md
+++ b/specs/architecture/responses-provider-history.md
@@ -2,9 +2,9 @@
 
 | Field | Value |
 |---|---|
-| **Version** | 0.2.0 |
+| **Version** | 0.3.0 |
 | **Status** | Living |
-| **Date** | 2026-07-25 |
+| **Date** | 2026-07-26 |
 | **Parent Specs** | [Session Core](session-core.md), [Prompt Cache](prompt-cache.md), [OpenAI Subscription Auth](openai-subscription-auth.md) |
 
 ## Overview
@@ -75,6 +75,12 @@ agent. The function-invocation wrapper marks MEAI response projections as covere
 its augmented sampling history. This lets the next tool-loop request map only newly appended tool
 results and guidance.
 
+Request-local history sanitization is not a conversation-history replacement. A sanitizer may
+repair an incomplete tool pair or remove content that is invalid for a role in the current request,
+but that projection must not replace, truncate, reorder, or regenerate the canonical Responses
+generation. Object identity or collection shape changes produced by sanitization are never evidence
+that canonical history changed.
+
 The existing Responses mapper remains authoritative for converting local MEAI content, assigning
 locally generated item IDs, and sanitizing invalid IDs. A correlation index derived from canonical
 calls is supplied when mapping a tail so a result for a native tool-search call remains a
@@ -125,6 +131,23 @@ transition set; adding an isolated lock to one method is not sufficient.
 - **Ephemeral threads:** use the same runtime state in memory and persist nothing until normal
   thread-promotion behavior makes the thread durable.
 
+Canonical replacement is an explicit lifecycle transition. Successful compaction, protocol return,
+and fork materialization may create `provider_history_replaced`; request-local sanitization,
+provider adapter normalization, retry preparation, and ordinary tool-loop projection may not.
+
+## MEAI projection boundaries
+
+Responses reasoning output is assistant-authored content even when the provider SDK leaves the
+corresponding MEAI streaming update role unset. Before an update enters a cross-service-call
+aggregate, the Responses adapter assigns it `Assistant` role so a reasoning item following a local
+tool-result update starts a new MEAI message instead of inheriting the `Tool` role.
+
+The provider response-item ID remains content-scoped metadata and is not promoted to
+`ChatMessage.MessageId`. A valid provider ID is preserved on every streamed reasoning fragment and
+on its encrypted completion fragment so MEAI content coalescing, model-history persistence, and
+outbound mapping retain one identity. Missing or invalid item IDs do not suppress the Assistant
+message boundary.
+
 ## Recovery and privacy
 
 Unknown capability versions or malformed records required by the active generation produce the
@@ -139,8 +162,12 @@ durable but must never be copied into diagnostics.
 
 - Consecutive tool-loop and cross-turn Responses requests keep the previous request input as a
   byte-identical prefix and append only completed provider items and new local tail items.
+- Request-local sanitization never emits `provider_history_replaced`; successful compaction emits
+  exactly one replacement for the new context window.
 - Provider IDs, `call_id`, item ordering, and encrypted reasoning bytes survive turn completion,
   cold resume, rollback, and compatible fork.
+- Reasoning emitted after a tool result is projected as Assistant content, while the Tool message
+  contains only the corresponding tool results.
 - Compaction and protocol return establish an explicit, diagnosable prefix boundary.
 - Legacy threads retain their existing Responses wire shape.
 - Anthropic and OpenAI Chat Completions produce the same transport shapes and persistence behavior

--- a/src/DotCraft.Core/ChatClient/ToolCalling/StreamingFunctionInvokingChatClient.cs
+++ b/src/DotCraft.Core/ChatClient/ToolCalling/StreamingFunctionInvokingChatClient.cs
@@ -184,20 +184,22 @@ public sealed class StreamingFunctionInvokingChatClient(IChatClient innerClient,
             if (reachedIterationLimit)
                 PrepareOptionsForLastIteration(ref options);
 
-            var preparedMessages = await PrepareMessagesForSamplingAsync(
+            var preparation = await PrepareMessagesForSamplingAsync(
                 currentMessages,
                 options,
                 cancellationToken);
-            if (!ReferenceEquals(preparedMessages, currentMessages))
+            var preparedMessages = preparation.Messages;
+            if (preparation.CanonicalHistoryWasReplaced && providerHistoryBridge != null)
             {
-                if (providerHistoryBridge != null)
-                {
-                    await providerHistoryBridge.HistoryReplacedAsync(
-                        preparedMessages,
-                        options,
-                        "sampling_history_replaced",
-                        cancellationToken);
-                }
+                await providerHistoryBridge.HistoryReplacedAsync(
+                    preparedMessages,
+                    options,
+                    "compaction",
+                    cancellationToken);
+            }
+            if (preparation.CanonicalHistoryWasReplaced
+                || !ReferenceEquals(preparedMessages, currentMessages))
+            {
                 currentMessages = preparedMessages;
                 originalMessages = preparedMessages.ToList();
                 augmentedHistory = originalMessages.ToList();
@@ -364,7 +366,7 @@ public sealed class StreamingFunctionInvokingChatClient(IChatClient innerClient,
         }
     }
 
-    private static async Task<IReadOnlyList<ChatMessage>> PrepareMessagesForSamplingAsync(
+    private static async Task<SamplingPreparationResult> PrepareMessagesForSamplingAsync(
         IEnumerable<ChatMessage> currentMessages,
         ChatOptions? options,
         CancellationToken cancellationToken)
@@ -372,7 +374,11 @@ public sealed class StreamingFunctionInvokingChatClient(IChatClient innerClient,
         var messages = currentMessages as IReadOnlyList<ChatMessage> ?? currentMessages.ToList();
         var compaction = PreSamplingCompactionRuntimeScope.Current;
         if (compaction == null)
-            return ModelRequestHistorySanitizer.Sanitize(messages);
+        {
+            return new SamplingPreparationResult(
+                ModelRequestHistorySanitizer.Sanitize(messages),
+                CanonicalHistoryWasReplaced: false);
+        }
 
         var snapshotBeforeCompaction = PromptRequestSnapshot.Capture(
             messages,
@@ -399,8 +405,14 @@ public sealed class StreamingFunctionInvokingChatClient(IChatClient innerClient,
             await capture(snapshot, cancellationToken);
         }
 
-        return preparedMessages;
+        return new SamplingPreparationResult(
+            preparedMessages,
+            CanonicalHistoryWasReplaced: replacement != null);
     }
+
+    private readonly record struct SamplingPreparationResult(
+        IReadOnlyList<ChatMessage> Messages,
+        bool CanonicalHistoryWasReplaced);
 
     private static void FixupHistories(
         IEnumerable<ChatMessage> originalMessages,

--- a/src/DotCraft.Core/Providers/OpenAI/OpenAIResponsesToolSearchChatClient.cs
+++ b/src/DotCraft.Core/Providers/OpenAI/OpenAIResponsesToolSearchChatClient.cs
@@ -291,7 +291,19 @@ internal sealed class OpenAIResponsesToolSearchChatClient : IChatClient
 
         public void Apply(ChatResponseUpdate update)
         {
-            if (!TryResolveReasoningItemId(update.RawRepresentation, out var providerItemId))
+            if (!TryGetReasoningEvent(
+                    update.RawRepresentation,
+                    out var outputIndex,
+                    out var eventItemId))
+                return;
+
+            // MEAI does not currently assign a role to Responses reasoning updates.
+            // Give every event in the reasoning item an Assistant boundary so its
+            // summary/protected content cannot be aggregated into a preceding Tool
+            // message. The provider item ID remains content metadata, not MessageId.
+            update.Role = ChatRole.Assistant;
+
+            if (!TryResolveItemId(outputIndex, eventItemId, out var providerItemId))
                 return;
 
             foreach (var reasoning in update.Contents.OfType<TextReasoningContent>())
@@ -335,39 +347,55 @@ internal sealed class OpenAIResponsesToolSearchChatClient : IChatClient
             }
         }
 
-        private bool TryResolveReasoningItemId(
+        private static bool TryGetReasoningEvent(
             object? rawRepresentation,
-            out string resolvedItemId)
+            out int outputIndex,
+            out string? providerItemId)
         {
-            return rawRepresentation switch
+            switch (rawRepresentation)
             {
-                StreamingResponseOutputItemAddedUpdate
+                case StreamingResponseOutputItemAddedUpdate
                 {
                     Item: ReasoningResponseItem item
-                } added => TryResolveItemId(added.OutputIndex, item.Id, out resolvedItemId),
-                StreamingResponseOutputItemDoneUpdate
+                } added:
+                    outputIndex = added.OutputIndex;
+                    providerItemId = item.Id;
+                    return true;
+                case StreamingResponseOutputItemDoneUpdate
                 {
                     Item: ReasoningResponseItem item
-                } done => TryResolveItemId(done.OutputIndex, item.Id, out resolvedItemId),
-                StreamingResponseReasoningSummaryPartAddedUpdate reasoning =>
-                    TryResolveItemId(reasoning.OutputIndex, reasoning.ItemId, out resolvedItemId),
-                StreamingResponseReasoningSummaryPartDoneUpdate reasoning =>
-                    TryResolveItemId(reasoning.OutputIndex, reasoning.ItemId, out resolvedItemId),
-                StreamingResponseReasoningSummaryTextDeltaUpdate reasoning =>
-                    TryResolveItemId(reasoning.OutputIndex, reasoning.ItemId, out resolvedItemId),
-                StreamingResponseReasoningSummaryTextDoneUpdate reasoning =>
-                    TryResolveItemId(reasoning.OutputIndex, reasoning.ItemId, out resolvedItemId),
-                StreamingResponseReasoningTextDeltaUpdate reasoning =>
-                    TryResolveItemId(reasoning.OutputIndex, reasoning.ItemId, out resolvedItemId),
-                StreamingResponseReasoningTextDoneUpdate reasoning =>
-                    TryResolveItemId(reasoning.OutputIndex, reasoning.ItemId, out resolvedItemId),
-                _ => Fail(out resolvedItemId)
-            };
-
-            static bool Fail(out string resolvedItemId)
-            {
-                resolvedItemId = string.Empty;
-                return false;
+                } done:
+                    outputIndex = done.OutputIndex;
+                    providerItemId = item.Id;
+                    return true;
+                case StreamingResponseReasoningSummaryPartAddedUpdate reasoning:
+                    outputIndex = reasoning.OutputIndex;
+                    providerItemId = reasoning.ItemId;
+                    return true;
+                case StreamingResponseReasoningSummaryPartDoneUpdate reasoning:
+                    outputIndex = reasoning.OutputIndex;
+                    providerItemId = reasoning.ItemId;
+                    return true;
+                case StreamingResponseReasoningSummaryTextDeltaUpdate reasoning:
+                    outputIndex = reasoning.OutputIndex;
+                    providerItemId = reasoning.ItemId;
+                    return true;
+                case StreamingResponseReasoningSummaryTextDoneUpdate reasoning:
+                    outputIndex = reasoning.OutputIndex;
+                    providerItemId = reasoning.ItemId;
+                    return true;
+                case StreamingResponseReasoningTextDeltaUpdate reasoning:
+                    outputIndex = reasoning.OutputIndex;
+                    providerItemId = reasoning.ItemId;
+                    return true;
+                case StreamingResponseReasoningTextDoneUpdate reasoning:
+                    outputIndex = reasoning.OutputIndex;
+                    providerItemId = reasoning.ItemId;
+                    return true;
+                default:
+                    outputIndex = default;
+                    providerItemId = null;
+                    return false;
             }
         }
 

--- a/tests/DotCraft.Core.Tests/ChatClient/ToolCalling/StreamingFunctionInvokingChatClientTests.cs
+++ b/tests/DotCraft.Core.Tests/ChatClient/ToolCalling/StreamingFunctionInvokingChatClientTests.cs
@@ -285,7 +285,8 @@ public sealed partial class StreamingFunctionInvokingChatClientTests
     [Fact]
     public async Task GetStreamingResponseAsync_RunsPreSamplingCompactionBeforeModelRequest()
     {
-        var inner = new SingleReplyFakeChatClient();
+        var bridge = new RecordingProviderHistoryBridge();
+        var inner = new ProviderHistoryBridgeFakeChatClient(bridge);
         var client = new StreamingFunctionInvokingChatClient(inner);
         var callbackCalls = 0;
         var replacement = new List<ChatMessage>
@@ -311,6 +312,40 @@ public sealed partial class StreamingFunctionInvokingChatClientTests
         Assert.Equal(1, callbackCalls);
         var call = Assert.Single(inner.Calls);
         Assert.Equal(["assistant:compacted summary", "user:latest user"], call.Select(m => $"{m.Role}:{m.Text}"));
+        var providerReplacement = Assert.Single(bridge.Replacements);
+        Assert.Equal("compaction", providerReplacement.Reason);
+        Assert.Same(replacement, providerReplacement.Messages);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_RequestSanitizationDoesNotReplaceCanonicalProviderHistory()
+    {
+        var bridge = new RecordingProviderHistoryBridge();
+        var inner = new ProviderHistoryBridgeFakeChatClient(bridge);
+        var client = new StreamingFunctionInvokingChatClient(inner);
+        var messages = new List<ChatMessage>
+        {
+            new(
+                ChatRole.Assistant,
+                [new FunctionCallContent("call-1", "GetStatus", new Dictionary<string, object?>())]),
+            new(
+                ChatRole.Tool,
+                [
+                    new TextReasoningContent("must stay canonical"),
+                    new FunctionResultContent("call-1", "tool result")
+                ])
+        };
+
+        await foreach (var _ in client.GetStreamingResponseAsync(messages))
+        {
+        }
+
+        Assert.Empty(bridge.Replacements);
+        var request = Assert.Single(inner.Calls);
+        Assert.Equal(2, request.Count);
+        var tool = request[1];
+        Assert.Single(tool.Contents);
+        Assert.IsType<FunctionResultContent>(tool.Contents[0]);
     }
 
     [Fact]
@@ -1139,6 +1174,63 @@ public sealed partial class StreamingFunctionInvokingChatClientTests
         public object? GetService(Type serviceType, object? serviceKey = null) => null;
 
         public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ProviderHistoryBridgeFakeChatClient(
+        RecordingProviderHistoryBridge bridge) : IChatClient
+    {
+        public List<List<ChatMessage>> Calls { get; } = [];
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "ok")]));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            Calls.Add(chatMessages.ToList());
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "done");
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceType == typeof(IProviderConversationHistoryBridge) ? bridge : null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class RecordingProviderHistoryBridge : IProviderConversationHistoryBridge
+    {
+        public List<(IReadOnlyList<ChatMessage> Messages, string Reason)> Replacements { get; } = [];
+
+        public ValueTask HistoryReplacedAsync(
+            IReadOnlyList<ChatMessage> messages,
+            ChatOptions? options,
+            string reason,
+            CancellationToken cancellationToken)
+        {
+            Replacements.Add((messages, reason));
+            return ValueTask.CompletedTask;
+        }
+
+        public void MarkProjectionCovered(IReadOnlyList<ChatMessage> messages)
+        {
+        }
+
+        public string? BeginAttempt() => null;
+
+        public ValueTask AbortAttemptAsync(string? attemptId, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+
+        public void EndAttempt(string? attemptId)
         {
         }
     }

--- a/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIResponsesToolSearchChatClientTests.cs
+++ b/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIResponsesToolSearchChatClientTests.cs
@@ -1936,6 +1936,132 @@ public sealed class OpenAIResponsesToolSearchChatClientTests
     }
 
     [Fact]
+    public async Task StreamingFunctionLoop_PostToolReasoningStartsAssistantMessage()
+    {
+        const string firstReasoningId = "rs_before_tools";
+        const string secondReasoningId = "rs_after_tools";
+        var tools = new[]
+        {
+            AIFunctionFactory.Create(() => "alpha", name: "ToolAlpha"),
+            AIFunctionFactory.Create(() => "beta", name: "ToolBeta"),
+            AIFunctionFactory.Create(() => "gamma", name: "ToolGamma")
+        };
+        var inner = new FakeChatClient(new ChatResponse([new ChatMessage(ChatRole.Assistant, "inner response")]));
+        var transport = new FakeToolSearchTransport([
+            [
+                CreateStreamingUpdate($$"""
+                    {
+                      "type": "response.output_item.added",
+                      "sequence_number": 1,
+                      "output_index": 0,
+                      "item": {
+                        "type": "reasoning",
+                        "id": "{{firstReasoningId}}",
+                        "status": "in_progress",
+                        "summary": []
+                      }
+                    }
+                    """),
+                new StreamingResponseReasoningSummaryTextDeltaUpdate
+                {
+                    SequenceNumber = 2,
+                    ItemId = firstReasoningId,
+                    OutputIndex = 0,
+                    SummaryIndex = 0,
+                    Delta = "before tools"
+                },
+                CreateFunctionCallDoneUpdate(3, 1, "fc_alpha", "call_alpha", "ToolAlpha"),
+                CreateFunctionCallDoneUpdate(4, 2, "fc_beta", "call_beta", "ToolBeta"),
+                CreateFunctionCallDoneUpdate(5, 3, "fc_gamma", "call_gamma", "ToolGamma")
+            ],
+            [
+                CreateStreamingUpdate($$"""
+                    {
+                      "type": "response.output_item.added",
+                      "sequence_number": 6,
+                      "output_index": 0,
+                      "item": {
+                        "type": "reasoning",
+                        "id": "{{secondReasoningId}}",
+                        "status": "in_progress",
+                        "summary": []
+                      }
+                    }
+                    """),
+                new StreamingResponseReasoningSummaryTextDeltaUpdate
+                {
+                    SequenceNumber = 7,
+                    ItemId = secondReasoningId,
+                    OutputIndex = 0,
+                    SummaryIndex = 0,
+                    Delta = "after tools"
+                },
+                CreateStreamingUpdate("""
+                    {
+                      "type": "response.output_item.done",
+                      "sequence_number": 8,
+                      "output_index": 0,
+                      "item": {
+                        "type": "reasoning",
+                        "id": "rs_after_tools",
+                        "status": "completed",
+                        "encrypted_content": "encrypted-after-tools",
+                        "summary": []
+                      }
+                    }
+                    """),
+                CreateStreamingUpdate("""
+                    {
+                      "type": "response.output_item.added",
+                      "sequence_number": 9,
+                      "output_index": 1,
+                      "item": {
+                        "type": "message",
+                        "id": "msg_done",
+                        "status": "in_progress",
+                        "content": [],
+                        "role": "assistant"
+                      }
+                    }
+                    """),
+                new StreamingResponseOutputTextDeltaUpdate
+                {
+                    SequenceNumber = 10,
+                    ItemId = "msg_done",
+                    OutputIndex = 1,
+                    ContentIndex = 0,
+                    Delta = "done"
+                }
+            ]
+        ]);
+        using var responsesClient = CreateClient(inner, transport);
+        using var invokingClient = new StreamingFunctionInvokingChatClient(responsesClient)
+        {
+            AdditionalTools = tools
+        };
+
+        var updates = await CollectStreamingAsync(invokingClient.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "run tools")],
+            new ChatOptions { Tools = tools.Cast<AITool>().ToList() }));
+        var response = updates.ToChatResponse();
+
+        var toolMessage = Assert.Single(response.Messages, message => message.Role == ChatRole.Tool);
+        Assert.Equal(3, toolMessage.Contents.OfType<FunctionResultContent>().Count());
+        Assert.DoesNotContain(toolMessage.Contents, content => content is TextReasoningContent);
+
+        var postToolReasoning = Assert.Single(
+            response.Messages
+                .Where(message => message.Role == ChatRole.Assistant)
+                .SelectMany(message => message.Contents)
+                .OfType<TextReasoningContent>(),
+            reasoning => reasoning.Text == "after tools");
+        Assert.Equal(
+            secondReasoningId,
+            postToolReasoning.AdditionalProperties![OpenAIResponsesItemIdentity.MetadataKey]);
+        Assert.Equal("encrypted-after-tools", postToolReasoning.ProtectedData);
+    }
+
+    [Fact]
     public async Task GetStreamingResponseAsync_WithTextReasoningAndUsage_UsesMeaiStreamingMapping()
     {
         var inner = new FakeChatClient(new ChatResponse([new ChatMessage(ChatRole.Assistant, "inner response")]));


### PR DESCRIPTION
## Summary

- Keep streamed Responses reasoning in assistant messages after tool results.
- Preserve provider reasoning IDs and encrypted content across tool loops.
- Prevent request-local history sanitization from replacing canonical Responses history.
- Restrict canonical history replacement to actual compaction.