### PR TITLE
feat(sdk): bundle contracts and fail runs on disconnect

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -153,8 +153,91 @@ jobs:
           if (!(Test-Path $snupkg)) {
             throw "Missing symbol package: $snupkg"
           }
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $package = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path $nupkg))
+          try {
+            $entries = @($package.Entries | ForEach-Object { $_.FullName })
+            foreach ($required in @(
+              "lib/net10.0/DotCraft.Sdk.dll",
+              "lib/net10.0/DotCraft.Protocol.Contracts.dll"
+            )) {
+              if ($entries -notcontains $required) {
+                throw "Package is missing required entry: $required"
+              }
+            }
+
+            $nuspecEntry = $package.Entries | Where-Object { $_.FullName -like "*.nuspec" } | Select-Object -Single
+            $reader = [System.IO.StreamReader]::new($nuspecEntry.Open())
+            try {
+              $nuspec = $reader.ReadToEnd()
+            }
+            finally {
+              $reader.Dispose()
+            }
+            if ($nuspec -match '<dependency\s+id="DotCraft\.Protocol\.Contracts"') {
+              throw "DotCraft.Sdk must bundle Contracts instead of declaring a package dependency."
+            }
+          }
+          finally {
+            $package.Dispose()
+          }
+
+          $symbols = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path $snupkg))
+          try {
+            if ($symbols.Entries.FullName -contains "lib/net10.0/DotCraft.Protocol.Contracts.pdb") {
+              throw "The symbol package must not contain DotCraft.Protocol.Contracts.pdb."
+            }
+          }
+          finally {
+            $symbols.Dispose()
+          }
+
           Get-ChildItem artifacts/nuget | Format-Table Name, Length
           Get-FileHash $nupkg, $snupkg -Algorithm SHA256 | Format-Table Algorithm, Hash, Path
+
+      - name: Restore bundled contracts from isolated source
+        shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ steps.validate.outputs.version }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $probe = Join-Path ([System.IO.Path]::GetTempPath()) "dotcraft-sdk-package-probe-$([guid]::NewGuid().ToString('N'))"
+          New-Item -ItemType Directory -Path $probe | Out-Null
+          try {
+            dotnet new console --framework net10.0 --no-restore --output $probe
+            Push-Location $probe
+            try {
+              dotnet add package DotCraft.Sdk --version $env:PACKAGE_VERSION --no-restore
+              $nugetConfig = @'
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="package-under-test" value="PACKAGE_SOURCE" />
+            </packageSources>
+          </configuration>
+          '@
+              $packageSource = (Resolve-Path "$env:GITHUB_WORKSPACE/artifacts/nuget").Path
+              $nugetConfig.Replace("PACKAGE_SOURCE", $packageSource) | Set-Content -Encoding utf8 NuGet.config
+              $program = @'
+          using DotCraft.Protocol.Contracts;
+          using DotCraft.Sdk.AppServer;
+
+          _ = new RpcEmpty();
+          _ = new DotCraftClientOptions();
+          '@
+              $program | Set-Content -Encoding utf8 Program.cs
+              dotnet restore --configfile NuGet.config
+              dotnet build --no-restore
+            }
+            finally {
+              Pop-Location
+            }
+          }
+          finally {
+            Remove-Item -LiteralPath $probe -Recurse -Force
+          }
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4

--- a/docs/developing/sdks/dotnet.md
+++ b/docs/developing/sdks/dotnet.md
@@ -28,6 +28,8 @@ This reference describes the current repository surface. The latest NuGet releas
 
 Core and the SDK use the same `DotCraft.Protocol.Contracts` assembly; the SDK does not maintain a second copy of Wire DTOs.
 
+The `DotCraft.Sdk` NuGet package includes both `DotCraft.Sdk.dll` and `DotCraft.Protocol.Contracts.dll`. Install only `DotCraft.Sdk`; Contracts is a separate logical layer and assembly, not a separate package.
+
 ## Typed and raw Wire APIs
 
 `DotCraftWireClient.RequestAsync` and `NotifyAsync` accept generated descriptors, so the descriptor determines the parameter and result types. Typed notification and server-request handlers use the same contracts.
@@ -40,11 +42,11 @@ Unknown or third-party extensions use the separate `RequestRawAsync` and `Notify
 
 The Wire client reports `Connecting`, `Initializing`, `Ready`, `Disconnected`, `Reconnecting`, `ReconnectError`, and `Closed`.
 
-- Raw Wire connections default to no reconnect. High-level clients and host profiles opt in explicitly.
+- Raw Wire connections default to no reconnect. Local and remote high-level connections enable it by default. Set `DotCraftClientOptions.AutoReconnect` to override the entry-point default.
 - The default RPC timeout is 30 seconds and includes reconnect queue time.
 - Reconnect uses 1-to-30-second exponential backoff with jitter and queues at most 1024 new requests in call order.
 - In-flight requests fail on disconnect and are not replayed. The client replays `initialize`, sends `initialized`, and then releases queued requests.
-- Registered handlers remain installed. Thread subscriptions, active Runs, and Runtime Dynamic Tools are not recreated automatically.
+- Registered handlers remain installed. Thread subscriptions and Runtime Dynamic Tools are not recreated automatically. An active Run fails with `RunDisconnectedError`; the SDK never replays `turn/start`.
 
 `ConnectLocalAsync` uses the Hub to ensure a workspace AppServer. Set `DotCraftLocalClientOptions.Executable` when the host has resolved a specific DotCraft binary. `ConnectRemoteAsync` connects to a known AppServer WebSocket, and `ConnectAsync` accepts a custom `IJsonRpcTransport`.
 

--- a/docs/developing/sdks/runs.md
+++ b/docs/developing/sdks/runs.md
@@ -126,7 +126,7 @@ Every event keeps the original notification on `raw`, so nothing is lost. The bu
 
 ## Reconnect boundaries
 
-Reconnect restores the Wire transport, repeats `initialize`, and preserves local handler registrations. It does not recreate a thread subscription, resume an active Run, or rebind Runtime Dynamic Tools on your behalf.
+Reconnect restores the Wire transport, repeats `initialize`, and preserves local handler registrations. It does not recreate a thread subscription or rebind Runtime Dynamic Tools on your behalf. An active .NET Run fails with `RunDisconnectedError`; no SDK binding replays `turn/start`.
 
 Treat a Run interrupted by disconnection as interrupted application work. After the connection is ready again, explicitly read or resume the thread to obtain current server state, resubscribe if needed, and start the next operation from that state. Do not assume a request that was already sent will be replayed.
 

--- a/docs/zh/developing/sdks/dotnet.md
+++ b/docs/zh/developing/sdks/dotnet.md
@@ -28,6 +28,8 @@ dotnet add package DotCraft.Sdk
 
 Core 与 SDK 使用同一个 `DotCraft.Protocol.Contracts` 程序集；SDK 不维护第二份 Wire DTO。
 
+`DotCraft.Sdk` NuGet 包同时包含 `DotCraft.Sdk.dll` 和 `DotCraft.Protocol.Contracts.dll`。只需安装 `DotCraft.Sdk`；Contracts 是独立的逻辑层和程序集，不是独立的包。
+
 ## Typed 与 raw Wire API
 
 `DotCraftWireClient.RequestAsync` 和 `NotifyAsync` 接受生成的 descriptor，由 descriptor 决定参数与结果类型。强类型通知和服务端请求 handler 使用同一套契约。
@@ -40,11 +42,11 @@ Core 与 SDK 使用同一个 `DotCraft.Protocol.Contracts` 程序集；SDK 不�
 
 Wire Client 会报告 `Connecting`、`Initializing`、`Ready`、`Disconnected`、`Reconnecting`、`ReconnectError` 和 `Closed`。
 
-- Raw Wire 连接默认不重连；高层 client 和宿主配置会显式启用。
+- Raw Wire 连接默认不重连；本地和远程高层连接默认启用重连。设置 `DotCraftClientOptions.AutoReconnect` 可覆盖入口默认值。
 - 默认 RPC 超时为 30 秒，包含重连队列等待时间。
 - 重连使用 1 到 30 秒的指数退避和抖动，最多按调用顺序排队 1024 个新请求。
 - 断线时进行中的请求会失败且不会重放。Client 会重新发送 `initialize` 和 `initialized`，之后才释放排队请求。
-- 已注册 handler 会保留；thread subscription、活动 Run 和运行时动态工具不会自动重建。
+- 已注册 handler 会保留；thread subscription 和运行时动态工具不会自动重建。活动 Run 会以 `RunDisconnectedError` 失败，SDK 绝不会重放 `turn/start`。
 
 `ConnectLocalAsync` 通过 Hub 确保工作区 AppServer。当宿主已解析特定 DotCraft 二进制时，设置 `DotCraftLocalClientOptions.Executable`。`ConnectRemoteAsync` 连接已知的 AppServer WebSocket，`ConnectAsync` 接受自定义 `IJsonRpcTransport`。
 

--- a/docs/zh/developing/sdks/runs.md
+++ b/docs/zh/developing/sdks/runs.md
@@ -126,7 +126,7 @@ result = await thread.run("Later: deploy to staging.", enqueue_if_busy=True)
 
 ## 重连边界
 
-重连会恢复 Wire 传输、重新执行 `initialize`，并保留本地 handler 注册。它不会替你重建 thread subscription、恢复活动 Run 或重新绑定运行时动态工具。
+重连会恢复 Wire 传输、重新执行 `initialize`，并保留本地 handler 注册。它不会替你重建 thread subscription 或重新绑定运行时动态工具。活动的 .NET Run 会以 `RunDisconnectedError` 失败；任何 SDK binding 都不会重放 `turn/start`。
 
 应把因断线中断的 Run 视为已经中断的应用工作。连接再次 ready 后，显式读取或恢复 thread 以取得当前服务端状态；需要时重新订阅，再从该状态发起下一项操作。不要假定已经发送的请求会被重放。
 

--- a/sdk/dotnet/src/DotCraft.Sdk/AppServer/AppServerModels.cs
+++ b/sdk/dotnet/src/DotCraft.Sdk/AppServer/AppServerModels.cs
@@ -9,6 +9,12 @@ namespace DotCraft.Sdk.AppServer;
 public class DotCraftClientOptions
 {
     /// <summary>
+    /// Overrides the connection entry point's reconnect default. Local and remote connections
+    /// default to enabled; custom transports default to disabled.
+    /// </summary>
+    public bool? AutoReconnect { get; set; }
+
+    /// <summary>
     /// Machine-readable client name.
     /// </summary>
     public string ClientName { get; set; } = "dotcraft-dotnet";

--- a/sdk/dotnet/src/DotCraft.Sdk/AppServer/DotCraftClient.cs
+++ b/sdk/dotnet/src/DotCraft.Sdk/AppServer/DotCraftClient.cs
@@ -156,7 +156,7 @@ public sealed class DotCraftClient : IAsyncDisposable
         CancellationToken cancellationToken = default)
     {
         var transport = await WebSocketJsonRpcTransport.ConnectAsync(appServerUrl, token, cancellationToken);
-        return await ConnectAsync(transport, options, cancellationToken, autoReconnect: true);
+        return await ConnectCoreAsync(transport, options, defaultAutoReconnect: true, cancellationToken);
     }
 
     /// <summary>
@@ -165,8 +165,14 @@ public sealed class DotCraftClient : IAsyncDisposable
     public static async Task<DotCraftClient> ConnectAsync(
         IJsonRpcTransport transport,
         DotCraftClientOptions? options = null,
-        CancellationToken cancellationToken = default,
-        bool autoReconnect = false)
+        CancellationToken cancellationToken = default) =>
+        await ConnectCoreAsync(transport, options, defaultAutoReconnect: false, cancellationToken);
+
+    private static async Task<DotCraftClient> ConnectCoreAsync(
+        IJsonRpcTransport transport,
+        DotCraftClientOptions? options,
+        bool defaultAutoReconnect,
+        CancellationToken cancellationToken)
     {
         var effectiveOptions = options ?? new DotCraftClientOptions();
         if (effectiveOptions.ApprovalSupport && effectiveOptions.ApprovalHandler is null)
@@ -188,7 +194,7 @@ public sealed class DotCraftClient : IAsyncDisposable
 
         var wire = new DotCraftWireClient(transport, new DotCraftWireClientOptions
         {
-            AutoReconnect = autoReconnect
+            AutoReconnect = effectiveOptions.AutoReconnect ?? defaultAutoReconnect
         });
         if (effectiveOptions.ApprovalHandler is not null)
         {

--- a/sdk/dotnet/src/DotCraft.Sdk/AppServer/DotCraftErrors.cs
+++ b/sdk/dotnet/src/DotCraft.Sdk/AppServer/DotCraftErrors.cs
@@ -84,6 +84,20 @@ public sealed class TurnCancelledError(string threadId, string? turnId, string? 
     public string? TurnId { get; } = turnId;
 }
 
+/// <summary>The Wire session ended while a high-level Run was active.</summary>
+public sealed class RunDisconnectedError(
+    string threadId,
+    string? turnId,
+    Exception? innerException = null)
+    : DotCraftSdkException("runDisconnected", "The connection ended while the run was active.", innerException)
+{
+    /// <summary>Thread that owns the interrupted Run.</summary>
+    public string ThreadId { get; } = threadId;
+
+    /// <summary>Identifier of the interrupted Turn when it was already known.</summary>
+    public string? TurnId { get; } = turnId;
+}
+
 /// <summary>The client did not answer an approval request in time.</summary>
 public sealed class ApprovalTimeoutError(string message, Exception? innerException = null)
     : DotCraftSdkException("approvalTimeout", message, innerException);

--- a/sdk/dotnet/src/DotCraft.Sdk/AppServer/DotCraftThread.cs
+++ b/sdk/dotnet/src/DotCraft.Sdk/AppServer/DotCraftThread.cs
@@ -16,7 +16,7 @@ public sealed class DotCraftThread
     private readonly DotCraftClient _client;
     private readonly SemaphoreSlim _subscribeLock = new(1, 1);
     private JsonElement _snapshot;
-    private bool _subscribed;
+    private long _subscribedGeneration;
 
     internal DotCraftThread(DotCraftClient client, string id, JsonElement snapshot)
     {
@@ -95,9 +95,21 @@ public sealed class DotCraftThread
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var opts = options ?? new RunOptions();
-        await EnsureSubscribedAsync(cancellationToken).ConfigureAwait(false);
-
         var channel = Channel.CreateUnbounded<DotCraftRunEvent>(new UnboundedChannelOptions { SingleReader = true });
+        string? turnId = null;
+
+        void HandleConnectionState(WireConnectionState state, Exception? error)
+        {
+            if (state == WireConnectionState.Ready)
+            {
+                return;
+            }
+
+            Interlocked.Exchange(ref _subscribedGeneration, 0);
+            channel.Writer.TryComplete(new RunDisconnectedError(Id, turnId, error));
+        }
+
+        _client.Wire.StateChanged += HandleConnectionState;
         using var registration = _client.Wire.RegisterNotificationHandlerRaw(notification =>
         {
             var threadId = ExtractThreadId(notification.Params);
@@ -107,66 +119,74 @@ public sealed class DotCraftThread
             }
 
             var runEvent = Normalize(notification);
+            turnId ??= runEvent.TurnId;
             channel.Writer.TryWrite(runEvent);
             if (IsTerminal(runEvent.Type))
             {
                 channel.Writer.TryComplete();
             }
         });
-
-        string? turnId = null;
-        var busy = false;
         try
         {
-            var startResult = await _client.Turns
-                .StartAsync(Id, input, opts.Sender, opts.ModelId, cancellationToken)
-                .ConfigureAwait(false);
-            turnId = startResult.TurnId;
-        }
-        catch (JsonRpcException ex) when (ex.Code == AppServerErrorCodes.TurnInProgress)
-        {
-            if (!opts.EnqueueIfBusy)
+            await EnsureSubscribedAsync(cancellationToken).ConfigureAwait(false);
+
+            var busy = false;
+            try
             {
-                throw new TurnInProgressError("A turn is already running on this thread.", ex);
+                var startResult = await _client.Turns
+                    .StartAsync(Id, input, opts.Sender, opts.ModelId, cancellationToken)
+                    .ConfigureAwait(false);
+                turnId = startResult.TurnId;
+            }
+            catch (JsonRpcException ex) when (ex.Code == AppServerErrorCodes.TurnInProgress)
+            {
+                if (!opts.EnqueueIfBusy)
+                {
+                    throw new TurnInProgressError("A turn is already running on this thread.", ex);
+                }
+
+                busy = true;
             }
 
-            busy = true;
-        }
-
-        if (busy)
-        {
-            var enqueue = await _client.Turns
-                .EnqueueAsync(Id, input, opts.Sender, cancellationToken)
-                .ConfigureAwait(false);
-            yield return new DotCraftRunEvent(
-                DotCraftRunEventTypes.QueueUpdated,
-                Id,
-                null,
-                new AppServerNotification("turn/enqueue", enqueue.Raw));
-            yield break;
-        }
-
-        await using var interruptRegistration = turnId is null
-            ? default
-            : cancellationToken.Register(() =>
+            if (busy)
             {
-                try
-                {
-                    _ = _client.Turns.InterruptAsync(Id, turnId, CancellationToken.None);
-                }
-                catch
-                {
-                    // Best-effort interrupt on cancellation.
-                }
-            });
-
-        await foreach (var runEvent in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
-        {
-            yield return runEvent;
-            if (IsTerminal(runEvent.Type))
-            {
+                var enqueue = await _client.Turns
+                    .EnqueueAsync(Id, input, opts.Sender, cancellationToken)
+                    .ConfigureAwait(false);
+                yield return new DotCraftRunEvent(
+                    DotCraftRunEventTypes.QueueUpdated,
+                    Id,
+                    null,
+                    new AppServerNotification("turn/enqueue", enqueue.Raw));
                 yield break;
             }
+
+            await using var interruptRegistration = turnId is null
+                ? default
+                : cancellationToken.Register(() =>
+                {
+                    try
+                    {
+                        _ = _client.Turns.InterruptAsync(Id, turnId, CancellationToken.None);
+                    }
+                    catch
+                    {
+                        // Best-effort interrupt on cancellation.
+                    }
+                });
+
+            await foreach (var runEvent in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return runEvent;
+                if (IsTerminal(runEvent.Type))
+                {
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            _client.Wire.StateChanged -= HandleConnectionState;
         }
     }
 
@@ -185,14 +205,14 @@ public sealed class DotCraftThread
     public async Task SubscribeAsync(bool replayRecent = false, CancellationToken cancellationToken = default)
     {
         await _client.RequestRawAsync("thread/subscribe", new { threadId = Id, replayRecent }, cancellationToken).ConfigureAwait(false);
-        _subscribed = true;
+        Interlocked.Exchange(ref _subscribedGeneration, _client.Wire.ConnectionGeneration);
     }
 
     /// <summary>Unsubscribes this connection from the thread's events.</summary>
     public async Task UnsubscribeAsync(CancellationToken cancellationToken = default)
     {
         await _client.RequestRawAsync("thread/unsubscribe", new { threadId = Id }, cancellationToken).ConfigureAwait(false);
-        _subscribed = false;
+        Interlocked.Exchange(ref _subscribedGeneration, 0);
     }
 
     /// <summary>Sets the thread operational mode.</summary>
@@ -226,7 +246,7 @@ public sealed class DotCraftThread
 
     private async Task EnsureSubscribedAsync(CancellationToken cancellationToken)
     {
-        if (_subscribed)
+        if (HasCurrentSubscription())
         {
             return;
         }
@@ -234,18 +254,30 @@ public sealed class DotCraftThread
         await _subscribeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (_subscribed)
+            if (HasCurrentSubscription())
             {
                 return;
             }
 
             await _client.RequestRawAsync("thread/subscribe", new { threadId = Id, replayRecent = false }, cancellationToken).ConfigureAwait(false);
-            _subscribed = true;
+            var generation = _client.Wire.ConnectionGeneration;
+            if (_client.Wire.State == WireConnectionState.Ready)
+            {
+                Interlocked.Exchange(ref _subscribedGeneration, generation);
+            }
         }
         finally
         {
             _subscribeLock.Release();
         }
+    }
+
+    private bool HasCurrentSubscription()
+    {
+        var generation = _client.Wire.ConnectionGeneration;
+        return generation != 0 &&
+               _client.Wire.State == WireConnectionState.Ready &&
+               Interlocked.Read(ref _subscribedGeneration) == generation;
     }
 
     private static IReadOnlyList<TurnInputPart> ToParts(string text) => [new TurnInputPart("text", Text: text)];

--- a/sdk/dotnet/src/DotCraft.Sdk/DotCraft.Sdk.csproj
+++ b/sdk/dotnet/src/DotCraft.Sdk/DotCraft.Sdk.csproj
@@ -16,6 +16,9 @@
     <PackageTags>dotcraft;appserver;json-rpc;sdk;ai</PackageTags>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeContractsAssemblyInPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,5 +32,12 @@
                       ReferenceOutputAssembly="false" />
     <AdditionalFiles Include="..\..\..\..\src\DotCraft.Protocol.Contracts\Artifacts\AppServer\appserver.manifest.json" />
   </ItemGroup>
+
+  <Target Name="IncludeContractsAssemblyInPackage">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)DotCraft.Protocol.Contracts.dll"
+                            TargetPath="DotCraft.Protocol.Contracts.dll" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/sdk/dotnet/src/DotCraft.Sdk/Wire/DotCraftWireClient.cs
+++ b/sdk/dotnet/src/DotCraft.Sdk/Wire/DotCraftWireClient.cs
@@ -26,10 +26,17 @@ public sealed class DotCraftWireClient : IAsyncDisposable
     private TaskCompletionSource _ready = CompletedReadySource();
     private DotCraftClientOptions? _initializeOptions;
     private int _queuedRequests;
+    private long _connectionGeneration;
     private bool _disposed;
 
     /// <summary>Current observable Wire session state.</summary>
     public WireConnectionState State { get; private set; } = WireConnectionState.Disconnected;
+
+    /// <summary>
+    /// Monotonically increasing initialized Wire session generation. The value changes only after
+    /// a successful initialize handshake, including one performed during reconnect.
+    /// </summary>
+    public long ConnectionGeneration => Interlocked.Read(ref _connectionGeneration);
 
     /// <summary>Raised when <see cref="State"/> changes.</summary>
     public event Action<WireConnectionState, Exception?>? StateChanged;
@@ -169,6 +176,7 @@ public sealed class DotCraftWireClient : IAsyncDisposable
             ?? throw new JsonException("Request 'initialize' returned an invalid result.");
         await NotifyRawCoreAsync(AppServerRpc.Initialized.Name, new RpcEmpty(), cancellationToken, bypassReady);
         var parsed = ParseInitializeResult(JsonSerializer.SerializeToElement(result, DotCraftJson.Options));
+        Interlocked.Increment(ref _connectionGeneration);
         _ready.TrySetResult();
         SetState(WireConnectionState.Ready);
         return parsed;
@@ -375,6 +383,7 @@ public sealed class DotCraftWireClient : IAsyncDisposable
                 {
                     var closed = new IOException("Wire transport disconnected.");
                     FailPending(closed);
+                    SetState(WireConnectionState.Disconnected, closed);
                     if (await TryReconnectAsync(closed))
                     {
                         continue;
@@ -388,6 +397,7 @@ public sealed class DotCraftWireClient : IAsyncDisposable
         catch (Exception ex)
         {
             FailPending(ex);
+            SetState(WireConnectionState.Disconnected, ex);
             if (await TryReconnectAsync(ex))
             {
                 await ReadLoopAsync();
@@ -395,7 +405,7 @@ public sealed class DotCraftWireClient : IAsyncDisposable
         }
         finally
         {
-            if (!_disposed)
+            if (!_disposed && State != WireConnectionState.Disconnected)
             {
                 SetState(WireConnectionState.Disconnected);
             }

--- a/sdk/dotnet/tests/DotCraft.Sdk.Tests/RunProfileTests.cs
+++ b/sdk/dotnet/tests/DotCraft.Sdk.Tests/RunProfileTests.cs
@@ -85,6 +85,80 @@ public sealed class RunProfileTests
     }
 
     [Fact]
+    public async Task RunAsync_DisconnectFailsRunAndResubscribesAfterReconnect()
+    {
+        var (client, transport) = await ConnectAsync(new DotCraftClientOptions
+        {
+            ClientName = "test",
+            ClientVersion = "0.1",
+            AutoReconnect = true
+        });
+        await using var _ = client;
+        var thread = await StartThreadAsync(client, transport);
+
+        var firstRun = thread.RunAsync("first");
+        await RespondAsync(transport, "thread/subscribe", new { ok = true });
+        await RespondAsync(transport, "turn/start", new { turnId = "turn_1" });
+        await PushNotificationAsync(transport, "turn/started", new { threadId = "thread_1", turnId = "turn_1" });
+
+        await transport.PushDisconnectAsync();
+
+        var error = await Assert.ThrowsAsync<RunDisconnectedError>(async () => await firstRun.WaitAsync(Timeout));
+        Assert.Equal("runDisconnected", error.Code);
+        Assert.Equal("thread_1", error.ThreadId);
+        Assert.Equal("turn_1", error.TurnId);
+        Assert.NotNull(error.InnerException);
+
+        using (var initialize = await transport.ReadOutboundAsync().WaitAsync(Timeout))
+        {
+            Assert.Equal("initialize", initialize.RootElement.GetProperty("method").GetString());
+            await transport.PushInboundAsync(new
+            {
+                jsonrpc = "2.0",
+                id = initialize.RootElement.GetProperty("id").GetInt64(),
+                result = new
+                {
+                    serverInfo = new { name = "dotcraft", version = "test", protocolVersion = "1" },
+                    capabilities = new { threadManagement = true, threadSubscriptions = true }
+                }
+            });
+        }
+        using (var initialized = await transport.ReadOutboundAsync().WaitAsync(Timeout))
+        {
+            Assert.Equal("initialized", initialized.RootElement.GetProperty("method").GetString());
+        }
+
+        var secondRun = thread.RunAsync("second");
+        await RespondAsync(transport, "thread/subscribe", new { ok = true });
+        await RespondAsync(transport, "turn/start", new { turnId = "turn_2" });
+        await PushNotificationAsync(transport, "turn/completed", new
+        {
+            turn = new { id = "turn_2", threadId = "thread_1", status = "completed", items = Array.Empty<object>() }
+        });
+
+        var result = await secondRun.WaitAsync(Timeout);
+        Assert.Equal("turn_2", result.TurnId);
+        Assert.Equal(1, transport.ReconnectCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_DisconnectWithoutReconnectPreservesTransportError()
+    {
+        var (client, transport) = await ConnectAsync();
+        await using var _ = client;
+        var thread = await StartThreadAsync(client, transport);
+
+        var run = thread.RunAsync("first");
+        await RespondAsync(transport, "thread/subscribe", new { ok = true });
+        await RespondAsync(transport, "turn/start", new { turnId = "turn_1" });
+        await transport.PushDisconnectAsync();
+
+        var error = await Assert.ThrowsAsync<RunDisconnectedError>(async () => await run.WaitAsync(Timeout));
+        Assert.IsType<IOException>(error.InnerException);
+        Assert.Equal(0, transport.ReconnectCount);
+    }
+
+    [Fact]
     public async Task RunAsync_ThrowsTurnFailedError_OnFailure()
     {
         var (client, transport) = await ConnectAsync();

--- a/sdk/dotnet/tests/DotCraft.Sdk.Tests/WireClientTests.cs
+++ b/sdk/dotnet/tests/DotCraft.Sdk.Tests/WireClientTests.cs
@@ -8,6 +8,39 @@ namespace DotCraft.Sdk.Tests;
 public sealed class WireClientTests
 {
     [Fact]
+    public async Task HighLevelCustomTransport_DoesNotReconnectByDefault()
+    {
+        var transport = new TestJsonRpcTransport();
+        var connectTask = DotCraftClient.ConnectAsync(transport, new DotCraftClientOptions
+        {
+            ClientName = "test",
+            ClientVersion = "1"
+        });
+        using (var initialize = await transport.ReadOutboundAsync())
+        {
+            await transport.PushInboundAsync(new
+            {
+                jsonrpc = "2.0",
+                id = initialize.RootElement.GetProperty("id").GetInt64(),
+                result = new
+                {
+                    serverInfo = new { name = "dotcraft", version = "1", protocolVersion = "1" },
+                    capabilities = new { }
+                }
+            });
+        }
+        using (await transport.ReadOutboundAsync())
+        {
+        }
+
+        await using var client = await connectTask;
+        await transport.PushDisconnectAsync();
+        await WaitUntilAsync(() => client.Wire.State == WireConnectionState.Disconnected);
+
+        Assert.Equal(0, transport.ReconnectCount);
+    }
+
+    [Fact]
     public async Task Reconnect_ReinitializesBeforeQueuedRequests()
     {
         await using var transport = new TestJsonRpcTransport();

--- a/specs/sdk/dotnet.md
+++ b/specs/sdk/dotnet.md
@@ -214,13 +214,7 @@ The canonical .NET SDK package id is:
 DotCraft.Sdk
 ```
 
-Repository-local consumers may reference:
-
-```text
-src/DotCraft.Sdk/DotCraft.Sdk.csproj
-```
-
-until a public NuGet release process is approved.
+The public `DotCraft.Sdk` NuGet package contains both `DotCraft.Sdk.dll` and `DotCraft.Protocol.Contracts.dll`. Contracts remains a separate transport-free project and assembly, but it is not published as an independent NuGet package.
 
 ### 4.2 Namespace Layout
 
@@ -232,6 +226,8 @@ until a public NuGet release process is approved.
 | `DotCraft.Sdk.Wire` | `IJsonRpcTransport`, `DotCraftWireClient`, `StreamJsonRpcTransport`, `WebSocketJsonRpcTransport`, `DotCraftJson`, `JsonRpcException`. |
 
 Wire DTOs and RPC descriptors come directly from `DotCraft.Protocol.Contracts`. `DotCraft.Sdk` does not define a second contract model.
+
+Installing `DotCraft.Sdk` makes both namespaces available. Consumers must not add a separate `DotCraft.Protocol.Contracts` package reference.
 
 ### 4.3 Top-Level Client
 
@@ -539,6 +535,8 @@ Required behavior:
 - attempt best-effort normal close on disposal.
 
 The transport represents one WebSocket connection and does not reconnect itself. `DotCraftWireClient` owns optional reconnect and protocol reinitialization according to the unified SDK lifecycle.
+
+`DotCraftClientOptions.AutoReconnect` overrides the entry-point default. Local and remote high-level connections default to reconnect enabled; custom transports default to disabled. When a ready session is lost, active `RunStreamedAsync` enumerations fail with `RunDisconnectedError`, cached subscription state becomes invalid, and no `turn/start` request is replayed.
 
 ### 8.5 Raw Request Escape Hatch
 
@@ -1467,13 +1465,13 @@ The SDK currently exposes `ApprovalSupport` as an initialize option but does not
 The package version is currently:
 
 ```text
-0.1.0
+0.5.0
 ```
 
 Preview NuGet packages use prerelease package versions such as:
 
 ```text
-0.1.0-preview.1
+0.5.0-preview.1
 ```
 
 ### 21.2 Publishing Policy
@@ -1493,6 +1491,9 @@ The release workflow must:
 - avoid storing long-lived NuGet API keys in repository secrets;
 - push exact package filenames, never broad globs;
 - fail when the requested package version already exists on nuget.org.
+- include `DotCraft.Sdk.dll` and `DotCraft.Protocol.Contracts.dll` in the single SDK package;
+- verify from an isolated local source that installing only `DotCraft.Sdk` exposes both assemblies;
+- reject a package whose nuspec declares an independent `DotCraft.Protocol.Contracts` package dependency.
 
 The Trusted Publishing policy on nuget.org must be configured for:
 

--- a/specs/sdk/sdk.md
+++ b/specs/sdk/sdk.md
@@ -68,6 +68,8 @@ Every general-purpose binding has four explicit layers:
 3. **High-level** owns application concepts such as `DotCraft`, Thread, Run, callbacks, App Binding helpers, and Channel adapters. It composes the Wire layer instead of reimplementing it.
 4. **Host adapters** integrate an SDK with an environment such as Electron. They own IPC, window and workspace routing, executable discovery, UI localization, and host security policy, but not another JSON-RPC client.
 
+Logical layers do not require one published package per layer. A binding may ship Contracts and runtime assemblies together when that keeps installation atomic, provided the dependency boundary and transport-free Contracts surface remain intact.
+
 The raw Wire API is the low-level SDK surface. Bindings must not preserve a parallel legacy wire client or compatibility facade after consumers migrate.
 
 ### 2.3 AppServer And Hub Are Authoritative
@@ -217,6 +219,7 @@ Wire connection behavior is shared across bindings:
 - After reconnect, the client replays the exact initialization parameters, sends `initialized`, and only then releases queued application messages.
 - Notification and server-request handler registrations survive reconnect. Explicit close cancels retries.
 - Wire does not recover Thread, Run, subscription, or Dynamic Tool state. Those decisions belong to the high-level client or host adapter.
+- A high-level Run that loses its Wire session terminates with a stable disconnect error. Reconnect must never replay `turn/start`; applications recover from persisted Thread and Turn state explicitly.
 
 Normal RPC calls default to thirty seconds and allow a finite override or no timeout. Ordinary local initialization defaults to no timeout. Desktop remote initialization uses fifteen seconds, and a Desktop connection probe uses ten seconds.
 

--- a/src/DotCraft.Protocol.Contracts/DotCraft.Protocol.Contracts.csproj
+++ b/src/DotCraft.Protocol.Contracts/DotCraft.Protocol.Contracts.csproj
@@ -10,6 +10,7 @@
     <Version>0.1.0</Version>
     <Authors>DotHarness</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
Packages DotCraft.Sdk and DotCraft.Protocol.Contracts assemblies in a single NuGet package and adds isolated package validation to the release workflow.
Defines explicit reconnect defaults and ensures active runs fail with RunDisconnectedError without replaying turn/start.