### PR TITLE
refactor(protocol): add typed AppServer wire DTOs

### DIFF
--- a/src/DotCraft.App/AppServer/AppServerHost.cs
+++ b/src/DotCraft.App/AppServer/AppServerHost.cs
@@ -468,11 +468,11 @@ public sealed class AppServerHost(
                                     {
                                         jsonrpc = "2.0",
                                         method = AppServerMethods.SystemEvent,
-                                        @params = new
+                                        @params = new ChannelRejectedSystemEventNotification
                                         {
-                                            kind = "channelRejected",
-                                            channelName,
-                                            message =
+                                            Kind = "channelRejected",
+                                            ChannelName = channelName,
+                                            Message =
                                                 $"Channel '{channelName}' is subprocess-only; WebSocket adapter attach is not supported."
                                         }
                                     }, hostCt);
@@ -508,11 +508,11 @@ public sealed class AppServerHost(
                             {
                                 jsonrpc = "2.0",
                                 method = AppServerMethods.SystemEvent,
-                                @params = new
+                                @params = new ChannelRejectedSystemEventNotification
                                 {
-                                    kind = "channelRejected",
-                                    channelName,
-                                    message = $"Channel '{channelName}' is not registered in server configuration."
+                                    Kind = "channelRejected",
+                                    ChannelName = channelName,
+                                    Message = $"Channel '{channelName}' is not registered in server configuration."
                                 }
                             }, hostCt);
 
@@ -718,7 +718,7 @@ public sealed class AppServerHost(
             case AppServerMethods.Initialized:
                 handler.HandleInitializedNotification();
                 break;
-            // Other client notifications (none defined in v1) are silently ignored
+                // Other client notifications (none defined in v1) are silently ignored
         }
     }
 
@@ -795,13 +795,13 @@ public sealed class AppServerHost(
         int? inputTokens = null,
         int? outputTokens = null)
     {
-        object? tokenUsage = null;
+        SystemJobTokenUsageWire? tokenUsage = null;
         if (inputTokens.HasValue || outputTokens.HasValue)
         {
-            tokenUsage = new
+            tokenUsage = new SystemJobTokenUsageWire
             {
-                inputTokens = inputTokens ?? 0,
-                outputTokens = outputTokens ?? 0
+                InputTokens = inputTokens ?? 0,
+                OutputTokens = outputTokens ?? 0
             };
         }
 
@@ -809,15 +809,15 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.SystemJobResult,
-            @params = new
+            @params = new SystemJobResultNotification
             {
-                source,
-                jobId,
-                jobName,
-                threadId,
-                result,
-                error,
-                tokenUsage
+                Source = source,
+                JobId = jobId,
+                JobName = jobName,
+                ThreadId = threadId,
+                Result = result,
+                Error = error,
+                TokenUsage = tokenUsage
             }
         };
 
@@ -846,7 +846,7 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.CronStateChanged,
-            @params = new { job, removed }
+            @params = new CronStateChangedNotification { Job = job, Removed = removed }
         };
 
         foreach (var (transport, connection) in _activeTransports)
@@ -899,14 +899,14 @@ public sealed class AppServerHost(
     }
 
     private void BroadcastAppBindingStatusChanged(AppBindingWire binding) =>
-        BroadcastTrustedNotification("thread/appBindings/changed", new
+        BroadcastTrustedNotification("thread/appBindings/changed", new ThreadAppBindingsChangedNotification
         {
-            binding.ThreadId,
-            binding.BindingId,
-            binding.AppId,
-            binding.State,
-            binding.FailureReason,
-            binding.AuthorityRevision
+            ThreadId = binding.ThreadId,
+            BindingId = binding.BindingId,
+            AppId = binding.AppId,
+            State = binding.State,
+            FailureReason = binding.FailureReason,
+            AuthorityRevision = binding.AuthorityRevision
         });
 
     private void BroadcastOpenAiUsageChanged(DotCraft.Auth.OpenAI.OpenAIUsageSnapshot? snapshot)
@@ -951,15 +951,14 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.McpServerStartupStatusUpdated,
-            @params = new
+            @params = new McpServerStartupStatusUpdatedNotification
             {
-                threadId = (string?)null,
-                name = server.Name,
-                status,
-                error = server.LastError,
-                failureReason = server.FailureReason,
-                transport = server.Transport,
-                authStatus = server.AuthStatus
+                Name = server.Name,
+                Status = status,
+                Error = server.LastError,
+                FailureReason = server.FailureReason,
+                Transport = server.Transport,
+                AuthStatus = server.AuthStatus
             }
         };
 
@@ -1030,10 +1029,10 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method,
-            @params = new
+            @params = new TerminalLifecycleNotification
             {
-                terminal = evt.Terminal,
-                delta = evt.Delta
+                Terminal = evt.Terminal,
+                Delta = evt.Delta
             }
         };
 
@@ -1080,7 +1079,7 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadStarted,
-            @params = new { thread = wire }
+            @params = new ThreadStartedNotification { Thread = wire }
         };
 
         var skipTransport = !IsSubAgentThread(thread)
@@ -1117,7 +1116,11 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.SubAgentGraphChanged,
-            @params = new { parentThreadId, childThreadId }
+            @params = new SubAgentGraphChangedNotification
+            {
+                ParentThreadId = parentThreadId,
+                ChildThreadId = childThreadId
+            }
         };
 
         foreach (var (transport, connection) in _activeTransports)
@@ -1150,7 +1153,12 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadGoalUpdated,
-            @params = new { threadId = goal.ThreadId, goal = wireGoal, turnId }
+            @params = new ThreadGoalUpdatedNotification
+            {
+                ThreadId = goal.ThreadId,
+                Goal = wireGoal,
+                TurnId = turnId
+            }
         };
 
         foreach (var (transport, connection) in _activeTransports)
@@ -1178,7 +1186,7 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadGoalCleared,
-            @params = new { threadId }
+            @params = new ThreadGoalClearedNotification { ThreadId = threadId }
         };
 
         foreach (var (transport, connection) in _activeTransports)
@@ -1213,7 +1221,11 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadRenamed,
-            @params = new { threadId = thread.Id, displayName = thread.DisplayName }
+            @params = new ThreadRenamedNotification
+            {
+                ThreadId = thread.Id,
+                DisplayName = thread.DisplayName
+            }
         };
 
         foreach (var (transport, connection) in _activeTransports)
@@ -1248,7 +1260,7 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadUpdated,
-            @params = new { thread = wire }
+            @params = new ThreadUpdatedNotification { Thread = wire }
         };
 
         var skipTransport = string.Equals(
@@ -1430,7 +1442,12 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadStatusChanged,
-            @params = new { threadId, previousStatus, newStatus }
+            @params = new ThreadStatusChangedNotification
+            {
+                ThreadId = threadId,
+                PreviousStatus = previousStatus,
+                NewStatus = newStatus
+            }
         };
 
         var skipTransport = AppServerRequestContext.CurrentTransport;
@@ -1469,7 +1486,7 @@ public sealed class AppServerHost(
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadDeleted,
-            @params = new { threadId }
+            @params = new ThreadDeletedNotification { ThreadId = threadId }
         };
 
         var skipTransport = AppServerRequestContext.CurrentTransport;
@@ -1532,18 +1549,18 @@ public sealed class AppServerHost(
     {
         jsonrpc = "2.0",
         method = AppServerMethods.PlanUpdated,
-        @params = new
+        @params = new PlanUpdatedNotification
         {
-            threadId,
-            title = plan.Title,
-            overview = plan.Overview,
-            content = plan.Content,
-            todos = plan.Todos.Select(t => new
+            ThreadId = threadId,
+            Title = plan.Title,
+            Overview = plan.Overview,
+            Content = plan.Content,
+            Todos = plan.Todos.Select(t => new PlanTodoWire
             {
-                id = t.Id,
-                content = t.Content,
-                priority = t.Priority,
-                status = t.Status
+                Id = t.Id,
+                Content = t.Content,
+                Priority = t.Priority,
+                Status = t.Status
             }).ToArray()
         }
     };

--- a/src/DotCraft.Automations/Protocol/AutomationsEventDispatcher.cs
+++ b/src/DotCraft.Automations/Protocol/AutomationsEventDispatcher.cs
@@ -46,10 +46,10 @@ public sealed class AutomationsEventDispatcher : IDisposable
         {
             jsonrpc = "2.0",
             method = AppServerMethods.AutomationTaskUpdated,
-            @params = new
+            @params = new AutomationTaskUpdatedNotification
             {
-                workspacePath,
-                task = AutomationsRequestHandler.ToNotificationWire(automationTask)
+                WorkspacePath = workspacePath,
+                Task = AutomationsRequestHandler.ToNotificationWire(automationTask)
             }
         };
     }

--- a/src/DotCraft.Automations/Protocol/AutomationsRequestHandler.cs
+++ b/src/DotCraft.Automations/Protocol/AutomationsRequestHandler.cs
@@ -387,7 +387,7 @@ public sealed partial class AutomationsRequestHandler(
             throw AppServerErrors.TaskInvalidStatus(ex.Message);
         }
 
-        return new { ok = true };
+        return new AutomationTaskDeleteResult { Ok = true };
     }
 
     #region Helpers

--- a/src/DotCraft.Core/AppBinding/AppBindingProtocolExtension.cs
+++ b/src/DotCraft.Core/AppBinding/AppBindingProtocolExtension.cs
@@ -147,35 +147,43 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var result = _controlPlane.StartConnection(craftPath, parameters.AppId, userId);
                 result.Handoff = BuildHandoff(context, parameters.AppId, result.ConnectionRequestId, result.RequestToken, "connect");
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("app/connection/changed", new { appId = parameters.AppId, state = "connecting" }));
+                    ("app/connection/changed", new AppConnectionChangedNotification
+                    {
+                        AppId = parameters.AppId,
+                        State = "connecting"
+                    }));
             }
             case ConnectionRequestGet:
             {
                 var parameters = GetParams<AppConnectionRequestGetParams>(msg);
                 var request = _controlPlane.GetConnectionRequest(craftPath, parameters);
                 var app = EnsureCatalogApp(context, request.AppId);
-                return new
+                return new AppConnectionRequestGetResult
                 {
-                    request.ConnectionRequestId,
-                    request.AppId,
-                    app.Descriptor.DisplayName,
-                    app.Descriptor.DeveloperName,
-                    request.UserId,
-                    request.ExpiresAt
+                    ConnectionRequestId = request.ConnectionRequestId,
+                    AppId = request.AppId,
+                    DisplayName = app.Descriptor.DisplayName,
+                    DeveloperName = app.Descriptor.DeveloperName,
+                    UserId = request.UserId,
+                    ExpiresAt = request.ExpiresAt
                 };
             }
             case ConnectionConnect:
             {
                 var result = _controlPlane.Connect(craftPath, GetParams<AppConnectionConnectParams>(msg));
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("app/connection/changed", new { result.Principal.AppId, state = "connected" }));
+                    ("app/connection/changed", new AppConnectionChangedNotification
+                    {
+                        AppId = result.Principal.AppId,
+                        State = "connected"
+                    }));
             }
             case ConnectionAuthenticate:
             {
                 var parameters = GetParams<AppConnectionAuthenticateParams>(msg);
                 var principal = _controlPlane.Authenticate(craftPath, parameters.AppId, parameters.Credential);
                 context.Connection.BindAppPrincipal(principal.PrincipalId, principal.AppId);
-                return new { principal };
+                return new AppConnectionAuthenticateResult { Principal = principal };
             }
             case ConnectionRefresh:
                 return _controlPlane.Refresh(craftPath, RequirePrincipal(context.Connection));
@@ -185,11 +193,11 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var principal = context.Connection.IsAppPrincipalAuthenticated
                     ? _controlPlane.GetActivePrincipal(craftPath, context.Connection.AppPrincipalAppId!)
                     : _controlPlane.GetActivePrincipal(craftPath, parameters.AppId);
-                return new
+                return new AppConnectionStatusResult
                 {
-                    appId = context.Connection.AppPrincipalAppId ?? parameters.AppId,
-                    state = principal == null ? "notConnected" : "connected",
-                    principal
+                    AppId = context.Connection.AppPrincipalAppId ?? parameters.AppId,
+                    State = principal == null ? "notConnected" : "connected",
+                    Principal = principal
                 };
             }
             case ConnectionRevoke:
@@ -212,9 +220,13 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                         foreach (var binding in bindings)
                             await _coordinator.RemoveAsync(binding.ThreadId, binding.BindingId, runtime, context.CancellationToken);
                 }
-                var result = new { state = AppBindingStates.Revoked };
+                var result = new AppConnectionRevokeResult { State = AppBindingStates.Revoked };
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("app/connection/changed", new { appId = parameters.AppId ?? context.Connection.AppPrincipalAppId, state = "revoked" }));
+                    ("app/connection/changed", new AppConnectionChangedNotification
+                    {
+                        AppId = parameters.AppId ?? context.Connection.AppPrincipalAppId,
+                        State = "revoked"
+                    }));
             }
             case SurfacePublish:
                 return _controlPlane.PublishSurface(
@@ -237,9 +249,19 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var result = _controlPlane.Enable(craftPath, parameters.ThreadId, parameters.AppId, userId);
                 result.Handoff = BuildHandoff(context, parameters.AppId, result.BindingRequestId, result.RequestToken, "bind");
                 context.NotifyAppPrincipal?.Invoke(parameters.AppId, "app/binding/requested",
-                    new { result.BindingRequestId, result.BindingId, parameters.ThreadId, parameters.AppId });
+                    new AppBindingRequestedNotification
+                    {
+                        BindingRequestId = result.BindingRequestId,
+                        BindingId = result.BindingId,
+                        ThreadId = parameters.ThreadId,
+                        AppId = parameters.AppId
+                    });
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { parameters.ThreadId, state = AppBindingStates.Connecting }));
+                    ("thread/appBindings/changed", new ThreadAppBindingsChangedNotification
+                    {
+                        ThreadId = parameters.ThreadId,
+                        State = AppBindingStates.Connecting
+                    }));
             }
             case BindingRequestGet:
                 return _controlPlane.GetBindingRequest(
@@ -247,12 +269,18 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                     GetParams<AppBindingRequestGetParams>(msg),
                     context.Connection.AppPrincipalId);
             case PrincipalBindingsList:
-                return new { bindings = _controlPlane.ListPrincipalBindings(craftPath, RequirePrincipal(context.Connection)) };
+                return new AppBindingsListResult
+                {
+                    Bindings = _controlPlane.ListPrincipalBindings(craftPath, RequirePrincipal(context.Connection))
+                };
             case ThreadBindingsList:
             {
                 EnsureTrustedClient(context.Connection);
                 var parameters = GetParams<ThreadAppBindingsListParams>(msg);
-                return new { bindings = _controlPlane.ListThreadBindings(craftPath, parameters.ThreadId) };
+                return new ThreadAppBindingsListResult
+                {
+                    Bindings = _controlPlane.ListThreadBindings(craftPath, parameters.ThreadId).ToList()
+                };
             }
             case BindingRevoke:
             {
@@ -262,7 +290,12 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 if (context.SessionService is IThreadMcpRuntimeService mcpRuntime)
                     await _coordinator.RemoveAsync(parameters.ThreadId, parameters.BindingId, mcpRuntime, context.CancellationToken);
                 return await SendNotificationsAfterResponseAsync(msg, context, binding,
-                    ("thread/appBindings/changed", new { parameters.ThreadId, parameters.BindingId, state = AppBindingStates.Revoked }));
+                    ("thread/appBindings/changed", new ThreadAppBindingsChangedNotification
+                    {
+                        ThreadId = parameters.ThreadId,
+                        BindingId = parameters.BindingId,
+                        State = AppBindingStates.Revoked
+                    }));
             }
             case BindingActivate:
             {
@@ -271,7 +304,7 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var result = await _coordinator.ActivateAsync(craftPath, RequirePrincipal(context.Connection),
                     parameters, runtime, context.CancellationToken);
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { result.ThreadId, result.BindingId, result.State }));
+                    ("thread/appBindings/changed", Changed(result.ThreadId, result.BindingId, result.State)));
             }
             case BindingRebind:
             {
@@ -280,7 +313,7 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var result = await _coordinator.RebindAsync(craftPath, RequirePrincipal(context.Connection),
                     parameters, runtime, context.CancellationToken);
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { result.ThreadId, result.BindingId, result.State }));
+                    ("thread/appBindings/changed", Changed(result.ThreadId, result.BindingId, result.State)));
             }
             case BindingConfirm:
             {
@@ -290,7 +323,7 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                     parameters, userId,
                     RequireMcpRuntime(context.SessionService), context.CancellationToken);
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { parameters.ThreadId, parameters.BindingId, result.State }));
+                    ("thread/appBindings/changed", Changed(parameters.ThreadId, parameters.BindingId, result.State)));
             }
             case SocialRequestCreate:
             {
@@ -299,8 +332,19 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 await context.SessionService.GetThreadAsync(parameters.ThreadId, context.CancellationToken);
                 var result = _controlPlane.CreateSocialRequest(craftPath, parameters.ThreadId, parameters.ChannelName, userId);
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { parameters.ThreadId, state = AppBindingStates.Connecting }),
-                    ("app/binding/requested", result));
+                    ("thread/appBindings/changed", new ThreadAppBindingsChangedNotification
+                    {
+                        ThreadId = parameters.ThreadId,
+                        State = AppBindingStates.Connecting
+                    }),
+                    ("app/binding/requested", new AppBindingRequestedNotification
+                    {
+                        BindingRequestId = result.BindingRequestId,
+                        BindingId = result.BindingId,
+                        Code = result.Code,
+                        ChannelName = result.ChannelName,
+                        ExpiresAt = result.ExpiresAt
+                    }));
             }
             case SocialRequestGet:
             {
@@ -313,14 +357,14 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var result = _controlPlane.AcceptSocial(craftPath, RequireChannel(context.Connection),
                     GetParams<SocialBindingAcceptParams>(msg));
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { result.ThreadId, result.BindingId, result.State }));
+                    ("thread/appBindings/changed", Changed(result.ThreadId, result.BindingId, result.State)));
             }
             case SocialRebind:
             {
                 var result = _controlPlane.RebindSocial(craftPath, RequireChannel(context.Connection),
                     GetParams<SocialBindingRebindParams>(msg));
                 return await SendNotificationsAfterResponseAsync(msg, context, result,
-                    ("thread/appBindings/changed", new { result.ThreadId, result.BindingId, result.State }));
+                    ("thread/appBindings/changed", Changed(result.ThreadId, result.BindingId, result.State)));
             }
             case SocialResolve:
             {
@@ -328,8 +372,11 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
                 var parameters = GetParams<AppSocialBindingResolveParams>(msg);
                 if (!string.Equals(parameters.ChannelName, channel, StringComparison.OrdinalIgnoreCase))
                     throw AppServerErrors.AppPrincipalUnauthorized("A channel adapter may resolve only its own bindings.");
-                return new { binding = _controlPlane.ResolveSocial(craftPath, channel, parameters.AccountId,
-                    parameters.ConversationKind, parameters.ConversationId) };
+                return new AppSocialBindingResolveResult
+                {
+                    Binding = _controlPlane.ResolveSocial(craftPath, channel, parameters.AccountId,
+                        parameters.ConversationKind, parameters.ConversationId)
+                };
             }
             case ThreadInputEnqueue:
             {
@@ -376,6 +423,16 @@ public sealed class AppBindingProtocolExtension : IAppServerProtocolExtension
     private static IThreadMcpRuntimeService RequireMcpRuntime(ISessionService sessionService) =>
         sessionService as IThreadMcpRuntimeService
         ?? throw AppServerErrors.InvalidRequest("This host does not provide binding-scoped MCP sessions.");
+
+    private static ThreadAppBindingsChangedNotification Changed(
+        string threadId,
+        string bindingId,
+        string state) => new()
+    {
+        ThreadId = threadId,
+        BindingId = bindingId,
+        State = state
+    };
 
     private static string RequireChannel(AppServerConnection connection) =>
         connection.ChannelAdapterName

--- a/src/DotCraft.Core/AppBinding/AppBindingService.cs
+++ b/src/DotCraft.Core/AppBinding/AppBindingService.cs
@@ -561,7 +561,11 @@ public sealed class AppBindingService
         return binding;
     }
 
-    public object CreateSocialRequest(string workspaceCraftPath, string threadId, string channelName, string userId)
+    public ThreadSocialBindingRequestCreateResult CreateSocialRequest(
+        string workspaceCraftPath,
+        string threadId,
+        string channelName,
+        string userId)
     {
         Require(threadId, "threadId");
         Require(channelName, "channelName");
@@ -591,7 +595,14 @@ public sealed class AppBindingService
             };
             state.Bindings.Add(binding); state.BindingRequests.Add(request);
             Audit(state, "social.requested", binding.UserId, appId, threadId, binding.BindingId, binding.AuthorityRevision);
-            return new { request.BindingRequestId, binding.BindingId, code, channelName = normalizedChannel, request.ExpiresAt };
+            return new ThreadSocialBindingRequestCreateResult
+            {
+                BindingRequestId = request.BindingRequestId,
+                BindingId = binding.BindingId,
+                Code = code,
+                ChannelName = normalizedChannel,
+                ExpiresAt = request.ExpiresAt
+            };
         });
     }
 

--- a/src/DotCraft.Core/AppBinding/AppOperationModels.cs
+++ b/src/DotCraft.Core/AppBinding/AppOperationModels.cs
@@ -134,19 +134,58 @@ public sealed class AppConnectionMetadataRefreshParams
 
 public sealed class AppConnectionRequestGetResult
 {
-    public string AppId { get; set; } = string.Empty;
-
+    [JsonPropertyName("connectionRequestId")]
     public string ConnectionRequestId { get; set; } = string.Empty;
 
+    [JsonPropertyName("appId")]
+    public string AppId { get; set; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
     public string DisplayName { get; set; } = string.Empty;
 
+    [JsonPropertyName("developerName")]
     public string DeveloperName { get; set; } = string.Empty;
 
-    public string WorkspaceLabel { get; set; } = string.Empty;
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
 
-    public string UserLabel { get; set; } = string.Empty;
-
+    [JsonPropertyName("expiresAt")]
     public DateTimeOffset ExpiresAt { get; set; }
+}
+
+/// <summary>Result for <c>app/connection/authenticate</c>.</summary>
+public sealed class AppConnectionAuthenticateResult
+{
+    [JsonPropertyName("principal")]
+    public AppPrincipalWire Principal { get; set; } = new();
+}
+
+/// <summary>Current wire result for <c>app/connection/status</c>.</summary>
+public sealed class AppConnectionStatusResult
+{
+    [JsonPropertyName("appId")]
+    public string AppId { get; set; } = string.Empty;
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = AppConnectionStates.NotConnected;
+
+    [JsonPropertyName("principal")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AppPrincipalWire? Principal { get; set; }
+}
+
+/// <summary>Result for <c>app/connection/revoke</c>.</summary>
+public sealed class AppConnectionRevokeResult
+{
+    [JsonPropertyName("state")]
+    public string State { get; set; } = AppBindingStates.Revoked;
+}
+
+/// <summary>Result for <c>app/bindings/list</c>.</summary>
+public sealed class AppBindingsListResult
+{
+    [JsonPropertyName("bindings")]
+    public IReadOnlyList<AppBindingWire> Bindings { get; set; } = [];
 }
 
 public sealed class AppConnectionStatusWire

--- a/src/DotCraft.Core/AppBinding/AppSocialBindingModels.cs
+++ b/src/DotCraft.Core/AppBinding/AppSocialBindingModels.cs
@@ -66,5 +66,5 @@ public sealed class AppSocialBindingResolveParams
 public sealed class AppSocialBindingResolveResult
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-    public ThreadAppBindingWire? Binding { get; set; }
+    public AppBindingWire? Binding { get; set; }
 }

--- a/src/DotCraft.Core/AppBinding/SocialBindingProtocolModels.cs
+++ b/src/DotCraft.Core/AppBinding/SocialBindingProtocolModels.cs
@@ -1,9 +1,105 @@
+using System.Text.Json.Serialization;
+
 namespace DotCraft.AppBinding;
 
 public sealed class ThreadSocialBindingRequestCreateParams
 {
     public string ThreadId { get; set; } = string.Empty;
     public string ChannelName { get; set; } = string.Empty;
+}
+
+/// <summary>Result for <c>thread/socialBindings/request/create</c>.</summary>
+public sealed class ThreadSocialBindingRequestCreateResult
+{
+    [JsonPropertyName("bindingRequestId")]
+    public string BindingRequestId { get; set; } = string.Empty;
+
+    [JsonPropertyName("bindingId")]
+    public string BindingId { get; set; } = string.Empty;
+
+    [JsonPropertyName("code")]
+    public string Code { get; set; } = string.Empty;
+
+    [JsonPropertyName("channelName")]
+    public string ChannelName { get; set; } = string.Empty;
+
+    [JsonPropertyName("expiresAt")]
+    public DateTimeOffset ExpiresAt { get; set; }
+}
+
+/// <summary>Payload for <c>app/connection/changed</c>.</summary>
+public sealed class AppConnectionChangedNotification
+{
+    [JsonPropertyName("appId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AppId { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = string.Empty;
+}
+
+/// <summary>Payload for <c>app/binding/requested</c>.</summary>
+public sealed class AppBindingRequestedNotification
+{
+    [JsonPropertyName("bindingRequestId")]
+    public string BindingRequestId { get; set; } = string.Empty;
+
+    [JsonPropertyName("bindingId")]
+    public string BindingId { get; set; } = string.Empty;
+
+    [JsonPropertyName("threadId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ThreadId { get; set; }
+
+    [JsonPropertyName("appId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AppId { get; set; }
+
+    [JsonPropertyName("code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("channelName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ChannelName { get; set; }
+
+    [JsonPropertyName("expiresAt")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? ExpiresAt { get; set; }
+}
+
+/// <summary>Payload for <c>thread/appBindings/changed</c>.</summary>
+public sealed class ThreadAppBindingsChangedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("bindingId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BindingId { get; set; }
+
+    [JsonPropertyName("appId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AppId { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = string.Empty;
+
+    [JsonPropertyName("failureReason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FailureReason { get; set; }
+
+    [JsonPropertyName("authorityRevision")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AuthorityRevision { get; set; }
+
+    [JsonPropertyName("previousState")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PreviousState { get; set; }
+
+    [JsonPropertyName("changeKind")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ChangeKind { get; set; }
 }
 
 public sealed class SocialBindingRequestGetParams

--- a/src/DotCraft.Core/AppBinding/ThreadAppBindingModels.cs
+++ b/src/DotCraft.Core/AppBinding/ThreadAppBindingModels.cs
@@ -27,7 +27,7 @@ public sealed class ThreadAppBindingsListParams
 
 public sealed class ThreadAppBindingsListResult
 {
-    public List<ThreadAppBindingWire> Bindings { get; set; } = [];
+    public List<AppBindingWire> Bindings { get; set; } = [];
 }
 
 public sealed class ThreadAppBindingRevokeParams

--- a/src/DotCraft.Core/Protocol/AppServer/Extensions/WireAcpExtensionProxy.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Extensions/WireAcpExtensionProxy.cs
@@ -82,12 +82,12 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
         if (!SupportsFileRead)
             return null;
         var el = await SendExtRawAsync(AppServerMethods.ExtAcpFsReadTextFile,
-            new { path, offset, limit }, ct);
+            new AcpFsReadTextFileParams { Path = path, Offset = offset, Limit = limit }, ct);
         if (!el.HasValue)
             return null;
         try
         {
-            return el.Value.Deserialize<AcpWireFsReadResult>(JsonOptions)?.Content;
+            return el.Value.Deserialize<AcpFsReadTextFileResult>(JsonOptions)?.Content;
         }
         catch
         {
@@ -101,12 +101,12 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
         if (!SupportsFileWrite)
             return false;
         var el = await SendExtRawAsync(AppServerMethods.ExtAcpFsWriteTextFile,
-            new { path, content }, ct);
+            new AcpFsWriteTextFileParams { Path = path, Content = content }, ct);
         if (!el.HasValue)
             return false;
         try
         {
-            return el.Value.Deserialize<AcpWireFsWriteResult>(JsonOptions)?.Success ?? false;
+            return el.Value.Deserialize<AcpFsWriteTextFileResult>(JsonOptions)?.Success ?? false;
         }
         catch
         {
@@ -121,12 +121,12 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
         if (!SupportsTerminal)
             return null;
         var el = await SendExtRawAsync(AppServerMethods.ExtAcpTerminalCreate,
-            new { command, cwd, env }, ct);
+            new AcpTerminalCreateParams { Command = command, Cwd = cwd, Env = env }, ct);
         if (!el.HasValue)
             return null;
         try
         {
-            return el.Value.Deserialize<AcpWireTerminalCreateResult>(JsonOptions)?.TerminalId;
+            return el.Value.Deserialize<AcpTerminalCreateResult>(JsonOptions)?.TerminalId;
         }
         catch
         {
@@ -139,12 +139,12 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
         CancellationToken ct = default)
     {
         var el = await SendExtRawAsync(AppServerMethods.ExtAcpTerminalGetOutput,
-            new { terminalId }, ct);
+            new AcpTerminalGetOutputParams { TerminalId = terminalId }, ct);
         if (!el.HasValue)
             return ("", null);
         try
         {
-            var r = el.Value.Deserialize<AcpWireTerminalOutputResult>(JsonOptions);
+            var r = el.Value.Deserialize<AcpTerminalOutputResult>(JsonOptions);
             return (r?.Output ?? "", r?.ExitCode);
         }
         catch
@@ -158,12 +158,12 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
         int? timeoutSeconds = null, CancellationToken ct = default)
     {
         var el = await SendExtRawAsync(AppServerMethods.ExtAcpTerminalWaitForExit,
-            new { terminalId, timeout = timeoutSeconds }, ct);
+            new AcpTerminalWaitForExitParams { TerminalId = terminalId, Timeout = timeoutSeconds }, ct);
         if (!el.HasValue)
             return ("", null);
         try
         {
-            var r = el.Value.Deserialize<AcpWireTerminalOutputResult>(JsonOptions);
+            var r = el.Value.Deserialize<AcpTerminalOutputResult>(JsonOptions);
             return (r?.Output ?? "", r?.ExitCode);
         }
         catch
@@ -175,13 +175,15 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
     /// <inheritdoc />
     public async Task KillTerminalAsync(string terminalId, CancellationToken ct = default)
     {
-        await SendExtRawAsync(AppServerMethods.ExtAcpTerminalKill, new { terminalId }, ct);
+        await SendExtRawAsync(AppServerMethods.ExtAcpTerminalKill,
+            new AcpTerminalKillParams { TerminalId = terminalId }, ct);
     }
 
     /// <inheritdoc />
     public async Task ReleaseTerminalAsync(string terminalId, CancellationToken ct = default)
     {
-        await SendExtRawAsync(AppServerMethods.ExtAcpTerminalRelease, new { terminalId }, ct);
+        await SendExtRawAsync(AppServerMethods.ExtAcpTerminalRelease,
+            new AcpTerminalReleaseParams { TerminalId = terminalId }, ct);
     }
 
     /// <inheritdoc />
@@ -208,6 +210,9 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
         var threadId = TracingChatClient.CurrentSessionKey;
         if (threadId == null || !_byThread.TryGetValue(threadId, out var binding))
             return null;
+
+        if (@params is IAcpThreadBoundParams threadBoundParams)
+            threadBoundParams.ThreadId = threadId;
 
         var mergedParams = MergeThreadIdIntoParams(threadId, @params);
         var response = await binding.Transport.SendClientRequestAsync(wireMethod, mergedParams, ct,
@@ -247,24 +252,4 @@ public sealed class WireAcpExtensionProxy : IAcpExtensionProxy
 
     private sealed record AcpThreadBinding(string ThreadId, IAppServerTransport Transport, AppServerConnection Connection);
 
-    private sealed class AcpWireFsReadResult
-    {
-        public string? Content { get; set; }
-    }
-
-    private sealed class AcpWireFsWriteResult
-    {
-        public bool Success { get; set; }
-    }
-
-    private sealed class AcpWireTerminalCreateResult
-    {
-        public string? TerminalId { get; set; }
-    }
-
-    private sealed class AcpWireTerminalOutputResult
-    {
-        public string? Output { get; set; }
-        public int? ExitCode { get; set; }
-    }
 }

--- a/src/DotCraft.Core/Protocol/AppServer/Extensions/WireNodeReplProxy.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Extensions/WireNodeReplProxy.cs
@@ -79,21 +79,21 @@ public sealed class WireNodeReplProxy : INodeReplProxy
         {
             var response = await binding.Transport.SendClientRequestAsync(
                 AppServerMethods.ExtNodeReplEvaluate,
-                new
+                new NodeReplEvaluateParams
                 {
-                    threadId,
-                    turnId,
-                    evaluationId,
-                    browserSession = new
+                    ThreadId = threadId,
+                    TurnId = turnId,
+                    EvaluationId = evaluationId,
+                    BrowserSession = new NodeReplBrowserSessionParams
                     {
-                        protocolVersion,
-                        sessionId,
-                        threadId,
-                        turnId,
-                        evaluationId
+                        ProtocolVersion = protocolVersion,
+                        SessionId = sessionId,
+                        ThreadId = threadId,
+                        TurnId = turnId,
+                        EvaluationId = evaluationId
                     },
-                    code,
-                    timeoutMs = safeTimeout * 1000
+                    Code = code,
+                    TimeoutMs = safeTimeout * 1000
                 },
                 ct,
                 TimeSpan.FromSeconds(safeTimeout + 5));
@@ -142,7 +142,7 @@ public sealed class WireNodeReplProxy : INodeReplProxy
             {
                 await binding.Transport.SendClientRequestAsync(
                     AppServerMethods.ExtNodeReplCancel,
-                    new { threadId, evaluationId },
+                    new NodeReplCancelParams { ThreadId = threadId, EvaluationId = evaluationId },
                     CancellationToken.None,
                     TimeSpan.FromSeconds(2));
             }

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/AppServerErrors.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/AppServerErrors.cs
@@ -138,7 +138,7 @@ public static class AppServerErrors
         Create(InvalidRequestCode, "InvalidRequest", "errors.invalidRequest", "Invalid request", detail: detail);
 
     public static AppServerException MethodNotFound(string method) =>
-        Create(MethodNotFoundCode, "MethodNotFound", "errors.methodNotFound", $"Method not found: {method}", new { method });
+        Create(MethodNotFoundCode, "MethodNotFound", "errors.methodNotFound", $"Method not found: {method}", new MethodErrorParams(method));
 
     public static AppServerException InvalidParams(string detail) =>
         Create(InvalidParamsCode, "InvalidParams", "errors.invalidParams", "Invalid params", detail: detail);
@@ -156,19 +156,19 @@ public static class AppServerErrors
         Create(AlreadyInitializedCode, "AlreadyInitialized", "errors.alreadyInitialized", "Already initialized");
 
     public static AppServerException ThreadNotFound(string threadId) =>
-        Create(ThreadNotFoundCode, "ThreadNotFound", "errors.threadNotFound", $"Thread not found: {threadId}", new { threadId });
+        Create(ThreadNotFoundCode, "ThreadNotFound", "errors.threadNotFound", $"Thread not found: {threadId}", new ThreadErrorParams(threadId));
 
     public static AppServerException ThreadNotActive(string threadId) =>
-        Create(ThreadNotActiveCode, "ThreadNotActive", "errors.threadNotActive", $"Thread is not active: {threadId}", new { threadId });
+        Create(ThreadNotActiveCode, "ThreadNotActive", "errors.threadNotActive", $"Thread is not active: {threadId}", new ThreadErrorParams(threadId));
 
     public static AppServerException TurnInProgress(string threadId) =>
-        Create(TurnInProgressCode, "TurnInProgress", "errors.turnInProgress", $"A turn is already in progress on thread: {threadId}", new { threadId });
+        Create(TurnInProgressCode, "TurnInProgress", "errors.turnInProgress", $"A turn is already in progress on thread: {threadId}", new ThreadErrorParams(threadId));
 
     public static AppServerException TurnNotFound(string turnId) =>
-        Create(TurnNotFoundCode, "TurnNotFound", "errors.turnNotFound", $"Turn not found: {turnId}", new { turnId });
+        Create(TurnNotFoundCode, "TurnNotFound", "errors.turnNotFound", $"Turn not found: {turnId}", new TurnErrorParams(turnId));
 
     public static AppServerException TurnNotRunning(string turnId) =>
-        Create(TurnNotRunningCode, "TurnNotRunning", "errors.turnNotRunning", $"Turn is not running: {turnId}", new { turnId });
+        Create(TurnNotRunningCode, "TurnNotRunning", "errors.turnNotRunning", $"Turn is not running: {turnId}", new TurnErrorParams(turnId));
 
     public static AppServerException WorktreeHandoffConflict(IReadOnlyList<string> conflictPaths) =>
         Create(
@@ -176,19 +176,19 @@ public static class AppServerErrors
             "WorktreeHandoffConflict",
             "errors.worktreeHandoffConflict",
             "Local workspace has conflicting uncommitted changes.",
-            new { conflictPaths });
+            new WorktreeConflictErrorParams(conflictPaths));
 
     public static AppServerException ApprovalTimeout() =>
         Create(ApprovalTimeoutCode, "ApprovalTimeout", "errors.approvalTimeout", "Approval request timed out");
 
     public static AppServerException ChannelRejected(string channelName) =>
-        Create(ChannelRejectedCode, "ChannelRejected", "errors.channelRejected", $"Channel adapter rejected: '{channelName}' is not registered in server configuration", new { channelName });
+        Create(ChannelRejectedCode, "ChannelRejected", "errors.channelRejected", $"Channel adapter rejected: '{channelName}' is not registered in server configuration", new ChannelErrorParams(channelName));
 
     public static AppServerException CronJobNotFound(string jobId) =>
-        Create(CronJobNotFoundCode, "CronJobNotFound", "errors.cronJobNotFound", $"Cron job not found: {jobId}", new { jobId });
+        Create(CronJobNotFoundCode, "CronJobNotFound", "errors.cronJobNotFound", $"Cron job not found: {jobId}", new CronJobErrorParams(jobId));
 
     public static AppServerException SkillNotFound(string name) =>
-        Create(SkillNotFoundCode, "SkillNotFound", "errors.skillNotFound", $"Skill not found: {name}", new { name });
+        Create(SkillNotFoundCode, "SkillNotFound", "errors.skillNotFound", $"Skill not found: {name}", new NamedResourceErrorParams(name));
 
     /// <summary>
     /// Maps a marketplace failure onto the JSON-RPC error that matches its stable code, keeping
@@ -204,7 +204,7 @@ public static class AppServerErrors
             code,
             $"errors.marketplace.{ToMessageKeySuffix(code)}",
             fallbackText,
-            marketplaceName == null ? null : new { marketplaceName });
+            marketplaceName == null ? null : new MarketplaceErrorParams(marketplaceName));
     }
 
     private static string ToMessageKeySuffix(string code)
@@ -215,16 +215,16 @@ public static class AppServerErrors
     }
 
     public static AppServerException CommandNotFound(string command) =>
-        Create(CommandNotFoundCode, "CommandNotFound", "errors.commandNotFound", $"Command not found: {command}", new { command });
+        Create(CommandNotFoundCode, "CommandNotFound", "errors.commandNotFound", $"Command not found: {command}", new CommandErrorParams(command));
 
     public static AppServerException CommandPermissionDenied(string command) =>
-        Create(CommandPermissionDeniedCode, "CommandPermissionDenied", "errors.commandPermissionDenied", $"Permission denied for command: {command}", new { command });
+        Create(CommandPermissionDeniedCode, "CommandPermissionDenied", "errors.commandPermissionDenied", $"Permission denied for command: {command}", new CommandErrorParams(command));
 
     public static AppServerException CommandServiceUnavailable(string command) =>
-        Create(CommandServiceUnavailableCode, "CommandServiceUnavailable", "errors.commandServiceUnavailable", $"Service unavailable for command: {command}", new { command });
+        Create(CommandServiceUnavailableCode, "CommandServiceUnavailable", "errors.commandServiceUnavailable", $"Service unavailable for command: {command}", new CommandErrorParams(command));
 
     public static AppServerException McpServerNotFound(string name) =>
-        Create(McpServerNotFoundCode, "McpServerNotFound", "errors.mcpServerNotFound", $"MCP server not found: {name}", new { name });
+        Create(McpServerNotFoundCode, "McpServerNotFound", "errors.mcpServerNotFound", $"MCP server not found: {name}", new NamedResourceErrorParams(name));
 
     public static AppServerException McpServerValidationFailed(string detail) =>
         Create(McpServerValidationFailedCode, "McpServerValidationFailed", "errors.mcpServerValidationFailed", "MCP server validation failed", detail: detail);
@@ -236,7 +236,7 @@ public static class AppServerErrors
         Create(McpServerNameConflictCode, "McpServerNameConflict", "errors.mcpServerNameConflict", "MCP server name conflict", detail: detail);
 
     public static AppServerException McpServerReadOnly(string name) =>
-        Create(McpServerReadOnlyCode, "McpServerReadOnly", "errors.mcpServerReadOnly", $"MCP server is read-only: {name}", new { name });
+        Create(McpServerReadOnlyCode, "McpServerReadOnly", "errors.mcpServerReadOnly", $"MCP server is read-only: {name}", new NamedResourceErrorParams(name));
 
     public static AppServerException AppBindingUpgradeRequired() =>
         Create(
@@ -244,7 +244,7 @@ public static class AppServerErrors
             "AppBindingUpgradeRequired",
             "errors.appBindingUpgradeRequired",
             "App Binding version 2 is required",
-            new { requiredVersion = 2 });
+            new AppBindingVersionErrorParams(2));
 
     public static AppServerException AppPrincipalUnauthorized(string detail) =>
         Create(
@@ -276,10 +276,10 @@ public static class AppServerErrors
             "AppSurfaceUnavailable",
             "errors.appSurfaceUnavailable",
             "App surface is unavailable",
-            new { appId, surfaceId });
+            new AppSurfaceErrorParams(appId, surfaceId));
 
     public static AppServerException ExternalChannelNotFound(string name) =>
-        Create(ExternalChannelNotFoundCode, "ExternalChannelNotFound", "errors.externalChannelNotFound", $"External channel not found: {name}", new { name });
+        Create(ExternalChannelNotFoundCode, "ExternalChannelNotFound", "errors.externalChannelNotFound", $"External channel not found: {name}", new NamedResourceErrorParams(name));
 
     public static AppServerException ExternalChannelValidationFailed(string detail) =>
         Create(ExternalChannelValidationFailedCode, "ExternalChannelValidationFailed", "errors.externalChannelValidationFailed", "External channel validation failed", detail: detail);
@@ -288,7 +288,7 @@ public static class AppServerErrors
         Create(ExternalChannelNameConflictCode, "ExternalChannelNameConflict", "errors.externalChannelNameConflict", "External channel name conflict", detail: detail);
 
     public static AppServerException SubAgentProfileNotFound(string name) =>
-        Create(SubAgentProfileNotFoundCode, "SubAgentProfileNotFound", "errors.subAgentProfileNotFound", $"SubAgent profile not found: {name}", new { name });
+        Create(SubAgentProfileNotFoundCode, "SubAgentProfileNotFound", "errors.subAgentProfileNotFound", $"SubAgent profile not found: {name}", new NamedResourceErrorParams(name));
 
     public static AppServerException SubAgentProfileValidationFailed(string detail) =>
         Create(SubAgentProfileValidationFailedCode, "SubAgentProfileValidationFailed", "errors.subAgentProfileValidationFailed", "SubAgent profile validation failed", detail: detail);
@@ -307,7 +307,7 @@ public static class AppServerErrors
             "AgentProfileValidationFailed",
             "errors.agentProfileValidationFailed",
             "Agent profile validation failed",
-            diagnostics == null ? null : new { diagnostics },
+            diagnostics == null ? null : new AgentProfileDiagnosticsErrorParams(diagnostics),
             detail);
 
     public static AppServerException AgentProfileProtected(string detail) =>
@@ -320,10 +320,10 @@ public static class AppServerErrors
         Create(AgentProfileConflictCode, "AgentProfileConflict", "errors.agentProfileConflict", "Agent profile conflict", detail: detail);
 
     public static AppServerException TaskAlreadyExists(string taskId) =>
-        Create(TaskAlreadyExistsCode, "TaskAlreadyExists", "errors.taskAlreadyExists", $"Task already exists: {taskId}", new { taskId });
+        Create(TaskAlreadyExistsCode, "TaskAlreadyExists", "errors.taskAlreadyExists", $"Task already exists: {taskId}", new TaskErrorParams(taskId));
 
     public static AppServerException TaskNotFound(string taskId) =>
-        Create(TaskNotFoundCode, "TaskNotFound", "errors.taskNotFound", $"Task not found: {taskId}", new { taskId });
+        Create(TaskNotFoundCode, "TaskNotFound", "errors.taskNotFound", $"Task not found: {taskId}", new TaskErrorParams(taskId));
 
     public static AppServerException TaskInvalidStatus(string detail) =>
         Create(TaskInvalidStatusCode, "TaskInvalidStatus", "errors.taskInvalidStatus", detail, detail: detail);

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/McpRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/McpRequestHandler.cs
@@ -259,15 +259,15 @@ internal sealed class McpRequestHandler(
                 ServerInfo = inventory?.ServerInfo,
                 Tools = inventory?.Tools.ToDictionary(
                             static tool => tool.Name,
-                            static tool => (object)new
+                            static tool => new McpRuntimeToolWire
                             {
-                                name = tool.Name,
-                                description = tool.Description,
-                                inputSchema = tool.JsonSchema,
-                                outputSchema = tool.ReturnJsonSchema
+                                Name = tool.Name,
+                                Description = tool.Description,
+                                InputSchema = tool.JsonSchema,
+                                OutputSchema = tool.ReturnJsonSchema
                             },
                             StringComparer.Ordinal)
-                        ?? new Dictionary<string, object>(StringComparer.Ordinal),
+                        ?? new Dictionary<string, McpRuntimeToolWire>(StringComparer.Ordinal),
                 Resources = resources,
                 ResourceTemplates = resourceTemplates,
                 AuthStatus = status.AuthStatus,

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/PluginRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/PluginRequestHandler.cs
@@ -521,14 +521,14 @@ internal sealed class PluginRequestHandler(
             {
                 jsonrpc = "2.0",
                 method = AppBindingThreadBindingsChangedNotification,
-                @params = new
+                @params = new ThreadAppBindingsChangedNotification
                 {
-                    threadId = binding.ThreadId,
-                    bindingId = binding.BindingId,
-                    appId = binding.AppId,
-                    state = binding.State,
-                    previousState = AppBindingStates.Active,
-                    changeKind = "offline"
+                    ThreadId = binding.ThreadId,
+                    BindingId = binding.BindingId,
+                    AppId = binding.AppId,
+                    State = binding.State,
+                    PreviousState = AppBindingStates.Active,
+                    ChangeKind = "offline"
                 }
             }, ct);
         }
@@ -536,7 +536,7 @@ internal sealed class PluginRequestHandler(
         return null;
     }
 
-    private object? TryBuildAppListUpdatedNotification(
+    private AppListUpdatedNotification? TryBuildAppListUpdatedNotification(
         PluginDiscoveryResult discovery,
         string pluginId,
         string reason)
@@ -556,11 +556,11 @@ internal sealed class PluginRequestHandler(
         if (!pluginHasAppContribution && appIds.Count == 0)
             return null;
 
-        return new
+        return new AppListUpdatedNotification
         {
-            pluginId,
-            reason,
-            appIds
+            PluginId = pluginId,
+            Reason = reason,
+            AppIds = appIds
         };
     }
 

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/TerminalRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/TerminalRequestHandler.cs
@@ -24,7 +24,7 @@ internal sealed class TerminalRequestHandler(
         var service = RequireBackgroundTerminals();
         var p = AppServerParams.Get<TerminalListParams>(msg);
         var sessions = await service.ListAsync(p.ThreadId, ct);
-        return new { terminals = sessions };
+        return new TerminalListResult { Terminals = sessions };
     }
 
     private async Task<object?> HandleTerminalReadAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -35,7 +35,7 @@ internal sealed class TerminalRequestHandler(
             throw AppServerErrors.InvalidParams("'sessionId' is required.");
 
         var terminal = await service.ReadAsync(p.SessionId, p.WaitMs ?? 0, p.MaxOutputChars, ct);
-        return new { terminal };
+        return new TerminalReadResult { Terminal = terminal };
     }
 
     private async Task<object?> HandleTerminalWriteAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -51,7 +51,7 @@ internal sealed class TerminalRequestHandler(
             p.YieldTimeMs ?? 1000,
             p.MaxOutputChars,
             ct);
-        return new { terminal };
+        return new TerminalWriteResult { Terminal = terminal };
     }
 
     private async Task<object?> HandleTerminalStopAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -62,7 +62,7 @@ internal sealed class TerminalRequestHandler(
             throw AppServerErrors.InvalidParams("'sessionId' is required.");
 
         var terminal = await service.StopAsync(p.SessionId, ct);
-        return new { terminal };
+        return new TerminalStopResult { Terminal = terminal };
     }
 
     private async Task<object?> HandleTerminalCleanAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -74,7 +74,7 @@ internal sealed class TerminalRequestHandler(
 
         await sessionService.CleanBackgroundTerminalsAsync(p.ThreadId, ct);
         var terminals = await service.ListAsync(p.ThreadId, ct);
-        return new { terminals };
+        return new TerminalCleanResult { Terminals = terminals };
     }
 
     private IBackgroundTerminalService RequireBackgroundTerminals()

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/ThreadRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/ThreadRequestHandler.cs
@@ -99,9 +99,9 @@ internal sealed class ThreadRequestHandler(
         var startedWire = await threadProjector.ProjectAsync(thread, true, false, ct);
         await responseWriter.SendNotificationAfterResponseAsync(
             msg.Id,
-            new { thread = startedWire },
+            new ThreadStartResult { Thread = startedWire },
             AppServerMethods.ThreadStarted,
-            new { thread = startedWire },
+            new ThreadStartedNotification { Thread = startedWire },
             ct);
 
         return null;
@@ -184,9 +184,9 @@ internal sealed class ThreadRequestHandler(
 
         await responseWriter.SendNotificationAfterResponseAsync(
             msg.Id,
-            new { thread = responseWire },
+            new ThreadForkResult { Thread = responseWire },
             AppServerMethods.ThreadStarted,
-            new { thread = notificationWire },
+            new ThreadStartedNotification { Thread = notificationWire },
             ct);
 
         return null;
@@ -210,8 +210,8 @@ internal sealed class ThreadRequestHandler(
 
         var resumedBy = connection.ClientInfo?.Name ?? "appserver";
         var resumedWire = await threadProjector.ProjectAsync(thread, true, false, ct);
-        var responseResult = new { thread = resumedWire };
-        var notifParams = new { thread = resumedWire, resumedBy };
+        var responseResult = new ThreadResumeResult { Thread = resumedWire };
+        var notifParams = new ThreadResumedNotification { Thread = resumedWire, ResumedBy = resumedBy };
 
         if (connection.HasSubscription(p.ThreadId))
         {
@@ -415,7 +415,7 @@ internal sealed class ThreadRequestHandler(
             msg.Id,
             result,
             AppServerMethods.ThreadGoalUpdated,
-            new { threadId = goal.ThreadId, goal = wireGoal, turnId = (string?)null },
+            new ThreadGoalUpdatedNotification { ThreadId = goal.ThreadId, Goal = wireGoal },
             ct);
         return null;
     }
@@ -440,7 +440,7 @@ internal sealed class ThreadRequestHandler(
             msg.Id,
             wireResult,
             AppServerMethods.ThreadGoalCleared,
-            new { threadId = p.ThreadId },
+            new ThreadGoalClearedNotification { ThreadId = p.ThreadId },
             ct);
         return null;
     }
@@ -474,7 +474,7 @@ internal sealed class ThreadRequestHandler(
     {
         var p = AppServerParams.Get<ThreadMaintenanceInterruptParams>(msg);
         await sessionService.CancelThreadMaintenanceAsync(p.ThreadId, ct);
-        return new { };
+        return new RpcEmpty();
     }
 
     private async Task<object?> HandleThreadRollbackAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -499,7 +499,7 @@ internal sealed class ThreadRequestHandler(
         if (!connection.TryAddSubscription(p.ThreadId, subCts))
         {
             subCts.Dispose();
-            await responseWriter.WriteResponseAsync(msg.Id, new { }, ct);
+            await responseWriter.WriteResponseAsync(msg.Id, new RpcEmpty(), ct);
             SchedulePendingInteractiveRequestReplay(p.ThreadId);
             return null;
         }
@@ -526,7 +526,7 @@ internal sealed class ThreadRequestHandler(
                         $"[AppServer] Subscription error for thread {p.ThreadId}: {t.Exception?.GetBaseException().Message}");
             }, TaskContinuationOptions.ExecuteSynchronously);
 
-        await responseWriter.WriteResponseAsync(msg.Id, new { }, ct);
+        await responseWriter.WriteResponseAsync(msg.Id, new RpcEmpty(), ct);
         SchedulePendingInteractiveRequestReplay(p.ThreadId);
         return null;
     }
@@ -536,7 +536,7 @@ internal sealed class ThreadRequestHandler(
         _ = ct;
         var p = AppServerParams.Get<ThreadUnsubscribeParams>(msg);
         connection.TryCancelSubscription(p.ThreadId);
-        return Task.FromResult<object?>(new { });
+        return Task.FromResult<object?>(new RpcEmpty());
     }
 
     private void SchedulePendingInteractiveRequestReplay(string threadId)
@@ -703,19 +703,24 @@ internal sealed class ThreadRequestHandler(
         await sessionService.PauseThreadAsync(p.ThreadId, ct);
 
         if (previousStatus == ThreadStatus.Paused)
-            return new { };
+            return new RpcEmpty();
 
         if (connection.HasSubscription(p.ThreadId))
         {
-            await responseWriter.WriteResponseAsync(msg.Id, new { }, ct);
+            await responseWriter.WriteResponseAsync(msg.Id, new RpcEmpty(), ct);
             return null;
         }
 
         await responseWriter.SendNotificationAfterResponseAsync(
             msg.Id,
-            new { },
+            new RpcEmpty(),
             AppServerMethods.ThreadStatusChanged,
-            new { threadId = p.ThreadId, previousStatus, newStatus = ThreadStatus.Paused },
+            new ThreadStatusChangedNotification
+            {
+                ThreadId = p.ThreadId,
+                PreviousStatus = previousStatus,
+                NewStatus = ThreadStatus.Paused
+            },
             ct);
         return null;
     }
@@ -729,22 +734,27 @@ internal sealed class ThreadRequestHandler(
         await sessionService.ArchiveThreadAsync(p.ThreadId, ct);
 
         if (previousStatus == ThreadStatus.Archived)
-            return new { };
+            return new RpcEmpty();
 
         var socialBindingCleanup = threadProjector.RevokeSocialAppBindingsForArchivedThread(thread);
         if (connection.HasSubscription(p.ThreadId))
         {
-            await responseWriter.WriteResponseAsync(msg.Id, new { }, ct);
+            await responseWriter.WriteResponseAsync(msg.Id, new RpcEmpty(), ct);
             await SendArchiveSocialBindingNotificationsAsync(socialBindingCleanup, ct);
             return null;
         }
 
-        await responseWriter.WriteResponseAsync(msg.Id, new { }, ct);
+        await responseWriter.WriteResponseAsync(msg.Id, new RpcEmpty(), ct);
         await transport.WriteMessageAsync(new
         {
             jsonrpc = "2.0",
             method = AppServerMethods.ThreadStatusChanged,
-            @params = new { threadId = p.ThreadId, previousStatus, newStatus = ThreadStatus.Archived }
+            @params = new ThreadStatusChangedNotification
+            {
+                ThreadId = p.ThreadId,
+                PreviousStatus = previousStatus,
+                NewStatus = ThreadStatus.Archived
+            }
         }, ct);
         await SendArchiveSocialBindingNotificationsAsync(socialBindingCleanup, ct);
         return null;
@@ -760,14 +770,14 @@ internal sealed class ThreadRequestHandler(
             {
                 jsonrpc = "2.0",
                 method = ThreadAppBindingsChanged,
-                @params = new
+                @params = new ThreadAppBindingsChangedNotification
                 {
-                    threadId = binding.ThreadId,
-                    bindingId = binding.BindingId,
-                    appId = binding.AppId,
-                    state = binding.State,
-                    previousState = AppBindingStates.Active,
-                    changeKind = "threadArchived"
+                    ThreadId = binding.ThreadId,
+                    BindingId = binding.BindingId,
+                    AppId = binding.AppId,
+                    State = binding.State,
+                    PreviousState = AppBindingStates.Active,
+                    ChangeKind = "threadArchived"
                 }
             }, ct);
         }
@@ -783,19 +793,24 @@ internal sealed class ThreadRequestHandler(
         await sessionService.UnarchiveThreadAsync(p.ThreadId, ct);
 
         if (previousStatus == ThreadStatus.Active)
-            return new { };
+            return new RpcEmpty();
 
         if (connection.HasSubscription(p.ThreadId))
         {
-            await responseWriter.WriteResponseAsync(msg.Id, new { }, ct);
+            await responseWriter.WriteResponseAsync(msg.Id, new RpcEmpty(), ct);
             return null;
         }
 
         await responseWriter.SendNotificationAfterResponseAsync(
             msg.Id,
-            new { },
+            new RpcEmpty(),
             AppServerMethods.ThreadStatusChanged,
-            new { threadId = p.ThreadId, previousStatus, newStatus = ThreadStatus.Active },
+            new ThreadStatusChangedNotification
+            {
+                ThreadId = p.ThreadId,
+                PreviousStatus = previousStatus,
+                NewStatus = ThreadStatus.Active
+            },
             ct);
         return null;
     }
@@ -806,7 +821,7 @@ internal sealed class ThreadRequestHandler(
         var thread = await sessionService.GetThreadAsync(p.ThreadId, ct);
         await sessionService.DeleteThreadPermanentlyAsync(p.ThreadId, ct);
         threadProjector.RevokeAppBindingsForDeletedThread(thread);
-        return new { };
+        return new RpcEmpty();
     }
 
     private async Task<object?> HandleThreadRenameAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -815,14 +830,14 @@ internal sealed class ThreadRequestHandler(
         if (string.IsNullOrWhiteSpace(p.DisplayName))
             throw AppServerErrors.InvalidParams("'displayName' must not be empty.");
         await sessionService.RenameThreadAsync(p.ThreadId, p.DisplayName, ct);
-        return new { };
+        return new RpcEmpty();
     }
 
     private async Task<object?> HandleThreadModeSetAsync(AppServerIncomingMessage msg, CancellationToken ct)
     {
         var p = AppServerParams.Get<ThreadModeSetParams>(msg);
         await sessionService.SetThreadModeAsync(p.ThreadId, p.Mode, ct);
-        return new { };
+        return new RpcEmpty();
     }
 
     private async Task<object?> HandleThreadConfigUpdateAsync(AppServerIncomingMessage msg, CancellationToken ct)
@@ -830,7 +845,7 @@ internal sealed class ThreadRequestHandler(
         var p = AppServerParams.Get<ThreadConfigUpdateParams>(msg);
         ValidateRuntimeConfiguration(p.Config);
         await sessionService.UpdateThreadConfigurationAsync(p.ThreadId, p.Config, ct);
-        return new { };
+        return new RpcEmpty();
     }
 
     private void ValidateRuntimeConfiguration(ThreadConfiguration? config)

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/TurnRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/TurnRequestHandler.cs
@@ -109,7 +109,7 @@ internal sealed class TurnRequestHandler(
 
         async Task OnTurnStarted(SessionWireTurn initialTurn)
         {
-            var responsePayload = new { turn = initialTurn };
+            var responsePayload = new TurnStartResult { Turn = initialTurn };
             try
             {
                 await responseWriter.WriteResponseAsync(msg.Id, responsePayload, ct);
@@ -166,7 +166,7 @@ internal sealed class TurnRequestHandler(
                         var wireTurn = startedTurn.ToWire(includeItems: false) with { Items = [] };
                         try
                         {
-                            await responseWriter.WriteResponseAsync(msg.Id, new { turn = wireTurn }, ct);
+                            await responseWriter.WriteResponseAsync(msg.Id, new TurnStartResult { Turn = wireTurn }, ct);
                         }
                         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
                         {
@@ -371,7 +371,7 @@ internal sealed class TurnRequestHandler(
         }
 
         await sessionService.CancelTurnAsync(p.ThreadId, p.TurnId, ct);
-        return new { };
+        return new RpcEmpty();
     }
 
     private void ValidateTurnStartInput(IReadOnlyList<SessionWireInputPart> input)

--- a/src/DotCraft.Core/Protocol/AppServer/Handlers/WorktreeRequestHandler.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Handlers/WorktreeRequestHandler.cs
@@ -53,7 +53,7 @@ internal sealed class WorktreeRequestHandler(
             msg.Id,
             new WorktreeCreateAndForkResponse { Thread = responseWire, Worktree = result.Worktree },
             AppServerMethods.ThreadStarted,
-            new { thread = notificationWire },
+            new ThreadStartedNotification { Thread = notificationWire },
             ct);
 
         return null;
@@ -87,7 +87,7 @@ internal sealed class WorktreeRequestHandler(
             msg.Id,
             new WorktreeCreateAndStartResponse { Thread = startedWire, Worktree = result.Worktree },
             AppServerMethods.ThreadStarted,
-            new { thread = startedWire },
+            new ThreadStartedNotification { Thread = startedWire },
             ct);
 
         return null;
@@ -125,7 +125,7 @@ internal sealed class WorktreeRequestHandler(
             msg.Id,
             response,
             AppServerMethods.ThreadUpdated,
-            new { thread = wire },
+            new ThreadUpdatedNotification { Thread = wire },
             ct);
 
         return null;

--- a/src/DotCraft.Core/Protocol/AppServer/Transport/AppServerEventDispatcher.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Transport/AppServerEventDispatcher.cs
@@ -214,11 +214,11 @@ public sealed class AppServerEventDispatcher
 
     private async ValueTask<object> BuildItemCompletedParamsAsync(
         SessionEvent evt,
-        CancellationToken cancellationToken) => new
+        CancellationToken cancellationToken) => new ItemCompletedNotification
     {
-        threadId = evt.ThreadId,
-        turnId = evt.TurnId,
-        item = await ToLiveItemWireAsync(evt, cancellationToken).ConfigureAwait(false)
+        ThreadId = evt.ThreadId,
+        TurnId = evt.TurnId,
+        Item = await ToLiveItemWireAsync(evt, cancellationToken).ConfigureAwait(false)
     };
 
     private async ValueTask<object> BuildTerminalTurnParamsAsync(
@@ -234,9 +234,17 @@ public sealed class AppServerEventDispatcher
             cancellationToken).ConfigureAwait(false);
         return evt.EventType switch
         {
-            SessionEventType.TurnFailed => new { turn, error = evt.TurnFailedPayload?.Error },
-            SessionEventType.TurnCancelled => new { turn, reason = evt.TurnCancelledPayload?.Reason },
-            _ => new { turn }
+            SessionEventType.TurnFailed => new TurnFailedNotification
+            {
+                Turn = turn,
+                Error = evt.TurnFailedPayload?.Error
+            },
+            SessionEventType.TurnCancelled => new TurnCancelledNotification
+            {
+                Turn = turn,
+                Reason = evt.TurnCancelledPayload?.Reason
+            },
+            _ => new TurnCompletedNotification { Turn = turn }
         };
     }
 
@@ -280,154 +288,154 @@ public sealed class AppServerEventDispatcher
     private object? BuildParams(SessionEvent evt) => evt.EventType switch
     {
         // Thread notifications (spec Section 6.1)
-        SessionEventType.ThreadCreated => new
+        SessionEventType.ThreadCreated => new ThreadStartedNotification
         {
-            thread = EnrichThreadWire(evt.ThreadPayload?.ToWire())
+            Thread = EnrichThreadWire(evt.ThreadPayload?.ToWire())
         },
-        SessionEventType.ThreadResumed => new
+        SessionEventType.ThreadResumed => new ThreadResumedNotification
         {
-            thread = EnrichThreadWire(evt.ThreadPayload?.ToWire()),
-            resumedBy = evt.ResumedPayload?.ResumedBy
+            Thread = EnrichThreadWire(evt.ThreadPayload?.ToWire()),
+            ResumedBy = evt.ResumedPayload?.ResumedBy
         },
-        SessionEventType.ThreadStatusChanged => new
+        SessionEventType.ThreadStatusChanged => new ThreadStatusChangedNotification
         {
-            threadId = evt.ThreadId,
-            previousStatus = evt.StatusChangedPayload?.PreviousStatus,
-            newStatus = evt.StatusChangedPayload?.NewStatus
+            ThreadId = evt.ThreadId,
+            PreviousStatus = evt.StatusChangedPayload?.PreviousStatus,
+            NewStatus = evt.StatusChangedPayload?.NewStatus
         },
-        SessionEventType.ThreadQueueUpdated when evt.ThreadQueueUpdatedPayload is { } queue => new
+        SessionEventType.ThreadQueueUpdated when evt.ThreadQueueUpdatedPayload is { } queue => new ThreadQueueUpdatedNotification
         {
-            threadId = queue.ThreadId,
-            queuedInputs = queue.QueuedInputs
+            ThreadId = queue.ThreadId,
+            QueuedInputs = queue.QueuedInputs
         },
 
         // Turn notifications (spec Section 6.2)
-        SessionEventType.TurnStarted => new
+        SessionEventType.TurnStarted => new TurnStartedNotification
         {
-            turn = ToWireTurnForConnection(evt.TurnPayload)
+            Turn = ToWireTurnForConnection(evt.TurnPayload)
         },
-        SessionEventType.TurnCompleted => new
+        SessionEventType.TurnCompleted => new TurnCompletedNotification
         {
-            turn = ToWireTurnForConnection(evt.TurnPayload)
+            Turn = ToWireTurnForConnection(evt.TurnPayload)
         },
-        SessionEventType.TurnFailed => new
+        SessionEventType.TurnFailed => new TurnFailedNotification
         {
-            turn = ToWireTurnForConnection(evt.TurnPayload),
-            error = evt.TurnFailedPayload?.Error
+            Turn = ToWireTurnForConnection(evt.TurnPayload),
+            Error = evt.TurnFailedPayload?.Error
         },
-        SessionEventType.TurnCancelled => new
+        SessionEventType.TurnCancelled => new TurnCancelledNotification
         {
-            turn = ToWireTurnForConnection(evt.TurnPayload),
-            reason = evt.TurnCancelledPayload?.Reason
+            Turn = ToWireTurnForConnection(evt.TurnPayload),
+            Reason = evt.TurnCancelledPayload?.Reason
         },
 
         // Item notifications (spec Section 6.3)
-        SessionEventType.ItemStarted => new
+        SessionEventType.ItemStarted => new ItemStartedNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            item = evt.ItemPayload?.ToWire()
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            Item = evt.ItemPayload?.ToWire()
         },
         // Fix 1: Include deltaKind so clients can distinguish agentMessage from reasoningContent
         // without inspecting surrounding state (spec Section 2.3).
-        SessionEventType.ItemDelta when evt.DeltaPayload is { } delta => new
+        SessionEventType.ItemDelta when evt.DeltaPayload is { } delta => new ItemDeltaNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            itemId = evt.ItemId,
-            deltaKind = delta.DeltaKind,
-            delta = delta.TextDelta
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            ItemId = evt.ItemId,
+            DeltaKind = delta.DeltaKind,
+            Delta = delta.TextDelta
         },
-        SessionEventType.ItemDelta when evt.CommandExecutionDeltaPayload is { } commandDelta => new
+        SessionEventType.ItemDelta when evt.CommandExecutionDeltaPayload is { } commandDelta => new ItemDeltaNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            itemId = evt.ItemId,
-            delta = commandDelta.TextDelta
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            ItemId = evt.ItemId,
+            Delta = commandDelta.TextDelta
         },
-        SessionEventType.ItemDelta when evt.ReasoningDeltaPayload is { } reasoning => new
+        SessionEventType.ItemDelta when evt.ReasoningDeltaPayload is { } reasoning => new ItemDeltaNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            itemId = evt.ItemId,
-            deltaKind = reasoning.DeltaKind,
-            delta = reasoning.TextDelta
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            ItemId = evt.ItemId,
+            DeltaKind = reasoning.DeltaKind,
+            Delta = reasoning.TextDelta
         },
-        SessionEventType.ItemDelta when evt.ToolCallArgumentsDeltaPayload is { } toolCallDelta => new
+        SessionEventType.ItemDelta when evt.ToolCallArgumentsDeltaPayload is { } toolCallDelta => new ItemDeltaNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            itemId = evt.ItemId,
-            deltaKind = toolCallDelta.DeltaKind,
-            toolName = toolCallDelta.ToolName,
-            callId = toolCallDelta.CallId,
-            delta = toolCallDelta.Delta
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            ItemId = evt.ItemId,
+            DeltaKind = toolCallDelta.DeltaKind,
+            ToolName = toolCallDelta.ToolName,
+            CallId = toolCallDelta.CallId,
+            Delta = toolCallDelta.Delta
         },
-        SessionEventType.ItemCompleted => new
+        SessionEventType.ItemCompleted => new ItemCompletedNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            item = evt.ItemPayload?.ToWire()
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            Item = evt.ItemPayload?.ToWire()
         },
 
         // Approval resolved notification (spec Section 6.4)
-        SessionEventType.ApprovalResolved => new
+        SessionEventType.ApprovalResolved => new ApprovalResolvedNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            item = evt.ItemPayload?.ToWire()
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            Item = evt.ItemPayload?.ToWire()
         },
 
         // Model question resolved notification.
-        SessionEventType.UserInputResolved => new
+        SessionEventType.UserInputResolved => new UserInputResolvedNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            item = evt.ItemPayload?.ToWire()
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            Item = evt.ItemPayload?.ToWire()
         },
 
         // SubAgent progress notification (spec Section 6.5)
-        SessionEventType.SubAgentProgress when evt.SubAgentProgressPayload is { } progress => new
+        SessionEventType.SubAgentProgress when evt.SubAgentProgressPayload is { } progress => new SubAgentProgressNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            entries = progress.Entries
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            Entries = progress.Entries
         },
 
         // Usage delta notification (spec Section 6.6)
-        SessionEventType.UsageDelta when evt.UsageDeltaPayload is { } usage => new
+        SessionEventType.UsageDelta when evt.UsageDeltaPayload is { } usage => new UsageDeltaNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            inputTokens = usage.InputTokens,
-            outputTokens = usage.OutputTokens,
-            cachedInputTokens = usage.CachedInputTokens,
-            cacheWriteInputTokens = usage.CacheWriteInputTokens,
-            freshInputTokens = usage.FreshInputTokens,
-            reasoningOutputTokens = usage.ReasoningOutputTokens,
-            llmCallDelta = usage.LlmCallDelta,
-            totalInputTokens = usage.TotalInputTokens,
-            totalOutputTokens = usage.TotalOutputTokens,
-            contextInputTokens = usage.ContextInputTokens,
-            turnInputTokens = usage.TurnInputTokens,
-            turnOutputTokens = usage.TurnOutputTokens,
-            turnLlmCalls = usage.TurnLlmCalls,
-            contextUsage = usage.ContextUsage
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            InputTokens = usage.InputTokens,
+            OutputTokens = usage.OutputTokens,
+            CachedInputTokens = usage.CachedInputTokens,
+            CacheWriteInputTokens = usage.CacheWriteInputTokens,
+            FreshInputTokens = usage.FreshInputTokens,
+            ReasoningOutputTokens = usage.ReasoningOutputTokens,
+            LlmCallDelta = usage.LlmCallDelta,
+            TotalInputTokens = usage.TotalInputTokens,
+            TotalOutputTokens = usage.TotalOutputTokens,
+            ContextInputTokens = usage.ContextInputTokens,
+            TurnInputTokens = usage.TurnInputTokens,
+            TurnOutputTokens = usage.TurnOutputTokens,
+            TurnLlmCalls = usage.TurnLlmCalls,
+            ContextUsage = usage.ContextUsage
         },
 
         // System event notification (spec Section 6.7)
-        SessionEventType.SystemEvent when evt.SystemEventPayload is { } sysEvt => new
+        SessionEventType.SystemEvent when evt.SystemEventPayload is { } sysEvt => new SystemEventNotification
         {
-            threadId = evt.ThreadId,
-            turnId = evt.TurnId,
-            kind = sysEvt.Kind,
-            messageKey = sysEvt.MessageKey,
-            @params = sysEvt.Params,
-            fallbackText = sysEvt.FallbackText,
-            message = sysEvt.Message,
-            percentLeft = sysEvt.PercentLeft,
-            tokenCount = sysEvt.TokenCount,
-            contextUsage = sysEvt.ContextUsage
+            ThreadId = evt.ThreadId,
+            TurnId = evt.TurnId,
+            Kind = sysEvt.Kind,
+            MessageKey = sysEvt.MessageKey,
+            Params = sysEvt.Params,
+            FallbackText = sysEvt.FallbackText,
+            Message = sysEvt.Message,
+            PercentLeft = sysEvt.PercentLeft,
+            TokenCount = sysEvt.TokenCount,
+            ContextUsage = sysEvt.ContextUsage
         },
 
         _ => null

--- a/src/DotCraft.Core/Protocol/AppServer/Transport/AppServerWireClient.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Transport/AppServerWireClient.cs
@@ -71,27 +71,19 @@ public sealed class AppServerWireClient(Stream input, Stream output) : IAsyncDis
         IReadOnlyList<string>? optOutMethods = null,
         AcpExtensionCapability? acpExtensions = null)
     {
-        object capabilities = acpExtensions is null
-            ? new
-            {
-                approvalSupport,
-                streamingSupport,
-                toolExecutionLifecycle,
-                optOutNotificationMethods = optOutMethods ?? Array.Empty<string>()
-            }
-            : new
-            {
-                approvalSupport,
-                streamingSupport,
-                toolExecutionLifecycle,
-                optOutNotificationMethods = optOutMethods ?? Array.Empty<string>(),
-                acpExtensions
-            };
-
-        var result = await SendRequestAsync(AppServerMethods.Initialize, new
+        var capabilities = new AppServerClientCapabilities
         {
-            clientInfo = new { name = clientName, version = clientVersion },
-            capabilities
+            ApprovalSupport = approvalSupport,
+            StreamingSupport = streamingSupport,
+            ToolExecutionLifecycle = toolExecutionLifecycle,
+            OptOutNotificationMethods = [.. optOutMethods ?? []],
+            AcpExtensions = acpExtensions
+        };
+
+        var result = await SendRequestAsync(AppServerMethods.Initialize, new AppServerInitializeParams
+        {
+            ClientInfo = new AppServerClientInfo { Name = clientName, Version = clientVersion },
+            Capabilities = capabilities
         });
         await SendNotificationAsync(AppServerMethods.Initialized);
         return result;
@@ -384,7 +376,7 @@ public sealed class AppServerWireClient(Stream input, Stream output) : IAsyncDis
     {
         var doc = await SendRequestAsync(
             AppServerMethods.CronList,
-            new { includeDisabled },
+            new CronListParams { IncludeDisabled = includeDisabled },
             ct: ct);
 
         ThrowIfError(doc, "cron/list");
@@ -402,7 +394,7 @@ public sealed class AppServerWireClient(Stream input, Stream output) : IAsyncDis
     {
         var doc = await SendRequestAsync(
             AppServerMethods.CronRemove,
-            new { jobId },
+            new CronRemoveParams { JobId = jobId },
             ct: ct);
 
         ThrowIfError(doc, jobId);
@@ -419,7 +411,7 @@ public sealed class AppServerWireClient(Stream input, Stream output) : IAsyncDis
     {
         var doc = await SendRequestAsync(
             AppServerMethods.CronEnable,
-            new { jobId, enabled },
+            new CronEnableParams { JobId = jobId, Enabled = enabled },
             ct: ct);
 
         ThrowIfError(doc, jobId);
@@ -437,7 +429,7 @@ public sealed class AppServerWireClient(Stream input, Stream output) : IAsyncDis
     {
         var doc = await SendRequestAsync(
             AppServerMethods.HeartbeatTrigger,
-            new { },
+            new RpcEmpty(),
             timeout: TimeSpan.FromSeconds(120),
             ct: ct);
 

--- a/src/DotCraft.Core/Protocol/AppServer/Transport/StdioTransport.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Transport/StdioTransport.cs
@@ -162,7 +162,11 @@ public sealed class StdioTransport : IAppServerTransport
                     {
                         jsonrpc = "2.0",
                         id = (object?)null,
-                        error = new { code = AppServerErrors.ParseErrorCode, message = "Parse error" }
+                        error = new AppServerError
+                        {
+                            Code = AppServerErrors.ParseErrorCode,
+                            Message = "Parse error"
+                        }
                     };
                     await WriteMessageAsync(parseErrorResponse, ct);
                     continue;

--- a/src/DotCraft.Core/Protocol/AppServer/Transport/WebSocketTransport.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Transport/WebSocketTransport.cs
@@ -210,7 +210,11 @@ public sealed class WebSocketTransport : IAppServerTransport
                     {
                         jsonrpc = "2.0",
                         id = (object?)null,
-                        error = new { code = AppServerErrors.ParseErrorCode, message = "Parse error" }
+                        error = new AppServerError
+                        {
+                            Code = AppServerErrors.ParseErrorCode,
+                            Message = "Parse error"
+                        }
                     };
                     await WriteMessageAsync(parseErrorResponse, ct);
                     continue;

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/AutomationWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/AutomationWire.cs
@@ -193,6 +193,23 @@ public sealed class AutomationTaskDeleteParams
     public string TaskId { get; set; } = string.Empty;
 }
 
+/// <summary>Result for <c>automation/task/delete</c>.</summary>
+public sealed class AutomationTaskDeleteResult
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; set; }
+}
+
+/// <summary>Payload for <c>automation/task/updated</c>.</summary>
+public sealed class AutomationTaskUpdatedNotification
+{
+    [JsonPropertyName("workspacePath")]
+    public string WorkspacePath { get; set; } = string.Empty;
+
+    [JsonPropertyName("task")]
+    public AutomationTaskWire Task { get; set; } = new();
+}
+
 public sealed class AutomationTaskDiscardWorktreeParams
 {
     public string WorkspacePath { get; set; } = string.Empty;

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/ErrorWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/ErrorWire.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace DotCraft.Protocol.AppServer;
+
+/// <summary>Error parameters identifying an RPC method.</summary>
+public sealed record MethodErrorParams([property: JsonPropertyName("method")] string Method);
+
+/// <summary>Error parameters identifying a thread.</summary>
+public sealed record ThreadErrorParams([property: JsonPropertyName("threadId")] string ThreadId);
+
+/// <summary>Error parameters identifying a turn.</summary>
+public sealed record TurnErrorParams([property: JsonPropertyName("turnId")] string TurnId);
+
+/// <summary>Error parameters carrying worktree conflict paths.</summary>
+public sealed record WorktreeConflictErrorParams(
+    [property: JsonPropertyName("conflictPaths")] IReadOnlyList<string> ConflictPaths);
+
+/// <summary>Error parameters identifying an external channel.</summary>
+public sealed record ChannelErrorParams([property: JsonPropertyName("channelName")] string ChannelName);
+
+/// <summary>Error parameters identifying a cron job.</summary>
+public sealed record CronJobErrorParams([property: JsonPropertyName("jobId")] string JobId);
+
+/// <summary>Error parameters identifying a named protocol resource.</summary>
+public sealed record NamedResourceErrorParams([property: JsonPropertyName("name")] string Name);
+
+/// <summary>Error parameters identifying a marketplace.</summary>
+public sealed record MarketplaceErrorParams(
+    [property: JsonPropertyName("marketplaceName")] string MarketplaceName);
+
+/// <summary>Error parameters identifying a command.</summary>
+public sealed record CommandErrorParams([property: JsonPropertyName("command")] string Command);
+
+/// <summary>Error parameters identifying a required App Binding version.</summary>
+public sealed record AppBindingVersionErrorParams(
+    [property: JsonPropertyName("requiredVersion")] int RequiredVersion);
+
+/// <summary>Error parameters identifying an app surface.</summary>
+public sealed record AppSurfaceErrorParams(
+    [property: JsonPropertyName("appId")] string AppId,
+    [property: JsonPropertyName("surfaceId")] string SurfaceId);
+
+/// <summary>Error parameters carrying agent-profile diagnostics.</summary>
+public sealed record AgentProfileDiagnosticsErrorParams(
+    [property: JsonPropertyName("diagnostics")] object Diagnostics);
+
+/// <summary>Error parameters identifying an automation task.</summary>
+public sealed record TaskErrorParams([property: JsonPropertyName("taskId")] string TaskId);

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/ExtensionWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/ExtensionWire.cs
@@ -1,0 +1,116 @@
+using System.Text.Json.Serialization;
+
+namespace DotCraft.Protocol.AppServer;
+
+internal interface IAcpThreadBoundParams
+{
+    string ThreadId { get; set; }
+}
+
+/// <summary>Parameters for <c>ext/acp/fs/readTextFile</c>.</summary>
+public sealed class AcpFsReadTextFileParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("path")] public string Path { get; set; } = string.Empty;
+    [JsonPropertyName("offset")] public int? Offset { get; set; }
+    [JsonPropertyName("limit")] public int? Limit { get; set; }
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Result for <c>ext/acp/fs/readTextFile</c>.</summary>
+public sealed class AcpFsReadTextFileResult
+{
+    [JsonPropertyName("content")] public string? Content { get; set; }
+}
+
+/// <summary>Parameters for <c>ext/acp/fs/writeTextFile</c>.</summary>
+public sealed class AcpFsWriteTextFileParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("path")] public string Path { get; set; } = string.Empty;
+    [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Result for <c>ext/acp/fs/writeTextFile</c>.</summary>
+public sealed class AcpFsWriteTextFileResult
+{
+    [JsonPropertyName("success")] public bool Success { get; set; }
+}
+
+/// <summary>Parameters for <c>ext/acp/terminal/create</c>.</summary>
+public sealed class AcpTerminalCreateParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("command")] public string Command { get; set; } = string.Empty;
+    [JsonPropertyName("cwd")] public string? Cwd { get; set; }
+    [JsonPropertyName("env")] public Dictionary<string, string>? Env { get; set; }
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Result for <c>ext/acp/terminal/create</c>.</summary>
+public sealed class AcpTerminalCreateResult
+{
+    [JsonPropertyName("terminalId")] public string? TerminalId { get; set; }
+}
+
+/// <summary>Parameters for terminal output requests.</summary>
+public sealed class AcpTerminalGetOutputParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("terminalId")] public string TerminalId { get; set; } = string.Empty;
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Parameters for <c>ext/acp/terminal/waitForExit</c>.</summary>
+public sealed class AcpTerminalWaitForExitParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("terminalId")] public string TerminalId { get; set; } = string.Empty;
+    [JsonPropertyName("timeout")] public int? Timeout { get; set; }
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Parameters for <c>ext/acp/terminal/kill</c>.</summary>
+public sealed class AcpTerminalKillParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("terminalId")] public string TerminalId { get; set; } = string.Empty;
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Parameters for <c>ext/acp/terminal/release</c>.</summary>
+public sealed class AcpTerminalReleaseParams : IAcpThreadBoundParams
+{
+    [JsonPropertyName("terminalId")] public string TerminalId { get; set; } = string.Empty;
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Result for ACP terminal output and wait requests.</summary>
+public sealed class AcpTerminalOutputResult
+{
+    [JsonPropertyName("output")] public string? Output { get; set; }
+    [JsonPropertyName("exitCode")] public int? ExitCode { get; set; }
+}
+
+/// <summary>Parameters for <c>ext/nodeRepl/evaluate</c>.</summary>
+public sealed class NodeReplEvaluateParams
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("evaluationId")] public string EvaluationId { get; set; } = string.Empty;
+    [JsonPropertyName("browserSession")] public NodeReplBrowserSessionParams BrowserSession { get; set; } = new();
+    [JsonPropertyName("code")] public string Code { get; set; } = string.Empty;
+    [JsonPropertyName("timeoutMs")] public int TimeoutMs { get; set; }
+}
+
+/// <summary>Browser-session routing nested in a Node REPL evaluation request.</summary>
+public sealed class NodeReplBrowserSessionParams
+{
+    [JsonPropertyName("protocolVersion")] public int ProtocolVersion { get; set; }
+    [JsonPropertyName("sessionId")] public string SessionId { get; set; } = string.Empty;
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("evaluationId")] public string EvaluationId { get; set; } = string.Empty;
+}
+
+/// <summary>Parameters for <c>ext/nodeRepl/cancel</c>.</summary>
+public sealed class NodeReplCancelParams
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("evaluationId")] public string EvaluationId { get; set; } = string.Empty;
+}

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/LifecycleWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/LifecycleWire.cs
@@ -1,0 +1,390 @@
+using System.Text.Json.Serialization;
+using DotCraft.Tools.BackgroundTerminals;
+
+namespace DotCraft.Protocol.AppServer;
+
+/// <summary>Shared empty JSON object used by AppServer methods with no parameters or result fields.</summary>
+public sealed class RpcEmpty
+{
+}
+
+/// <summary>Result for <c>thread/start</c>.</summary>
+public sealed class ThreadStartResult
+{
+    [JsonPropertyName("thread")]
+    public SessionWireThread Thread { get; set; } = new();
+}
+
+/// <summary>Result for <c>thread/fork</c>.</summary>
+public sealed class ThreadForkResult
+{
+    [JsonPropertyName("thread")]
+    public SessionWireThread Thread { get; set; } = new();
+}
+
+/// <summary>Result for <c>thread/resume</c>.</summary>
+public sealed class ThreadResumeResult
+{
+    [JsonPropertyName("thread")]
+    public SessionWireThread Thread { get; set; } = new();
+}
+
+/// <summary>Result for <c>turn/start</c>.</summary>
+public sealed class TurnStartResult
+{
+    [JsonPropertyName("turn")]
+    public SessionWireTurn Turn { get; set; } = new();
+}
+
+/// <summary>Payload for <c>thread/started</c>.</summary>
+public sealed class ThreadStartedNotification
+{
+    [JsonPropertyName("thread")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireThread? Thread { get; set; }
+}
+
+/// <summary>Payload for <c>thread/resumed</c>.</summary>
+public sealed class ThreadResumedNotification
+{
+    [JsonPropertyName("thread")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireThread? Thread { get; set; }
+
+    [JsonPropertyName("resumedBy")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ResumedBy { get; set; }
+}
+
+/// <summary>Payload for <c>thread/updated</c>.</summary>
+public sealed class ThreadUpdatedNotification
+{
+    [JsonPropertyName("thread")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireThread? Thread { get; set; }
+}
+
+/// <summary>Payload for <c>thread/renamed</c>.</summary>
+public sealed class ThreadRenamedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+}
+
+/// <summary>Payload for <c>thread/deleted</c> and other thread-id-only notifications.</summary>
+public sealed class ThreadDeletedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Payload for <c>thread/status/changed</c>.</summary>
+public sealed class ThreadStatusChangedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("previousStatus")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ThreadStatus? PreviousStatus { get; set; }
+
+    [JsonPropertyName("newStatus")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ThreadStatus? NewStatus { get; set; }
+}
+
+/// <summary>Payload for <c>thread/queue/updated</c>.</summary>
+public sealed class ThreadQueueUpdatedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("queuedInputs")]
+    public IReadOnlyList<QueuedTurnInput> QueuedInputs { get; set; } = [];
+}
+
+/// <summary>Payload for <c>thread/goal/updated</c>.</summary>
+public sealed class ThreadGoalUpdatedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("goal")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ThreadGoalWire? Goal { get; set; }
+
+    [JsonPropertyName("turnId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TurnId { get; set; }
+}
+
+/// <summary>Payload for <c>thread/goal/cleared</c>.</summary>
+public sealed class ThreadGoalClearedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Payload for <c>turn/started</c>.</summary>
+public sealed class TurnStartedNotification
+{
+    [JsonPropertyName("turn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireTurn? Turn { get; set; }
+}
+
+/// <summary>Payload for <c>turn/completed</c>.</summary>
+public sealed class TurnCompletedNotification
+{
+    [JsonPropertyName("turn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireTurn? Turn { get; set; }
+}
+
+/// <summary>Payload for <c>turn/failed</c>.</summary>
+public sealed class TurnFailedNotification
+{
+    [JsonPropertyName("turn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireTurn? Turn { get; set; }
+
+    [JsonPropertyName("error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Error { get; set; }
+}
+
+/// <summary>Payload for <c>turn/cancelled</c>.</summary>
+public sealed class TurnCancelledNotification
+{
+    [JsonPropertyName("turn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireTurn? Turn { get; set; }
+
+    [JsonPropertyName("reason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Reason { get; set; }
+}
+
+/// <summary>Payload for <c>item/started</c>.</summary>
+public sealed class ItemStartedNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("turnId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TurnId { get; set; }
+
+    [JsonPropertyName("item")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SessionWireItem? Item { get; set; }
+}
+
+/// <summary>Payload for <c>item/completed</c>.</summary>
+public sealed class ItemCompletedNotification
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("item"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public SessionWireItem? Item { get; set; }
+}
+
+/// <summary>Payload for <c>item/approval/resolved</c>.</summary>
+public sealed class ApprovalResolvedNotification
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("item"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public SessionWireItem? Item { get; set; }
+}
+
+/// <summary>Payload for <c>item/tool/requestUserInput/resolved</c>.</summary>
+public sealed class UserInputResolvedNotification
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("item"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public SessionWireItem? Item { get; set; }
+}
+
+/// <summary>Payload for item delta notifications.</summary>
+public sealed class ItemDeltaNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("turnId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TurnId { get; set; }
+
+    [JsonPropertyName("itemId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ItemId { get; set; }
+
+    [JsonPropertyName("deltaKind")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DeltaKind { get; set; }
+
+    [JsonPropertyName("toolName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ToolName { get; set; }
+
+    [JsonPropertyName("callId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CallId { get; set; }
+
+    [JsonPropertyName("delta")]
+    public string Delta { get; set; } = string.Empty;
+}
+
+/// <summary>Payload for persisted item delta event data.</summary>
+public sealed class ItemDeltaPayloadWire
+{
+    [JsonPropertyName("deltaKind")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DeltaKind { get; set; }
+
+    [JsonPropertyName("toolName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ToolName { get; set; }
+
+    [JsonPropertyName("callId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CallId { get; set; }
+
+    [JsonPropertyName("delta")]
+    public string Delta { get; set; } = string.Empty;
+}
+
+/// <summary>Payload for <c>subagent/progress</c>.</summary>
+public sealed class SubAgentProgressNotification
+{
+    [JsonPropertyName("threadId")]
+    public string ThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("turnId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TurnId { get; set; }
+
+    [JsonPropertyName("entries")]
+    public IReadOnlyList<SubAgentProgressEntry> Entries { get; set; } = [];
+}
+
+/// <summary>Payload for <c>subagent/graph/changed</c>.</summary>
+public sealed class SubAgentGraphChangedNotification
+{
+    [JsonPropertyName("parentThreadId")]
+    public string ParentThreadId { get; set; } = string.Empty;
+
+    [JsonPropertyName("childThreadId")]
+    public string ChildThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Payload for <c>item/usage/delta</c>.</summary>
+public sealed class UsageDeltaNotification
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("inputTokens")] public long InputTokens { get; set; }
+    [JsonPropertyName("outputTokens")] public long OutputTokens { get; set; }
+    [JsonPropertyName("cachedInputTokens")] public long CachedInputTokens { get; set; }
+    [JsonPropertyName("cacheWriteInputTokens")] public long CacheWriteInputTokens { get; set; }
+    [JsonPropertyName("freshInputTokens")] public long FreshInputTokens { get; set; }
+    [JsonPropertyName("reasoningOutputTokens")] public long ReasoningOutputTokens { get; set; }
+    [JsonPropertyName("llmCallDelta")] public int LlmCallDelta { get; set; }
+    [JsonPropertyName("totalInputTokens"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public long? TotalInputTokens { get; set; }
+    [JsonPropertyName("totalOutputTokens"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public long? TotalOutputTokens { get; set; }
+    [JsonPropertyName("contextInputTokens"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public long? ContextInputTokens { get; set; }
+    [JsonPropertyName("turnInputTokens"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public long? TurnInputTokens { get; set; }
+    [JsonPropertyName("turnOutputTokens"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public long? TurnOutputTokens { get; set; }
+    [JsonPropertyName("turnLlmCalls"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public int? TurnLlmCalls { get; set; }
+    [JsonPropertyName("contextUsage"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public ContextUsageSnapshot? ContextUsage { get; set; }
+}
+
+/// <summary>Payload for <c>system/event</c>.</summary>
+public sealed class SystemEventNotification
+{
+    [JsonPropertyName("threadId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? ThreadId { get; set; }
+    [JsonPropertyName("turnId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? TurnId { get; set; }
+    [JsonPropertyName("kind")] public string Kind { get; set; } = string.Empty;
+    [JsonPropertyName("messageKey"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? MessageKey { get; set; }
+    [JsonPropertyName("params"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyDictionary<string, object?>? Params { get; set; }
+    [JsonPropertyName("fallbackText"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? FallbackText { get; set; }
+    [JsonPropertyName("message"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Message { get; set; }
+    [JsonPropertyName("percentLeft"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public double? PercentLeft { get; set; }
+    [JsonPropertyName("tokenCount"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public long? TokenCount { get; set; }
+    [JsonPropertyName("contextUsage"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public ContextUsageSnapshot? ContextUsage { get; set; }
+}
+
+/// <summary>Payload for a channel rejection emitted as a <c>system/event</c>.</summary>
+public sealed class ChannelRejectedSystemEventNotification
+{
+    [JsonPropertyName("kind")] public string Kind { get; set; } = string.Empty;
+    [JsonPropertyName("channelName")] public string ChannelName { get; set; } = string.Empty;
+    [JsonPropertyName("message")] public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>Token usage nested in <c>system/jobResult</c>.</summary>
+public sealed class SystemJobTokenUsageWire
+{
+    [JsonPropertyName("inputTokens")] public int InputTokens { get; set; }
+    [JsonPropertyName("outputTokens")] public int OutputTokens { get; set; }
+}
+
+/// <summary>Payload for <c>system/jobResult</c>.</summary>
+public sealed class SystemJobResultNotification
+{
+    [JsonPropertyName("source")] public string Source { get; set; } = string.Empty;
+    [JsonPropertyName("jobId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? JobId { get; set; }
+    [JsonPropertyName("jobName"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? JobName { get; set; }
+    [JsonPropertyName("threadId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? ThreadId { get; set; }
+    [JsonPropertyName("result"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Result { get; set; }
+    [JsonPropertyName("error"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Error { get; set; }
+    [JsonPropertyName("tokenUsage"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public SystemJobTokenUsageWire? TokenUsage { get; set; }
+}
+
+/// <summary>Payload for <c>cron/stateChanged</c>.</summary>
+public sealed class CronStateChangedNotification
+{
+    [JsonPropertyName("job")] public CronJobWireInfo Job { get; set; } = new();
+    [JsonPropertyName("removed")] public bool Removed { get; set; }
+}
+
+/// <summary>Payload for MCP startup status notifications.</summary>
+public sealed class McpServerStartupStatusUpdatedNotification
+{
+    [JsonPropertyName("threadId"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? ThreadId { get; set; }
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
+    [JsonPropertyName("error"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Error { get; set; }
+    [JsonPropertyName("failureReason"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? FailureReason { get; set; }
+    [JsonPropertyName("transport"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Transport { get; set; }
+    [JsonPropertyName("authStatus"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? AuthStatus { get; set; }
+}
+
+/// <summary>Payload for background-terminal lifecycle notifications.</summary>
+public sealed class TerminalLifecycleNotification
+{
+    [JsonPropertyName("terminal")] public BackgroundTerminalSnapshot Terminal { get; set; } = null!;
+    [JsonPropertyName("delta"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Delta { get; set; }
+}
+
+/// <summary>Payload for <c>plan/updated</c>.</summary>
+public sealed class PlanUpdatedNotification
+{
+    [JsonPropertyName("threadId")] public string ThreadId { get; set; } = string.Empty;
+    [JsonPropertyName("title")] public string Title { get; set; } = string.Empty;
+    [JsonPropertyName("overview")] public string Overview { get; set; } = string.Empty;
+    [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
+    [JsonPropertyName("todos")] public IReadOnlyList<PlanTodoWire> Todos { get; set; } = [];
+}
+
+/// <summary>Todo entry nested in <see cref="PlanUpdatedNotification"/>.</summary>
+public sealed class PlanTodoWire
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("content")] public string Content { get; set; } = string.Empty;
+    [JsonPropertyName("priority")] public string Priority { get; set; } = string.Empty;
+    [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
+}

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/McpWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/McpWire.cs
@@ -182,7 +182,7 @@ public sealed class McpServerRuntimeStatusWire
     public string? LastError { get; set; }
     public string AuthState { get; set; } = "notRequired";
     public object? ServerInfo { get; set; }
-    public Dictionary<string, object> Tools { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, McpRuntimeToolWire> Tools { get; set; } = new(StringComparer.Ordinal);
     public List<object> Resources { get; set; } = [];
     public List<object> ResourceTemplates { get; set; } = [];
     public string AuthStatus { get; set; } = "unsupported";
@@ -193,6 +193,15 @@ public sealed class McpServerRuntimeStatusWire
     public long? Generation { get; set; }
     public McpServerOriginWire? Origin { get; set; }
     public string? FailureReason { get; set; }
+}
+
+/// <summary>Stable tool inventory entry returned with an MCP runtime status.</summary>
+public sealed class McpRuntimeToolWire
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("description"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Description { get; set; }
+    [JsonPropertyName("inputSchema")] public JsonElement InputSchema { get; set; }
+    [JsonPropertyName("outputSchema"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public JsonElement? OutputSchema { get; set; }
 }
 
 /// <summary>Result for <c>mcpServerStatus/list</c>.</summary>

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/PluginWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/PluginWire.cs
@@ -2,6 +2,14 @@ using System.Text.Json.Serialization;
 
 namespace DotCraft.Protocol.AppServer;
 
+/// <summary>Payload for <c>app/list/updated</c>.</summary>
+public sealed class AppListUpdatedNotification
+{
+    [JsonPropertyName("pluginId")] public string PluginId { get; set; } = string.Empty;
+    [JsonPropertyName("reason")] public string Reason { get; set; } = string.Empty;
+    [JsonPropertyName("appIds")] public IReadOnlyList<string> AppIds { get; set; } = [];
+}
+
 
 // ───── plugin/* ─────
 

--- a/src/DotCraft.Core/Protocol/AppServer/Wire/TerminalWire.cs
+++ b/src/DotCraft.Core/Protocol/AppServer/Wire/TerminalWire.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using DotCraft.Tools.BackgroundTerminals;
 
 namespace DotCraft.Protocol.AppServer;
 
@@ -39,4 +40,39 @@ public sealed class TerminalStopParams
 public sealed class TerminalCleanParams
 {
     public string ThreadId { get; set; } = string.Empty;
+}
+
+/// <summary>Result for <c>terminal/list</c>.</summary>
+public sealed class TerminalListResult
+{
+    [JsonPropertyName("terminals")]
+    public IReadOnlyList<BackgroundTerminalSnapshot> Terminals { get; set; } = [];
+}
+
+/// <summary>Result for <c>terminal/read</c>.</summary>
+public sealed class TerminalReadResult
+{
+    [JsonPropertyName("terminal")]
+    public BackgroundTerminalSnapshot Terminal { get; set; } = null!;
+}
+
+/// <summary>Result for <c>terminal/write</c>.</summary>
+public sealed class TerminalWriteResult
+{
+    [JsonPropertyName("terminal")]
+    public BackgroundTerminalSnapshot Terminal { get; set; } = null!;
+}
+
+/// <summary>Result for <c>terminal/stop</c>.</summary>
+public sealed class TerminalStopResult
+{
+    [JsonPropertyName("terminal")]
+    public BackgroundTerminalSnapshot Terminal { get; set; } = null!;
+}
+
+/// <summary>Result for <c>terminal/clean</c>.</summary>
+public sealed class TerminalCleanResult
+{
+    [JsonPropertyName("terminals")]
+    public IReadOnlyList<BackgroundTerminalSnapshot> Terminals { get; set; } = [];
 }

--- a/src/DotCraft.Core/Protocol/Wire/SessionWireMapper.cs
+++ b/src/DotCraft.Core/Protocol/Wire/SessionWireMapper.cs
@@ -207,24 +207,45 @@ public static class SessionWireMapper
                 SessionTurn turn => turn.ToWire(includeItems: true),
                 SessionItem item => item.ToWire(),
                 // Map ThreadResumedPayload to wire shape: { thread, resumedBy }
-                ThreadResumedPayload resumed => new { thread = resumed.Thread.ToWire(), resumedBy = resumed.ResumedBy },
-                // Map TurnCancelledPayload to wire shape: { turn, reason }
-                TurnCancelledPayload cancelled => new { turn = cancelled.Turn.ToWire(includeItems: true), reason = cancelled.Reason },
-                // Map TurnFailedPayload to wire shape: { turn, error }
-                TurnFailedPayload failed => new { turn = failed.Turn.ToWire(includeItems: true), error = failed.Error },
-                // Map ThreadStatusChangedPayload to wire shape: { threadId, previousStatus, newStatus }
-                ThreadStatusChangedPayload statusChanged => new { threadId = evt.ThreadId, previousStatus = statusChanged.PreviousStatus, newStatus = statusChanged.NewStatus },
-                ThreadQueueUpdatedPayload queueUpdated => new { threadId = queueUpdated.ThreadId, queuedInputs = queueUpdated.QueuedInputs },
-                // Flatten delta payloads to { delta } string per spec Section 6.3
-                AgentMessageDelta agentDelta => new { delta = agentDelta.TextDelta },
-                ReasoningContentDelta reasoningDelta => new { delta = reasoningDelta.TextDelta },
-                CommandExecutionOutputDelta commandDelta => new { delta = commandDelta.TextDelta },
-                ToolCallArgumentsDelta toolCallDelta => new
+                ThreadResumedPayload resumed => new ThreadResumedNotification
                 {
-                    deltaKind = toolCallDelta.DeltaKind,
-                    toolName = toolCallDelta.ToolName,
-                    callId = toolCallDelta.CallId,
-                    delta = toolCallDelta.Delta
+                    Thread = resumed.Thread.ToWire(),
+                    ResumedBy = resumed.ResumedBy
+                },
+                // Map TurnCancelledPayload to wire shape: { turn, reason }
+                TurnCancelledPayload cancelled => new TurnCancelledNotification
+                {
+                    Turn = cancelled.Turn.ToWire(includeItems: true),
+                    Reason = cancelled.Reason
+                },
+                // Map TurnFailedPayload to wire shape: { turn, error }
+                TurnFailedPayload failed => new TurnFailedNotification
+                {
+                    Turn = failed.Turn.ToWire(includeItems: true),
+                    Error = failed.Error
+                },
+                // Map ThreadStatusChangedPayload to wire shape: { threadId, previousStatus, newStatus }
+                ThreadStatusChangedPayload statusChanged => new ThreadStatusChangedNotification
+                {
+                    ThreadId = evt.ThreadId,
+                    PreviousStatus = statusChanged.PreviousStatus,
+                    NewStatus = statusChanged.NewStatus
+                },
+                ThreadQueueUpdatedPayload queueUpdated => new ThreadQueueUpdatedNotification
+                {
+                    ThreadId = queueUpdated.ThreadId,
+                    QueuedInputs = queueUpdated.QueuedInputs
+                },
+                // Flatten delta payloads to { delta } string per spec Section 6.3
+                AgentMessageDelta agentDelta => new ItemDeltaPayloadWire { Delta = agentDelta.TextDelta },
+                ReasoningContentDelta reasoningDelta => new ItemDeltaPayloadWire { Delta = reasoningDelta.TextDelta },
+                CommandExecutionOutputDelta commandDelta => new ItemDeltaPayloadWire { Delta = commandDelta.TextDelta },
+                ToolCallArgumentsDelta toolCallDelta => new ItemDeltaPayloadWire
+                {
+                    DeltaKind = toolCallDelta.DeltaKind,
+                    ToolName = toolCallDelta.ToolName,
+                    CallId = toolCallDelta.CallId,
+                    Delta = toolCallDelta.Delta
                 },
                 // SubAgent progress: pass through the payload as-is (entries array serialized directly)
                 SubAgentProgressPayload => evt.Payload,

--- a/src/DotCraft.Teams/TeamsModels.cs
+++ b/src/DotCraft.Teams/TeamsModels.cs
@@ -458,3 +458,23 @@ public sealed class TeamsMemberOpenThreadResult
 {
     public string ThreadId { get; set; } = string.Empty;
 }
+
+/// <summary>Teams capability payload contributed during AppServer initialization.</summary>
+public sealed class TeamsCapabilities
+{
+    [JsonPropertyName("team")]
+    public bool Team { get; set; }
+
+    [JsonPropertyName("missions")]
+    public bool Missions { get; set; }
+}
+
+/// <summary>Payload for <c>teams/team/changed</c>.</summary>
+public sealed class TeamsTeamChangedNotification
+{
+    [JsonPropertyName("reason")]
+    public string Reason { get; set; } = string.Empty;
+
+    [JsonPropertyName("missionId")]
+    public string MissionId { get; set; } = string.Empty;
+}

--- a/src/DotCraft.Teams/TeamsProtocolExtension.cs
+++ b/src/DotCraft.Teams/TeamsProtocolExtension.cs
@@ -28,7 +28,7 @@ public sealed class TeamsProtocolExtension(TeamsService teamsService) : IAppServ
     public void ContributeCapabilities(AppServerCapabilityBuilder builder)
     {
         if (!string.IsNullOrWhiteSpace(builder.WorkspaceCraftPath))
-            builder.SetExtension("teams", new { team = true, missions = true });
+            builder.SetExtension("teams", new TeamsCapabilities { Team = true, Missions = true });
     }
 
     public async Task<object?> HandleAsync(AppServerIncomingMessage msg, AppServerExtensionContext context)
@@ -59,7 +59,11 @@ public sealed class TeamsProtocolExtension(TeamsService teamsService) : IAppServ
                     context,
                     result,
                     TeamChanged,
-                    new { reason = "missionCreated", missionId = result.Mission.MissionId });
+                    new TeamsTeamChangedNotification
+                    {
+                        Reason = "missionCreated",
+                        MissionId = result.Mission.MissionId
+                    });
             }
 
             case MissionCancel:
@@ -71,7 +75,11 @@ public sealed class TeamsProtocolExtension(TeamsService teamsService) : IAppServ
                     context,
                     result,
                     TeamChanged,
-                    new { reason = "missionCancelled", missionId = p.MissionId });
+                    new TeamsTeamChangedNotification
+                    {
+                        Reason = "missionCancelled",
+                        MissionId = p.MissionId
+                    });
             }
 
             case MissionArchive:
@@ -83,7 +91,11 @@ public sealed class TeamsProtocolExtension(TeamsService teamsService) : IAppServ
                     context,
                     result,
                     TeamChanged,
-                    new { reason = "missionArchived", missionId = p.MissionId });
+                    new TeamsTeamChangedNotification
+                    {
+                        Reason = "missionArchived",
+                        MissionId = p.MissionId
+                    });
             }
 
             case MemberOpenThread:

--- a/tests/DotCraft.Core.Tests/Protocol/AppServer/AppServerWireDtoSerializationTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/AppServer/AppServerWireDtoSerializationTests.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using DotCraft.AppBinding;
+using DotCraft.Protocol;
+using DotCraft.Protocol.AppServer;
+using DotCraft.Teams;
+
+namespace DotCraft.Core.Tests.Protocol.AppServer;
+
+public sealed class AppServerWireDtoSerializationTests
+{
+    [Fact]
+    public void RpcEmpty_SerializesAsEmptyObject()
+    {
+        Assert.Equal("{}", Serialize(new RpcEmpty()));
+    }
+
+    [Fact]
+    public void ChannelRejectedSystemEventNotification_PreservesCurrentWireShape()
+    {
+        var json = Serialize(new ChannelRejectedSystemEventNotification
+        {
+            Kind = "channelRejected",
+            ChannelName = "test-channel",
+            Message = "Channel is not available."
+        });
+
+        Assert.Equal(
+            "{\"kind\":\"channelRejected\",\"channelName\":\"test-channel\",\"message\":\"Channel is not available.\"}",
+            json);
+    }
+
+    [Fact]
+    public void ItemDeltaNotification_OmitsUnusedVariantFieldsAndKeepsWireOrder()
+    {
+        var json = Serialize(new ItemDeltaNotification
+        {
+            ThreadId = "thread-1",
+            TurnId = "turn-1",
+            ItemId = "item-1",
+            Delta = "chunk"
+        });
+
+        Assert.Equal(
+            "{\"threadId\":\"thread-1\",\"turnId\":\"turn-1\",\"itemId\":\"item-1\",\"delta\":\"chunk\"}",
+            json);
+    }
+
+    [Fact]
+    public void SystemJobResultNotification_PreservesCurrentOptionalFieldShape()
+    {
+        var json = Serialize(new SystemJobResultNotification
+        {
+            Source = "cron",
+            JobId = "job-1",
+            Result = "done",
+            TokenUsage = new SystemJobTokenUsageWire { InputTokens = 4, OutputTokens = 2 }
+        });
+
+        Assert.Equal(
+            "{\"source\":\"cron\",\"jobId\":\"job-1\",\"result\":\"done\",\"tokenUsage\":{\"inputTokens\":4,\"outputTokens\":2}}",
+            json);
+    }
+
+    [Fact]
+    public void AppConnectionRequestGetResult_MatchesExistingServerWire()
+    {
+        var json = Serialize(new AppConnectionRequestGetResult
+        {
+            ConnectionRequestId = "request-1",
+            AppId = "app-1",
+            DisplayName = "Example",
+            DeveloperName = "Example Developer",
+            UserId = "user-1",
+            ExpiresAt = DateTimeOffset.Parse("2026-07-31T01:02:03Z")
+        });
+
+        Assert.Equal(
+            "{\"connectionRequestId\":\"request-1\",\"appId\":\"app-1\",\"displayName\":\"Example\",\"developerName\":\"Example Developer\",\"userId\":\"user-1\",\"expiresAt\":\"2026-07-31T01:02:03+00:00\"}",
+            json);
+    }
+
+    [Fact]
+    public void AppBindingRequestedNotification_RepresentsBothExistingShapesWithoutExtraFields()
+    {
+        var appRequest = Serialize(new AppBindingRequestedNotification
+        {
+            BindingRequestId = "request-1",
+            BindingId = "binding-1",
+            ThreadId = "thread-1",
+            AppId = "app-1"
+        });
+        var socialRequest = Serialize(new AppBindingRequestedNotification
+        {
+            BindingRequestId = "request-2",
+            BindingId = "binding-2",
+            Code = "ABC123",
+            ChannelName = "test-channel",
+            ExpiresAt = DateTimeOffset.Parse("2026-07-31T01:02:03Z")
+        });
+
+        Assert.Equal(
+            "{\"bindingRequestId\":\"request-1\",\"bindingId\":\"binding-1\",\"threadId\":\"thread-1\",\"appId\":\"app-1\"}",
+            appRequest);
+        Assert.Equal(
+            "{\"bindingRequestId\":\"request-2\",\"bindingId\":\"binding-2\",\"code\":\"ABC123\",\"channelName\":\"test-channel\",\"expiresAt\":\"2026-07-31T01:02:03+00:00\"}",
+            socialRequest);
+    }
+
+    [Fact]
+    public void McpRuntimeToolWire_PreservesOpaqueSchemas()
+    {
+        using var input = JsonDocument.Parse("{\"type\":\"object\",\"x-extra\":true}");
+        using var output = JsonDocument.Parse("{\"type\":\"string\"}");
+        var json = Serialize(new McpRuntimeToolWire
+        {
+            Name = "lookup",
+            Description = "Looks up a value",
+            InputSchema = input.RootElement.Clone(),
+            OutputSchema = output.RootElement.Clone()
+        });
+
+        Assert.Equal(
+            "{\"name\":\"lookup\",\"description\":\"Looks up a value\",\"inputSchema\":{\"type\":\"object\",\"x-extra\":true},\"outputSchema\":{\"type\":\"string\"}}",
+            json);
+    }
+
+    [Fact]
+    public void NodeReplEvaluateParams_OmitsNullTurnIdsAtBothLevels()
+    {
+        var json = Serialize(new NodeReplEvaluateParams
+        {
+            ThreadId = "thread-1",
+            EvaluationId = "eval-1",
+            BrowserSession = new NodeReplBrowserSessionParams
+            {
+                ProtocolVersion = 1,
+                SessionId = "session-1",
+                ThreadId = "thread-1",
+                EvaluationId = "eval-1"
+            },
+            Code = "1 + 1",
+            TimeoutMs = 30_000
+        });
+
+        Assert.Equal(
+            "{\"threadId\":\"thread-1\",\"evaluationId\":\"eval-1\",\"browserSession\":{\"protocolVersion\":1,\"sessionId\":\"session-1\",\"threadId\":\"thread-1\",\"evaluationId\":\"eval-1\"},\"code\":\"1 \\u002B 1\",\"timeoutMs\":30000}",
+            json);
+    }
+
+    [Fact]
+    public void FirstPartyExtensionDtos_PreserveStablePayloads()
+    {
+        Assert.Equal(
+            "{\"ok\":true}",
+            Serialize(new AutomationTaskDeleteResult { Ok = true }));
+        Assert.Equal(
+            "{\"team\":true,\"missions\":true}",
+            Serialize(new TeamsCapabilities { Team = true, Missions = true }));
+        Assert.Equal(
+            "{\"reason\":\"missionCreated\",\"missionId\":\"mission-1\"}",
+            Serialize(new TeamsTeamChangedNotification
+            {
+                Reason = "missionCreated",
+                MissionId = "mission-1"
+            }));
+    }
+
+    private static string Serialize<T>(T value) =>
+        JsonSerializer.Serialize(value, SessionWireJsonOptions.Default);
+}

--- a/tests/DotCraft.Core.Tests/Protocol/AppServer/WireAcpExtensionProxyMergeTests.cs
+++ b/tests/DotCraft.Core.Tests/Protocol/AppServer/WireAcpExtensionProxyMergeTests.cs
@@ -33,6 +33,24 @@ public sealed class WireAcpExtensionProxyMergeTests
     }
 
     [Fact]
+    public void MergeThreadIdIntoParams_TypedFixedRequest_PreservesNullFieldsAndWireOrder()
+    {
+        var parameters = new AcpFsReadTextFileParams
+        {
+            Path = "sample.txt",
+            Offset = null,
+            Limit = null
+        };
+
+        var merged = WireAcpExtensionProxy.MergeThreadIdIntoParams("thread-a", parameters);
+        var json = JsonSerializer.Serialize(merged, JsonOptions);
+
+        Assert.Equal(
+            "{\"path\":\"sample.txt\",\"offset\":null,\"limit\":null,\"threadId\":\"thread-a\"}",
+            json);
+    }
+
+    [Fact]
     public void MergeThreadIdIntoParams_NonObject_WrapsPayload()
     {
         var o = WireAcpExtensionProxy.MergeThreadIdIntoParams("tid", "plain");


### PR DESCRIPTION
- Added strongly typed DTOs for AppServer core and first-party extension protocols, replacing anonymous objects for stable payloads.  
- Preserved the existing wire schema and open JSON boundaries, with serialization regression tests for compatibility.