### PR TITLE
fix: apply setup model preference to workspace

### DIFF
--- a/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
+++ b/desktop/src/renderer/components/conversation/ConversationWelcome.tsx
@@ -464,6 +464,14 @@ export function ConversationWelcome({
     return parseJsonConfig<Record<string, unknown>>(raw, {})
   }, [remoteWorkspace, workspaceConfigPath])
 
+  const readEffectiveWorkspaceConfig = useCallback(async (): Promise<Record<string, unknown>> => {
+    const getCore = window.api.workspaceConfig?.getCore
+    if (typeof getCore === 'function') {
+      return configObjectFromWorkspaceCore(await getCore() as WorkspaceCoreConfigLike)
+    }
+    return readWorkspaceConfig()
+  }, [readWorkspaceConfig])
+
   const readWorkspaceProviderPreferences = useCallback(async (): Promise<ProviderPreferences> => {
     if (remoteWorkspace) {
       const getCore = window.api.workspaceConfig?.getCore
@@ -874,7 +882,7 @@ export function ConversationWelcome({
       }
 
       try {
-        const cfg = await readWorkspaceConfig()
+        const cfg = await readEffectiveWorkspaceConfig()
         if (disposed) return
         const nextProviderId = resolveWorkspaceProviderFromConfig(cfg)
         // A concrete workspace provider is authoritative even when a draft exists. This keeps
@@ -936,7 +944,7 @@ export function ConversationWelcome({
       disposed = true
     }
   }, [
-    readWorkspaceConfig,
+    readEffectiveWorkspaceConfig,
     loadModels,
     readWorkspaceProviderPreferences,
     workspaceConfigChange,
@@ -1076,7 +1084,7 @@ export function ConversationWelcome({
     const previousProvider = providerId
     const previousModel = modelName
     try {
-      const cfg = await readWorkspaceConfig()
+      const cfg = await readEffectiveWorkspaceConfig()
       await loadModels(true, nextProviderId)
       const catalogState = useModelCatalogStore.getState()
       const remembered = findProviderPreference(
@@ -1106,7 +1114,7 @@ export function ConversationWelcome({
     } finally {
       setModelApplying(false)
     }
-  }, [loadModels, modelName, persistWelcomePreference, providerId, readWorkspaceConfig, t, workspaceConfigPath])
+  }, [loadModels, modelName, persistWelcomePreference, providerId, readEffectiveWorkspaceConfig, t, workspaceConfigPath])
 
   const handleReasoningChange = useCallback(
     async (nextReasoning: ReasoningQuickValue): Promise<void> => {

--- a/desktop/src/renderer/components/conversation/useComposerModelControls.ts
+++ b/desktop/src/renderer/components/conversation/useComposerModelControls.ts
@@ -141,6 +141,14 @@ export function useComposerModelControls({
     return parseJsonConfig<Record<string, unknown>>(raw, {})
   }, [remoteWorkspace, workspaceConfigPath])
 
+  const readEffectiveWorkspaceConfig = useCallback(async (): Promise<Record<string, unknown>> => {
+    const getCore = window.api.workspaceConfig?.getCore
+    if (typeof getCore === 'function') {
+      return configObjectFromWorkspaceCore(await getCore() as WorkspaceCoreConfigLike)
+    }
+    return readWorkspaceConfig()
+  }, [readWorkspaceConfig])
+
   const setCaseInsensitiveField = useCallback(
     (target: Record<string, unknown>, key: string, value: unknown): void => {
       const lower = key.toLowerCase()
@@ -222,7 +230,7 @@ export function useComposerModelControls({
     let disposed = false
     const loadEffectiveModel = async (): Promise<void> => {
       try {
-        const workspaceCfg = await readWorkspaceConfig()
+        const workspaceCfg = await readEffectiveWorkspaceConfig()
         if (disposed) return
         const effectiveProviderId = resolveEffectiveProvider(activeThread, workspaceCfg)
         setProviderId(effectiveProviderId)
@@ -284,7 +292,7 @@ export function useComposerModelControls({
     detachedReasoningTouched,
     detachedSpeedTouched,
     detachedContextTouched,
-    readWorkspaceConfig,
+    readEffectiveWorkspaceConfig,
     resolveEffectiveModel,
     resolveEffectiveProvider,
     resolveEffectiveReasoning,
@@ -355,7 +363,7 @@ export function useComposerModelControls({
     if (!nextProviderId || nextProviderId === providerId || detached || !activeThread) return
     setModelApplying(true)
     try {
-      const workspaceCfg = await readWorkspaceConfig()
+      const workspaceCfg = await readEffectiveWorkspaceConfig()
       await loadModels(true, nextProviderId)
       const catalogState = useModelCatalogStore.getState()
       const remembered = readWorkspacePreference(workspaceCfg, nextProviderId)
@@ -402,7 +410,7 @@ export function useComposerModelControls({
     } finally {
       setModelApplying(false)
     }
-  }, [activeThread, detached, loadModels, providerId, readWorkspaceConfig, setCaseInsensitiveField, t])
+  }, [activeThread, detached, loadModels, providerId, readEffectiveWorkspaceConfig, setCaseInsensitiveField, t])
 
   const handleReasoningChange = useCallback(
     async (nextReasoning: ReasoningQuickValue): Promise<void> => {

--- a/desktop/src/renderer/tests/AgentBuilderViewIntro.test.tsx
+++ b/desktop/src/renderer/tests/AgentBuilderViewIntro.test.tsx
@@ -257,18 +257,24 @@ describe('AgentBuilderView intro composer', () => {
     expect(appServerSendRequest.mock.calls.some(([method]) => method === 'turn/enqueue')).toBe(false)
   })
 
-  it('starts a detached builder thread with the provider-specific workspace model', async () => {
-    vi.mocked(window.api.file.readFile).mockResolvedValue(JSON.stringify({
-      ProviderId: 'provider-a',
-      ProviderPreferences: {
-        'provider-a': {
-          Model: 'provider-model',
-          Reasoning: { Enabled: false, Effort: 'Medium', Output: 'Full' },
-          Speed: 'Standard',
-          ContextWindow: { Mode: 'Default' }
+  it('starts a detached builder thread with an inherited personal provider preference', async () => {
+    vi.mocked(window.api.workspaceConfig.getCore).mockResolvedValue({
+      workspace: {
+        providerId: null,
+        providerPreferences: {}
+      },
+      userDefaults: {
+        providerId: 'provider-a',
+        providerPreferences: {
+          'provider-a': {
+            model: 'provider-model',
+            reasoning: { enabled: false, effort: 'medium', output: 'full' },
+            speed: 'standard',
+            contextWindow: { mode: 'default' }
+          }
         }
       }
-    }))
+    } as unknown as Awaited<ReturnType<typeof window.api.workspaceConfig.getCore>>)
     const defaultSendRequest = appServerSendRequest.getMockImplementation()
     appServerSendRequest.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
       if (method === 'model/list') {

--- a/desktop/src/renderer/tests/ConversationWelcome.test.tsx
+++ b/desktop/src/renderer/tests/ConversationWelcome.test.tsx
@@ -177,6 +177,25 @@ function workspacePreferenceConfig(
   }
 }
 
+function configValue(config: Record<string, unknown>, key: string): unknown {
+  const expected = key.toLowerCase()
+  return Object.entries(config).find(([candidate]) => candidate.toLowerCase() === expected)?.[1]
+}
+
+function coreSnapshotFromConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const providerId = configValue(config, 'ProviderId')
+  const providerPreferences = configValue(config, 'ProviderPreferences')
+  return {
+    providerId: typeof providerId === 'string' ? providerId : null,
+    providerPreferences:
+      providerPreferences != null && typeof providerPreferences === 'object' && !Array.isArray(providerPreferences)
+        ? providerPreferences
+        : {},
+    welcomeSuggestionsEnabled: null,
+    defaultApprovalPolicy: null
+  }
+}
+
 describe('ConversationWelcome composer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -259,16 +278,12 @@ describe('ConversationWelcome composer', () => {
     })
 
     fileReadFile.mockResolvedValue('{}')
-    workspaceConfigGetCore.mockResolvedValue({
-      workspace: {
-        providerPreferences: {},
-        welcomeSuggestionsEnabled: null,
-        defaultApprovalPolicy: null
-      },
-      userDefaults: {
-        providerPreferences: {},
-        welcomeSuggestionsEnabled: null,
-        defaultApprovalPolicy: null
+    workspaceConfigGetCore.mockImplementation(async () => {
+      const raw = await fileReadFile()
+      const config = typeof raw === 'string' && raw.trim() ? JSON.parse(raw) as Record<string, unknown> : {}
+      return {
+        workspace: coreSnapshotFromConfig(config),
+        userDefaults: coreSnapshotFromConfig({})
       }
     })
     settingsGet.mockResolvedValue({ locale: 'en' })
@@ -819,6 +834,106 @@ describe('ConversationWelcome composer', () => {
     })
     expect(workspaceConfigGetCore).toHaveBeenCalled()
     expect(fileReadFile).not.toHaveBeenCalled()
+  })
+
+  it('loads an inherited personal provider preference for a local workspace without persisting it', async () => {
+    useConnectionStore.setState((state) => ({
+      capabilities: { ...state.capabilities, providerManagement: true }
+    }))
+    workspaceConfigGetCore.mockResolvedValue({
+      workspace: {
+        providerId: null,
+        providerPreferences: {},
+        welcomeSuggestionsEnabled: null,
+        defaultApprovalPolicy: null
+      },
+      userDefaults: {
+        providerId: 'openai',
+        providerPreferences: { openai: preference('gpt-5.6-sol') },
+        welcomeSuggestionsEnabled: null,
+        defaultApprovalPolicy: null
+      }
+    })
+    const defaultSendRequest = appServerSendRequest.getMockImplementation()
+    appServerSendRequest.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'provider/list') {
+        return {
+          providers: [
+            { id: 'openai', displayName: 'OpenAI', protocol: 'openai-responses' }
+          ]
+        }
+      }
+      if (method === 'model/list') {
+        return { success: true, providerId: params?.providerId, models: [{ id: 'gpt-5.6-sol' }] }
+      }
+      return defaultSendRequest?.(method, params)
+    })
+
+    renderWelcome()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select model' })).toHaveTextContent('gpt-5.6-sol')
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Select model' }))
+    expect(screen.getByRole('menuitem', { name: /Provider.*OpenAI/ })).toBeInTheDocument()
+    expect(appServerSendRequest).not.toHaveBeenCalledWith('workspace/config/update', expect.anything())
+  })
+
+  it('uses an inherited personal preference when switching providers and persists only the workspace override', async () => {
+    useConnectionStore.setState((state) => ({
+      capabilities: { ...state.capabilities, providerManagement: true }
+    }))
+    workspaceConfigGetCore.mockResolvedValue({
+      workspace: {
+        providerId: null,
+        providerPreferences: {},
+        welcomeSuggestionsEnabled: null,
+        defaultApprovalPolicy: null
+      },
+      userDefaults: {
+        providerId: 'openai',
+        providerPreferences: {
+          openai: preference('gpt-5.6-sol'),
+          anthropic: preference('claude-sonnet-4-5')
+        },
+        welcomeSuggestionsEnabled: null,
+        defaultApprovalPolicy: null
+      }
+    })
+    const defaultSendRequest = appServerSendRequest.getMockImplementation()
+    appServerSendRequest.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'provider/list') {
+        return {
+          providers: [
+            { id: 'openai', displayName: 'OpenAI', protocol: 'openai-responses' },
+            { id: 'anthropic', displayName: 'Anthropic', protocol: 'anthropic' }
+          ]
+        }
+      }
+      if (method === 'model/list') {
+        const model = params?.providerId === 'anthropic' ? 'claude-sonnet-4-5' : 'gpt-5.6-sol'
+        return { success: true, providerId: params?.providerId, models: [{ id: model }] }
+      }
+      return defaultSendRequest?.(method, params)
+    })
+
+    renderWelcome()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select model' })).toHaveTextContent('gpt-5.6-sol')
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Select model' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /Provider.*OpenAI/ }))
+    fireEvent.click(within(screen.getByRole('listbox', { name: 'Provider' })).getByRole('option', { name: /Anthropic/ }))
+
+    await waitFor(() => {
+      expect(appServerSendRequest).toHaveBeenCalledWith('workspace/config/update', {
+        providerId: 'anthropic',
+        providerPreferences: {
+          anthropic: preference('claude-sonnet-4-5')
+        }
+      })
+    })
   })
 
   it('stages connected welcome apps with a switch and restores an explicit empty selection', async () => {

--- a/specs/clients/desktop-client.md
+++ b/specs/clients/desktop-client.md
@@ -136,6 +136,8 @@ The client exposes four user-visible connection states:
 
 During first-time workspace setup, provider model discovery uses the DotCraft backend model catalog rather than Desktop-owned model constants or direct provider-specific HTTP parsing. Existing providers are resolved by id; unsaved provider drafts are passed to the backend over stdin so credentials do not enter process arguments or logs. ChatGPT subscription setup completes OAuth in the wizard before requesting the account-scoped catalog. The wizard preserves a user's explicit model selection across refreshes, requires reselection when it disappears, and treats backend cache or bundled results as the only fallback source.
 
+The setup wizard's future-default choice controls configuration scope. When disabled, the selected provider and complete model preference are persisted as explicit workspace overrides even when they equal the current personal defaults, so later personal-default changes do not affect the workspace. When enabled, setup updates the personal provider and preference defaults and removes equivalent workspace overrides so the workspace inherits them. Provider credentials remain personal in both cases.
+
 ### 3.4 Reconnection
 
 Desktop enables the SDK Wire reconnect profile. Already-written requests fail on disconnect and are never replayed. Calls made while reconnecting remain ordered behind a successful `initialize` / `initialized` handshake. Desktop remains responsible for restoring UI subscriptions, interactive-request state, runtime Dynamic Tools, remote tunnels, and other workspace resources after the Wire connection becomes ready.

--- a/src/DotCraft.App/CLI/InitHelper.cs
+++ b/src/DotCraft.App/CLI/InitHelper.cs
@@ -122,15 +122,18 @@ public static class InitHelper
 
     private static void RemoveCaseInsensitive(JsonObject node, string key)
     {
-        var matched = node.FirstOrDefault(p => string.Equals(p.Key, key, StringComparison.OrdinalIgnoreCase));
-        if (!string.IsNullOrEmpty(matched.Key))
-            node.Remove(matched.Key);
+        var matches = node
+            .Select(pair => pair.Key)
+            .Where(candidate => string.Equals(candidate, key, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        foreach (var match in matches)
+            node.Remove(match);
     }
 
     private static void RemoveProviderAwareWorkspaceFields(JsonObject node)
     {
-        node.Remove("ProviderId");
-        node.Remove("ProviderPreferences");
+        RemoveCaseInsensitive(node, "ProviderId");
+        RemoveCaseInsensitive(node, "ProviderPreferences");
     }
 
     private static JsonObject GetOrCreateObject(JsonObject node, string key)

--- a/src/DotCraft.App/CLI/InitHelper.cs
+++ b/src/DotCraft.App/CLI/InitHelper.cs
@@ -120,12 +120,6 @@ public static class InitHelper
         createdItems?.Add(("[green]✓[/]", ".gitignore"));
     }
 
-    private static string? ReadTrimmedString(JsonObject node, string key)
-    {
-        var matched = node.FirstOrDefault(p => string.Equals(p.Key, key, StringComparison.OrdinalIgnoreCase));
-        return matched.Value?.GetValue<string>()?.Trim();
-    }
-
     private static void RemoveCaseInsensitive(JsonObject node, string key)
     {
         var matched = node.FirstOrDefault(p => string.Equals(p.Key, key, StringComparison.OrdinalIgnoreCase));
@@ -237,34 +231,19 @@ public static class InitHelper
 
     private static void ApplyProviderAwareWorkspaceSelection(
         JsonObject workspaceNode,
-        JsonObject globalNode,
         string providerId,
-        ModelPreference preference)
+        ModelPreference preference,
+        bool inheritPersonalDefault)
     {
         RemoveProviderAwareWorkspaceFields(workspaceNode);
 
-        var trimmedProviderId = providerId.Trim();
-        if (!string.IsNullOrWhiteSpace(trimmedProviderId)
-            && !string.Equals(ReadTrimmedString(globalNode, "ProviderId"), trimmedProviderId, StringComparison.Ordinal))
-        {
-            workspaceNode["ProviderId"] = trimmedProviderId;
-        }
-        else
-        {
-            workspaceNode.Remove("ProviderId");
-        }
+        if (inheritPersonalDefault)
+            return;
 
-        var globalPreferences = globalNode["ProviderPreferences"] as JsonObject;
-        var inheritedPreference = globalPreferences?
-            .FirstOrDefault(pair => string.Equals(
-                pair.Key,
-                trimmedProviderId,
-                StringComparison.OrdinalIgnoreCase)).Value;
-        var preferenceNode = JsonSerializer.SerializeToNode(preference, JsonOptions);
-        if (!JsonNode.DeepEquals(inheritedPreference, preferenceNode))
-        {
-            GetOrCreateObject(workspaceNode, "ProviderPreferences")[trimmedProviderId] = preferenceNode;
-        }
+        var trimmedProviderId = providerId.Trim();
+        workspaceNode["ProviderId"] = trimmedProviderId;
+        GetOrCreateObject(workspaceNode, "ProviderPreferences")[trimmedProviderId] =
+            JsonSerializer.SerializeToNode(preference, JsonOptions);
     }
 
     private static int RunProviderAwareSetup(
@@ -319,7 +298,11 @@ public static class InitHelper
         }
 
         SaveJsonObject(globalConfigPath, globalNode);
-        ApplyProviderAwareWorkspaceSelection(workspaceNode, globalNode, providerId, preference);
+        ApplyProviderAwareWorkspaceSelection(
+            workspaceNode,
+            providerId,
+            preference,
+            inheritPersonalDefault: setAsUserDefault);
         SaveJsonObject(workspaceConfigPath, workspaceNode);
         WriteWorkspaceTemplates(craftPath, request.Profile);
         return 0;

--- a/tests/DotCraft.App.Tests/CLI/InitHelperSetupTests.cs
+++ b/tests/DotCraft.App.Tests/CLI/InitHelperSetupTests.cs
@@ -123,6 +123,19 @@ public sealed class InitHelperSetupTests : IDisposable
     {
         var craftPath = Path.Combine(tempRoot, ".craft");
         var globalConfigPath = Path.Combine(tempRoot, "user", ".craft", "config.json");
+        Directory.CreateDirectory(craftPath);
+        File.WriteAllText(Path.Combine(craftPath, "config.json"), """
+        {
+          "providerId": "stale-lower",
+          "PROVIDERID": "stale-upper",
+          "providerPreferences": {
+            "stale-lower": { "model": "stale-lower-model" }
+          },
+          "PROVIDERPREFERENCES": {
+            "stale-upper": { "model": "stale-upper-model" }
+          }
+        }
+        """);
         Directory.CreateDirectory(Path.GetDirectoryName(globalConfigPath)!);
         File.WriteAllText(globalConfigPath, """
         {
@@ -170,6 +183,10 @@ public sealed class InitHelperSetupTests : IDisposable
         Assert.Equal(
             "gpt-5.6-sol",
             workspaceNode["ProviderPreferences"]!["openai"]!["model"]?.GetValue<string>());
+        Assert.False(workspaceNode.ContainsKey("providerId"));
+        Assert.False(workspaceNode.ContainsKey("PROVIDERID"));
+        Assert.False(workspaceNode.ContainsKey("providerPreferences"));
+        Assert.False(workspaceNode.ContainsKey("PROVIDERPREFERENCES"));
 
         var globalNode = JsonNode.Parse(File.ReadAllText(globalConfigPath))!.AsObject();
         Assert.Equal("openai", globalNode["ProviderId"]?.GetValue<string>());

--- a/tests/DotCraft.App.Tests/CLI/InitHelperSetupTests.cs
+++ b/tests/DotCraft.App.Tests/CLI/InitHelperSetupTests.cs
@@ -119,6 +119,66 @@ public sealed class InitHelperSetupTests : IDisposable
     }
 
     [Fact]
+    public void RunSetup_ExistingPersonalDefaultWithoutFutureDefault_PinsMatchingWorkspacePreference()
+    {
+        var craftPath = Path.Combine(tempRoot, ".craft");
+        var globalConfigPath = Path.Combine(tempRoot, "user", ".craft", "config.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(globalConfigPath)!);
+        File.WriteAllText(globalConfigPath, """
+        {
+          "ProviderId": "openai",
+          "ProviderPreferences": {
+            "openai": {
+              "model": "gpt-5.6-sol",
+              "reasoning": {
+                "enabled": false,
+                "effort": "Medium",
+                "output": "Full"
+              },
+              "speed": "Standard",
+              "contextWindow": {
+                "mode": "Default"
+              }
+            }
+          },
+          "Providers": {
+            "openai": {
+              "DisplayName": "OpenAI",
+              "Protocol": "openai-responses",
+              "ApiKey": "test-existing-key"
+            }
+          }
+        }
+        """);
+
+        var result = InitHelper.RunSetup(craftPath, new WorkspaceSetupRequest
+        {
+            ApiKey = "",
+            EndPoint = "",
+            Model = "gpt-5.6-sol",
+            Preference = new ModelPreference { Model = "gpt-5.6-sol" },
+            Profile = WorkspaceBootstrapProfile.Default,
+            ProviderMode = WorkspaceSetupProviderMode.Existing,
+            ProviderId = "openai",
+            SetAsUserDefault = false
+        }, globalConfigPath);
+
+        Assert.Equal(0, result);
+
+        var workspaceNode = JsonNode.Parse(File.ReadAllText(Path.Combine(craftPath, "config.json")))!.AsObject();
+        Assert.Equal("openai", workspaceNode["ProviderId"]?.GetValue<string>());
+        Assert.Equal(
+            "gpt-5.6-sol",
+            workspaceNode["ProviderPreferences"]!["openai"]!["model"]?.GetValue<string>());
+
+        var globalNode = JsonNode.Parse(File.ReadAllText(globalConfigPath))!.AsObject();
+        Assert.Equal("openai", globalNode["ProviderId"]?.GetValue<string>());
+        Assert.Equal(
+            "gpt-5.6-sol",
+            globalNode["ProviderPreferences"]!["openai"]!["model"]?.GetValue<string>());
+    }
+
+    [Fact]
     public void RunSetup_SkipProvider_PreservesUnrelatedGlobalSettings()
     {
         var craftPath = Path.Combine(tempRoot, ".craft");


### PR DESCRIPTION
Summary
- Persist explicit workspace provider and model preferences when “Set as future default” is disabled.
- Inherit personal defaults when the option is enabled.
- Resolve effective workspace and personal preferences in Welcome and detached model controls.
- Keep provider credentials in personal configuration only.
- Add regression tests and document the setup behavior.