### PR TITLE
fix(openai): preserve tool results in provider history

### DIFF
--- a/specs/architecture/responses-provider-history.md
+++ b/specs/architecture/responses-provider-history.md
@@ -73,11 +73,13 @@ For a version-1 thread, the Responses request input is:
 2. plus only the current MEAI sampling tail not already represented by that generation.
 
 The turn runtime captures the MEAI baseline before the current user input enters the agent.
-Coverage is an append-only message boundary measured against the same sanitizer-normalized
-sampling projection used for provider requests, not against the raw MEAI collection shape. The
-function-invocation wrapper marks that projection as covered after it updates its augmented
-sampling history. This lets the next tool-loop request map only newly appended tool results and
-guidance without rewriting the canonical generation.
+Coverage is an append-only message boundary measured against the sanitizer-normalized sampling
+projection used for provider requests, not against the raw MEAI collection shape. Raw baselines,
+replacement histories, and compaction inputs are normalized when they enter that projection. The
+function-invocation wrapper then passes the already-prepared sampling buffer through the live tool
+loop. Provider-history preparation and coverage marking must use that buffer directly rather than
+sanitize it again. This keeps newly appended real tool results beyond the covered provider-output
+prefix so the next request maps them without rewriting the canonical generation.
 
 Request-local history sanitization is not a conversation-history replacement. A sanitizer may
 repair an incomplete tool pair or remove content that is invalid for a role in the current request,

--- a/src/DotCraft.Core/Agents/Providers/OpenAI/OpenAIResponsesProviderHistoryRuntime.cs
+++ b/src/DotCraft.Core/Agents/Providers/OpenAI/OpenAIResponsesProviderHistoryRuntime.cs
@@ -21,7 +21,7 @@ internal interface IProviderConversationHistoryBridge
         string reason,
         CancellationToken cancellationToken);
 
-    void MarkProjectionCovered(IReadOnlyList<ChatMessage> messages);
+    void MarkProjectionCovered(IReadOnlyList<ChatMessage> samplingMessages);
 
     string? BeginAttempt();
 
@@ -47,8 +47,8 @@ internal sealed class OpenAIResponsesProviderHistoryBridge : IProviderConversati
             ? context.ReplaceAsync(messages, options, reason, cancellationToken)
             : ValueTask.CompletedTask;
 
-    public void MarkProjectionCovered(IReadOnlyList<ChatMessage> messages) =>
-        OpenAIResponsesProviderHistoryRuntimeScope.Current?.MarkProjectionCovered(messages);
+    public void MarkProjectionCovered(IReadOnlyList<ChatMessage> samplingMessages) =>
+        OpenAIResponsesProviderHistoryRuntimeScope.Current?.MarkProjectionCovered(samplingMessages);
 
     public string? BeginAttempt() =>
         OpenAIResponsesProviderHistoryRuntimeScope.Current?.BeginAttempt();
@@ -104,14 +104,13 @@ internal sealed class OpenAIResponsesProviderHistoryContext : IProviderHistoryCo
     }
 
     public async ValueTask<CanonicalResponsesInput> PrepareInputAsync(
-        IReadOnlyList<ChatMessage> messages,
+        IReadOnlyList<ChatMessage> samplingMessages,
         ChatOptions? options,
         CancellationToken cancellationToken)
     {
         await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var samplingMessages = GetSamplingProjection(messages);
             if (_coveredSamplingMessageCount > samplingMessages.Count)
             {
                 throw new InvalidDataException(
@@ -386,10 +385,10 @@ internal sealed class OpenAIResponsesProviderHistoryContext : IProviderHistoryCo
         }
     }
 
-    public void MarkProjectionCovered(IReadOnlyList<ChatMessage> messages)
+    public void MarkProjectionCovered(IReadOnlyList<ChatMessage> samplingMessages)
     {
-        ArgumentNullException.ThrowIfNull(messages);
-        _coveredSamplingMessageCount = GetSamplingProjection(messages).Count;
+        ArgumentNullException.ThrowIfNull(samplingMessages);
+        _coveredSamplingMessageCount = samplingMessages.Count;
     }
 
     public string BeginAttempt()

--- a/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIResponsesProviderHistoryTests.cs
+++ b/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIResponsesProviderHistoryTests.cs
@@ -87,6 +87,7 @@ public sealed class OpenAIResponsesProviderHistoryTests
         Assert.Equal(
             ["message", "reasoning", "function_call", "function_call_output"],
             second.Input.Select(ReadType));
+        Assert.Equal("file contents", second.Input[^1]!["output"]!.GetValue<string>());
         Assert.Equal(
             "encrypted-provider-bytes",
             second.Input[1]!["encrypted_content"]!.GetValue<string>());
@@ -155,8 +156,10 @@ public sealed class OpenAIResponsesProviderHistoryTests
             initial.CaptureSnapshot(),
             rawBaseline,
             resumedRecords);
+        var samplingHistory = ModelRequestHistorySanitizer.Sanitize(
+            [.. rawBaseline, new ChatMessage(ChatRole.User, "continue")]);
         var next = await resumed.PrepareInputAsync(
-            [.. rawBaseline, new ChatMessage(ChatRole.User, "continue")],
+            samplingHistory,
             options: null,
             CancellationToken.None);
 


### PR DESCRIPTION
PR #172 fixed sampling coverage mismatches introduced with provider history in PR #150, but also re-sanitized live sampling buffers and could replace real tool results with synthetic aborted outputs. This restores the correct boundary behavior while preserving streaming output and the original resumed-history fix.