### PR TITLE
feat: extract OpenSandbox adapter from core

### DIFF
--- a/dotcraft.sln
+++ b/dotcraft.sln
@@ -7,11 +7,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.App", "src\DotCraf
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.Core", "src\DotCraft.Core\DotCraft.Core.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.OpenSandbox", "src\DotCraft.OpenSandbox\DotCraft.OpenSandbox.csproj", "{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.ContextExport", "src\DotCraft.ContextExport\DotCraft.ContextExport.csproj", "{08CE662B-AAB8-4C62-90D6-A13380AE5AD2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.Generators", "src\DotCraft.Generators\DotCraft.Generators.csproj", "{B2C3D4E5-6789-4B9A-CDEF-012345678901}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.Core.Tests", "tests\DotCraft.Core.Tests\DotCraft.Core.Tests.csproj", "{78456EB1-623C-4644-971B-341DE3478752}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.OpenSandbox.Tests", "tests\DotCraft.OpenSandbox.Tests\DotCraft.OpenSandbox.Tests.csproj", "{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotCraft.ContextExport.Tests", "tests\DotCraft.ContextExport.Tests\DotCraft.ContextExport.Tests.csproj", "{B5322D2E-D6DE-4A02-8DBB-51EBDA762317}"
 EndProject
@@ -101,6 +105,18 @@ Global
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Debug|x86.Build.0 = Debug|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Release|x64.Build.0 = Release|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F1C2D4E-5A6B-47C8-9D01-23456789ABCD}.Release|x86.Build.0 = Release|Any CPU
 		{08CE662B-AAB8-4C62-90D6-A13380AE5AD2}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{08CE662B-AAB8-4C62-90D6-A13380AE5AD2}.Debug|x64.Build.0 = Debug|Any CPU
 		{08CE662B-AAB8-4C62-90D6-A13380AE5AD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -137,6 +153,18 @@ Global
 		{78456EB1-623C-4644-971B-341DE3478752}.Release|Any CPU.Build.0 = Release|Any CPU
 		{78456EB1-623C-4644-971B-341DE3478752}.Release|x86.ActiveCfg = Release|Any CPU
 		{78456EB1-623C-4644-971B-341DE3478752}.Release|x86.Build.0 = Release|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Debug|x64.Build.0 = Debug|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Debug|x86.Build.0 = Debug|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Release|x64.ActiveCfg = Release|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Release|x64.Build.0 = Release|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Release|x86.ActiveCfg = Release|Any CPU
+		{4A2D3E5F-6B7C-48D9-A012-3456789ABCDE}.Release|x86.Build.0 = Release|Any CPU
 		{B5322D2E-D6DE-4A02-8DBB-51EBDA762317}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{B5322D2E-D6DE-4A02-8DBB-51EBDA762317}.Debug|x64.Build.0 = Debug|Any CPU
 		{B5322D2E-D6DE-4A02-8DBB-51EBDA762317}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/specs/architecture/tools-architecture.md
+++ b/specs/architecture/tools-architecture.md
@@ -91,6 +91,12 @@ Canonical sources are:
 | MCP | MCP connection/session | MCP server | workspace, thread, plugin, or binding MCP |
 | Runtime Dynamic | AppServer connection + thread | connected AppServer client | Desktop thread management, client-owned run callbacks |
 
+Core owns the Sandbox execution semantics, tool definitions, configuration, workspace synchronization,
+and thread-scoped lifecycle. A concrete sandbox backend is an infrastructure adapter: it implements the
+Core sandbox provider contracts and owns its vendor SDK dependency, protocol mapping, and provider-specific
+error translation. The default application composes the OpenSandbox adapter explicitly; this boundary does
+not make Sandbox a Plugin Native source or change its stable Core Native tool identities.
+
 ### 5.2 Registration boundary
 
 A source contribution MUST separate durable semantic definition from live executability:

--- a/src/DotCraft.App/DotCraft.App.csproj
+++ b/src/DotCraft.App/DotCraft.App.csproj
@@ -54,6 +54,7 @@
     <ProjectReference Include="..\DotCraft.Agents.Anthropic\DotCraft.Agents.Anthropic.csproj" />
     <ProjectReference Include="..\DotCraft.Automations\DotCraft.Automations.csproj" />
     <ProjectReference Include="..\DotCraft.DynamicWorkflows\DotCraft.DynamicWorkflows.csproj" />
+    <ProjectReference Include="..\DotCraft.OpenSandbox\DotCraft.OpenSandbox.csproj" />
     <ProjectReference Include="..\DotCraft.Teams\DotCraft.Teams.csproj" />
   </ItemGroup>
 

--- a/src/DotCraft.App/Program.cs
+++ b/src/DotCraft.App/Program.cs
@@ -11,6 +11,7 @@ using DotCraft.Modules;
 using DotCraft.Agents;
 using DotCraft.Logging;
 using DotCraft.DynamicWorkflows;
+using DotCraft.OpenSandbox;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -481,6 +482,7 @@ try
         .AddSingleton<IConfigSchemaProvider>(ConfigSchemaRegistrations.CreateSchemaProvider())
         .AddOpenAIModelProvider()
         .AddAnthropicModelProvider()
+        .AddOpenSandboxProvider(config.Tools.Sandbox)
         .AddDotCraft(config, workspacePath, botPath);
 
     var (provider, host) = hostBuilder.Build(services);

--- a/src/DotCraft.Core/DotCraft.Core.csproj
+++ b/src/DotCraft.Core/DotCraft.Core.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Alibaba.OpenSandbox" Version="0.1.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/DotCraft.Core/Hosting/WorkspaceRuntime.cs
+++ b/src/DotCraft.Core/Hosting/WorkspaceRuntime.cs
@@ -237,8 +237,12 @@ public sealed class WorkspaceRuntime : IAsyncDisposable
                 contextPageManager));
             if (Config.Tools.Sandbox.Enabled)
             {
+                var sandboxProvider = Services.GetService<ISandboxProvider>()
+                    ?? throw new InvalidOperationException(
+                        "Sandbox is enabled, but no ISandboxProvider is registered. Register a sandbox backend before starting the workspace runtime.");
                 toolSources.Add(new SandboxToolSource(
                     Config,
+                    sandboxProvider,
                     chatClientRegistry,
                     SkillsLoader,
                     scopedApproval,

--- a/src/DotCraft.Core/Tools/Sandbox/ISandboxCommandClient.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/ISandboxCommandClient.cs
@@ -1,5 +1,3 @@
-using OpenSandbox.Models;
-
 namespace DotCraft.Tools.Sandbox;
 
 /// <summary>
@@ -8,10 +6,10 @@ namespace DotCraft.Tools.Sandbox;
 public interface ISandboxCommandClient
 {
     /// <summary>Runs a command and streams its execution lifecycle to the supplied handlers.</summary>
-    Task<Execution> RunAsync(
+    Task<SandboxCommandResult> RunAsync(
         string command,
-        RunCommandOptions options,
-        ExecutionHandlers handlers,
+        SandboxCommandOptions options,
+        SandboxCommandHandlers handlers,
         CancellationToken cancellationToken);
 
     /// <summary>Interrupts a running sandbox command by execution identifier.</summary>
@@ -20,19 +18,19 @@ public interface ISandboxCommandClient
 
 internal sealed class SandboxCommandClient(SandboxSessionManager sandboxManager) : ISandboxCommandClient
 {
-    public async Task<Execution> RunAsync(
+    public async Task<SandboxCommandResult> RunAsync(
         string command,
-        RunCommandOptions options,
-        ExecutionHandlers handlers,
+        SandboxCommandOptions options,
+        SandboxCommandHandlers handlers,
         CancellationToken cancellationToken)
     {
         var sandbox = await sandboxManager.GetOrCreateAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        return await sandbox.Commands.RunAsync(command, options, handlers, cancellationToken).ConfigureAwait(false);
+        return await sandbox.RunCommandAsync(command, options, handlers, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task InterruptAsync(string executionId, CancellationToken cancellationToken)
     {
         var sandbox = await sandboxManager.GetOrCreateAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        await sandbox.Commands.InterruptAsync(executionId, cancellationToken).ConfigureAwait(false);
+        await sandbox.InterruptCommandAsync(executionId, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxAgentFileSystem.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxAgentFileSystem.cs
@@ -43,8 +43,8 @@ public sealed class SandboxAgentFileSystem(SandboxSessionManager sandboxManager)
     {
         var sandbox = await sandboxManager.GetOrCreateAsync();
         var escaped = "'" + sandboxPath.Replace("'", "'\\''") + "'";
-        var result = await sandbox.Commands.RunAsync($"base64 -w0 {escaped}");
-        var output = string.Join("", result.Logs.Stdout.Select(l => l.Text?.Trim()));
+        var result = await sandbox.RunCommandAsync($"base64 -w0 {escaped}");
+        var output = string.Join("", result.Stdout.Select(l => l.Text?.Trim()));
 
         if (string.IsNullOrEmpty(output))
             throw new FileNotFoundException($"File not found in sandbox: {sandboxPath}");

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxFileTools.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxFileTools.cs
@@ -1,12 +1,11 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using OpenSandbox.Models;
 
 namespace DotCraft.Tools.Sandbox;
 
 /// <summary>
-/// File operations inside an OpenSandbox container.
+/// File operations inside a sandbox container.
 /// All reads and writes happen within the sandbox's isolated filesystem.
 /// No path validation or approval is needed — the container is the boundary.
 /// </summary>
@@ -38,12 +37,12 @@ public sealed class SandboxFileTools
             var fullPath = ResolveSandboxPath(path);
 
             // Check if it's a directory
-            var checkResult = await sandbox.Commands.RunAsync($"test -d {EscapeShellArg(fullPath)} && echo DIR || echo FILE");
-            var isDir = checkResult.Logs.Stdout.FirstOrDefault()?.Text?.Trim() == "DIR";
+            var checkResult = await sandbox.RunCommandAsync($"test -d {EscapeShellArg(fullPath)} && echo DIR || echo FILE");
+            var isDir = checkResult.Stdout.FirstOrDefault()?.Text?.Trim() == "DIR";
 
             if (isDir)
             {
-                var lsResult = await sandbox.Commands.RunAsync($"ls -la {EscapeShellArg(fullPath)}");
+                var lsResult = await sandbox.RunCommandAsync($"ls -la {EscapeShellArg(fullPath)}");
                 return FormatCommandOutput(lsResult);
             }
 
@@ -67,7 +66,7 @@ public sealed class SandboxFileTools
                 return TextFileReadLimiter.FormatUnpaginatedTooLarge(path, byteLength.Value);
 
             // Read file content
-            var content = await sandbox.Files.ReadFileAsync(fullPath);
+            var content = await sandbox.ReadFileAsync(fullPath);
 
             if (content.Length > _maxFileSize)
                 return $"Error: File too large ({content.Length} bytes). Max size: {_maxFileSize} bytes.";
@@ -78,9 +77,9 @@ public sealed class SandboxFileTools
 
             return FormatTextReadResult(content, offset, limit);
         }
-        catch (OpenSandbox.Core.SandboxException ex)
+        catch (SandboxProviderException ex)
         {
-            return $"Sandbox error: [{ex.Error.Code}] {ex.Error.Message}";
+            return $"Sandbox error: [{ex.Code}] {ex.Message}";
         }
         catch (Exception ex)
         {
@@ -105,22 +104,22 @@ public sealed class SandboxFileTools
                 var parentDir = fullPath[..fullPath.LastIndexOf('/')];
                 if (!string.IsNullOrEmpty(parentDir))
                 {
-                    await sandbox.Files.CreateDirectoriesAsync([
-                        new CreateDirectoryEntry { Path = parentDir, Mode = 755 }
+                    await sandbox.CreateDirectoriesAsync([
+                        new SandboxDirectoryEntry(parentDir, 755)
                     ]);
                 }
 
-                await sandbox.Files.WriteFilesAsync([
-                    new WriteEntry { Path = fullPath, Data = content, Mode = 644 }
+                await sandbox.WriteFilesAsync([
+                    new SandboxWriteEntry(fullPath, content, 644)
                 ]);
             }
 
             var lineCount = content.Split('\n').Length;
             return $"Successfully wrote {content.Length} bytes ({lineCount} lines) to {path}";
         }
-        catch (OpenSandbox.Core.SandboxException ex)
+        catch (SandboxProviderException ex)
         {
-            return $"Sandbox error: [{ex.Error.Code}] {ex.Error.Message}";
+            return $"Sandbox error: [{ex.Code}] {ex.Message}";
         }
         catch (Exception ex)
         {
@@ -150,7 +149,7 @@ public sealed class SandboxFileTools
             string result;
             using (await PathAsyncMutex.AcquireKeyAsync($"sandbox:{fullPath}"))
             {
-                var content = await sandbox.Files.ReadFileAsync(fullPath);
+                var content = await sandbox.ReadFileAsync(fullPath);
                 var useCrLf = content.Contains("\r\n", StringComparison.Ordinal);
                 var lfContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
                 var lfOld = oldText.Replace("\r\n", "\n", StringComparison.Ordinal);
@@ -163,8 +162,8 @@ public sealed class SandboxFileTools
 
                 var newContent = useCrLf ? newLfContent.Replace("\n", "\r\n", StringComparison.Ordinal) : newLfContent;
 
-                await sandbox.Files.WriteFilesAsync([
-                    new WriteEntry { Path = fullPath, Data = newContent, Mode = 644 }
+                await sandbox.WriteFilesAsync([
+                    new SandboxWriteEntry(fullPath, newContent, 644)
                 ]);
 
                 if (replaceCount > 1)
@@ -179,9 +178,9 @@ public sealed class SandboxFileTools
 
             return result;
         }
-        catch (OpenSandbox.Core.SandboxException ex)
+        catch (SandboxProviderException ex)
         {
-            return $"Sandbox error: [{ex.Error.Code}] {ex.Error.Message}";
+            return $"Sandbox error: [{ex.Code}] {ex.Message}";
         }
         catch (Exception ex)
         {
@@ -205,16 +204,16 @@ public sealed class SandboxFileTools
             var includeArg = string.IsNullOrEmpty(include) ? "" : $"--include={EscapeShellArg(include)}";
             var command = $"grep -rn {includeArg} --max-count=100 -P {EscapeShellArg(pattern)} {EscapeShellArg(searchPath)} 2>/dev/null | head -100";
 
-            var result = await sandbox.Commands.RunAsync(command);
+            var result = await sandbox.RunCommandAsync(command);
             var output = FormatCommandOutput(result);
 
             return string.IsNullOrWhiteSpace(output) || output == "(no output)"
                 ? "No matches found."
                 : output;
         }
-        catch (OpenSandbox.Core.SandboxException ex)
+        catch (SandboxProviderException ex)
         {
-            return $"Sandbox error: [{ex.Error.Code}] {ex.Error.Message}";
+            return $"Sandbox error: [{ex.Code}] {ex.Message}";
         }
         catch (Exception ex)
         {
@@ -240,16 +239,16 @@ public sealed class SandboxFileTools
 
             var command = $"find {EscapeShellArg(searchPath)} {nameArgs} -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | head -200";
 
-            var result = await sandbox.Commands.RunAsync(command);
+            var result = await sandbox.RunCommandAsync(command);
             var output = FormatCommandOutput(result);
 
             return string.IsNullOrWhiteSpace(output) || output == "(no output)"
                 ? "No files found."
                 : output;
         }
-        catch (OpenSandbox.Core.SandboxException ex)
+        catch (SandboxProviderException ex)
         {
-            return $"Sandbox error: [{ex.Error.Code}] {ex.Error.Message}";
+            return $"Sandbox error: [{ex.Code}] {ex.Message}";
         }
         catch (Exception ex)
         {
@@ -268,10 +267,10 @@ public sealed class SandboxFileTools
         return "/workspace/" + path;
     }
 
-    private static string FormatCommandOutput(Execution execution)
+    private static string FormatCommandOutput(SandboxCommandResult execution)
     {
         var sb = new StringBuilder();
-        foreach (var line in execution.Logs.Stdout)
+        foreach (var line in execution.Stdout)
         {
             if (line.Text != null) sb.AppendLine(line.Text);
         }
@@ -282,10 +281,10 @@ public sealed class SandboxFileTools
     internal static string FormatTextReadResult(string content, int offset, int limit)
         => TextFileReadLimiter.FormatInMemory(content, offset, limit);
 
-    private static async Task<long?> TryGetSandboxFileSizeAsync(OpenSandbox.Sandbox sandbox, string fullPath)
+    private static async Task<long?> TryGetSandboxFileSizeAsync(ISandboxInstance sandbox, string fullPath)
     {
         var arg = EscapeShellArg(fullPath);
-        var result = await sandbox.Commands.RunAsync($"stat -c%s {arg} 2>/dev/null || wc -c < {arg} 2>/dev/null");
+        var result = await sandbox.RunCommandAsync($"stat -c%s {arg} 2>/dev/null || wc -c < {arg} 2>/dev/null");
         var output = FormatCommandOutput(result);
         if (output == "(no output)")
             return null;
@@ -294,9 +293,9 @@ public sealed class SandboxFileTools
         return long.TryParse(firstLine, out var size) ? size : null;
     }
 
-    private static async Task<byte[]> ReadSandboxFileSampleAsync(OpenSandbox.Sandbox sandbox, string fullPath)
+    private static async Task<byte[]> ReadSandboxFileSampleAsync(ISandboxInstance sandbox, string fullPath)
     {
-        var result = await sandbox.Commands.RunAsync(
+        var result = await sandbox.RunCommandAsync(
             $"head -c {FileContentClassifier.SampleSize} {EscapeShellArg(fullPath)} 2>/dev/null | base64 -w0");
         var output = FormatCommandOutput(result).Trim();
         if (string.IsNullOrWhiteSpace(output) || output == "(no output)")

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxProviderContracts.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxProviderContracts.cs
@@ -1,0 +1,87 @@
+namespace DotCraft.Tools.Sandbox;
+
+/// <summary>Creates isolated sandbox instances for the Core sandbox runtime.</summary>
+public interface ISandboxProvider
+{
+    /// <summary>Creates a new isolated sandbox instance.</summary>
+    Task<ISandboxInstance> CreateAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>Provider-neutral operations required by Core sandbox tools.</summary>
+public interface ISandboxInstance : IAsyncDisposable
+{
+    /// <summary>Gets the provider-assigned instance identifier.</summary>
+    string Id { get; }
+
+    /// <summary>Runs a command inside the sandbox.</summary>
+    Task<SandboxCommandResult> RunCommandAsync(
+        string command,
+        SandboxCommandOptions? options = null,
+        SandboxCommandHandlers? handlers = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Interrupts a running command by provider-assigned execution identifier.</summary>
+    Task InterruptCommandAsync(string executionId, CancellationToken cancellationToken = default);
+
+    /// <summary>Reads a UTF-8 text file from the sandbox.</summary>
+    Task<string> ReadFileAsync(string path, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates directories inside the sandbox.</summary>
+    Task CreateDirectoriesAsync(
+        IReadOnlyList<SandboxDirectoryEntry> entries,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Writes UTF-8 text files inside the sandbox.</summary>
+    Task WriteFilesAsync(
+        IReadOnlyList<SandboxWriteEntry> entries,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Terminates the remote sandbox instance.</summary>
+    Task KillAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>Provider-neutral command execution options.</summary>
+public sealed class SandboxCommandOptions
+{
+    /// <summary>Gets or sets the provider-side command timeout in seconds.</summary>
+    public int TimeoutSeconds { get; set; }
+}
+
+/// <summary>Provider-neutral command lifecycle callbacks.</summary>
+public sealed class SandboxCommandHandlers
+{
+    /// <summary>Gets or sets the callback invoked when the provider assigns an execution id.</summary>
+    public Func<string, Task>? OnInitialized { get; set; }
+}
+
+/// <summary>One provider-neutral command log line.</summary>
+public sealed record SandboxCommandLogLine(string? Text);
+
+/// <summary>Provider-neutral command failure details.</summary>
+public sealed record SandboxCommandError(string Name, string Value);
+
+/// <summary>Provider-neutral command execution result.</summary>
+public sealed record SandboxCommandResult(
+    IReadOnlyList<SandboxCommandLogLine> Stdout,
+    IReadOnlyList<SandboxCommandLogLine> Stderr,
+    SandboxCommandError? Error = null);
+
+/// <summary>Directory creation request for one sandbox path.</summary>
+public sealed record SandboxDirectoryEntry(string Path, int Mode);
+
+/// <summary>Text file write request for one sandbox path.</summary>
+public sealed record SandboxWriteEntry(string Path, string Data, int Mode);
+
+/// <summary>A provider failure normalized at the Core sandbox boundary.</summary>
+public sealed class SandboxProviderException : Exception
+{
+    /// <summary>Creates a normalized provider failure.</summary>
+    public SandboxProviderException(string code, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Code = code;
+    }
+
+    /// <summary>Gets the provider-supplied stable error code when available.</summary>
+    public string Code { get; }
+}

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxSessionManager.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxSessionManager.cs
@@ -1,21 +1,19 @@
 using System.Collections.Concurrent;
 using DotCraft.Configuration;
-using OpenSandbox;
-using OpenSandbox.Config;
-using OpenSandbox.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DotCraft.Tools.Sandbox;
 
 /// <summary>
-/// Manages OpenSandbox instances per agent session.
+/// Manages sandbox instances per agent session.
 /// Each session gets its own isolated sandbox container.
 /// Handles creation, reuse, idle cleanup, and workspace synchronization.
 /// </summary>
 public sealed class SandboxSessionManager : IAsyncDisposable
 {
     private readonly AppConfig.SandboxConfig _config;
+    private readonly ISandboxProvider _provider;
     private readonly string _workspacePath;
     private readonly IReadOnlyList<string> _workspaceRoots;
     private readonly ConcurrentDictionary<string, SandboxEntry> _sandboxes = new();
@@ -30,11 +28,13 @@ public sealed class SandboxSessionManager : IAsyncDisposable
 
     public SandboxSessionManager(
         AppConfig.SandboxConfig config,
+        ISandboxProvider provider,
         string workspacePath,
         IReadOnlyList<string>? workspaceRoots = null,
         ILogger<SandboxSessionManager>? logger = null)
     {
         _config = config;
+        _provider = provider;
         _workspacePath = Path.GetFullPath(workspacePath);
         _workspaceRoots = (workspaceRoots ?? [_workspacePath])
             .Select(Path.GetFullPath)
@@ -56,7 +56,7 @@ public sealed class SandboxSessionManager : IAsyncDisposable
     /// Gets or creates a sandbox for the given session key.
     /// If a sandbox already exists and is healthy, it is reused.
     /// </summary>
-    public async Task<OpenSandbox.Sandbox> GetOrCreateAsync(
+    public async Task<ISandboxInstance> GetOrCreateAsync(
         string? sessionKey = null,
         CancellationToken cancellationToken = default)
     {
@@ -127,77 +127,26 @@ public sealed class SandboxSessionManager : IAsyncDisposable
         _createLock.Dispose();
     }
 
-    private async Task<OpenSandbox.Sandbox> CreateSandboxAsync(CancellationToken cancellationToken)
+    private async Task<ISandboxInstance> CreateSandboxAsync(CancellationToken cancellationToken)
     {
-        var connectionConfig = new ConnectionConfig(new ConnectionConfigOptions
-        {
-            Domain = _config.Domain,
-            ApiKey = string.IsNullOrWhiteSpace(_config.ApiKey) ? null : _config.ApiKey,
-            Protocol = _config.UseHttps ? ConnectionProtocol.Https : ConnectionProtocol.Http,
-            RequestTimeoutSeconds = 30,
-        });
-
-        var createOptions = new SandboxCreateOptions
-        {
-            ConnectionConfig = connectionConfig,
-            Image = _config.Image,
-            TimeoutSeconds = _config.TimeoutSeconds,
-            Resource = new Dictionary<string, string>
-            {
-                ["cpu"] = _config.Cpu,
-                ["memory"] = _config.Memory
-            },
-        };
-
-        // Apply network policy
-        var networkPolicy = BuildNetworkPolicy();
-        if (networkPolicy != null)
-        {
-            createOptions.NetworkPolicy = networkPolicy;
-        }
-
-        var sandbox = await OpenSandbox.Sandbox.CreateAsync(createOptions, cancellationToken);
+        var sandbox = await _provider.CreateAsync(cancellationToken).ConfigureAwait(false);
 
         // Create a timestamp marker for tracking file modifications
-        await sandbox.Commands.RunAsync("touch /tmp/.sandbox_created", cancellationToken: cancellationToken);
+        await sandbox.RunCommandAsync("touch /tmp/.sandbox_created", cancellationToken: cancellationToken);
 
         return sandbox;
     }
 
-    private NetworkPolicy? BuildNetworkPolicy()
-    {
-        return _config.NetworkPolicy.ToLowerInvariant() switch
-        {
-            "deny" => new NetworkPolicy
-            {
-                DefaultAction = NetworkRuleAction.Deny
-            },
-            "allow" => null, // No policy = allow all
-            "custom" when _config.AllowedEgressDomains.Count > 0 => new NetworkPolicy
-            {
-                DefaultAction = NetworkRuleAction.Deny,
-                Egress = _config.AllowedEgressDomains
-                    .Select(domain => new NetworkRule
-                    {
-                        Action = NetworkRuleAction.Allow,
-                        Target = domain
-                    })
-                    .ToList()
-            },
-            _ => null
-        };
-    }
-
     private async Task SyncWorkspaceToSandboxAsync(
-        OpenSandbox.Sandbox sandbox,
+        ISandboxInstance sandbox,
         CancellationToken cancellationToken)
     {
         try
         {
             // Create workspace directory in sandbox
-            await sandbox.Files.CreateDirectoriesAsync([
-                new CreateDirectoryEntry { Path = "/workspace", Mode = 755 },
-                new CreateDirectoryEntry { Path = "/workspace-roots", Mode = 755 }
+            await sandbox.CreateDirectoriesAsync([
+                new SandboxDirectoryEntry("/workspace", 755),
+                new SandboxDirectoryEntry("/workspace-roots", 755)
             ], cancellationToken);
 
             // Use tar to efficiently transfer workspace contents
@@ -212,8 +161,8 @@ public sealed class SandboxSessionManager : IAsyncDisposable
                 var sandboxRoot = string.Equals(root, _workspacePath, StringComparison.OrdinalIgnoreCase)
                     ? "/workspace"
                     : $"/workspace-roots/{rootIndex}";
-                await sandbox.Files.CreateDirectoriesAsync([
-                    new CreateDirectoryEntry { Path = sandboxRoot, Mode = 755 }
+                await sandbox.CreateDirectoriesAsync([
+                    new SandboxDirectoryEntry(sandboxRoot, 755)
                 ], cancellationToken);
 
                 var files = EnumerateWorkspaceFiles(root, _config.SyncExclude)
@@ -221,7 +170,7 @@ public sealed class SandboxSessionManager : IAsyncDisposable
                     .ToList();
                 foreach (var batch in Chunk(files, 20))
                 {
-                    var writeEntries = new List<WriteEntry>();
+                    var writeEntries = new List<SandboxWriteEntry>();
                     foreach (var filePath in batch)
                     {
                         try
@@ -230,12 +179,7 @@ public sealed class SandboxSessionManager : IAsyncDisposable
                             var sandboxPath = sandboxRoot + "/" + relativePath.Replace('\\', '/');
                             var content = await File.ReadAllTextAsync(filePath, cancellationToken);
 
-                            writeEntries.Add(new WriteEntry
-                            {
-                                Path = sandboxPath,
-                                Data = content,
-                                Mode = 644
-                            });
+                            writeEntries.Add(new SandboxWriteEntry(sandboxPath, content, 644));
                         }
                         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                         {
@@ -249,7 +193,7 @@ public sealed class SandboxSessionManager : IAsyncDisposable
 
                     if (writeEntries.Count > 0)
                     {
-                        await sandbox.Files.WriteFilesAsync(writeEntries, cancellationToken);
+                        await sandbox.WriteFilesAsync(writeEntries, cancellationToken);
                     }
                 }
 
@@ -348,7 +292,7 @@ public sealed class SandboxSessionManager : IAsyncDisposable
         return false;
     }
 
-    private async Task CleanupIdleSandboxesAsync()
+    internal async Task CleanupIdleSandboxesAsync()
     {
         var cutoff = DateTime.UtcNow.AddSeconds(-_config.IdleTimeoutSeconds);
         var toRemove = _sandboxes
@@ -390,9 +334,9 @@ public sealed class SandboxSessionManager : IAsyncDisposable
         }
     }
 
-    private sealed class SandboxEntry(OpenSandbox.Sandbox sandbox)
+    private sealed class SandboxEntry(ISandboxInstance sandbox)
     {
-        public OpenSandbox.Sandbox Sandbox { get; } = sandbox;
+        public ISandboxInstance Sandbox { get; } = sandbox;
         public DateTime LastUsed { get; set; } = DateTime.UtcNow;
         public bool IsDisposed { get; set; }
     }

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxShellTools.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxShellTools.cs
@@ -5,7 +5,7 @@ using DotCraft.Sessions;
 namespace DotCraft.Tools.Sandbox;
 
 /// <summary>
-/// Shell command execution inside an OpenSandbox container.
+/// Shell command execution inside a sandbox container.
 /// Commands run in complete isolation from the host machine — no regex guards,
 /// path blacklists, or approval flows are needed because the container boundary
 /// is the security boundary.
@@ -52,15 +52,15 @@ public sealed class SandboxShellTools
 
             var execution = await _commandClient.RunAsync(
                 effectiveCommand,
-                new OpenSandbox.Models.RunCommandOptions
+                new SandboxCommandOptions
                 {
                     TimeoutSeconds = _timeoutSeconds
                 },
-                new OpenSandbox.Models.ExecutionHandlers
+                new SandboxCommandHandlers
                 {
-                    OnInit = init =>
+                    OnInitialized = id =>
                     {
-                        executionId = init.Id;
+                        executionId = id;
                         return Task.CompletedTask;
                     }
                 },
@@ -100,9 +100,9 @@ public sealed class SandboxShellTools
             }
             throw;
         }
-        catch (OpenSandbox.Core.SandboxException ex)
+        catch (SandboxProviderException ex)
         {
-            var error = $"Sandbox error: [{ex.Error.Code}] {ex.Error.Message}";
+            var error = $"Sandbox error: [{ex.Code}] {ex.Message}";
             commandExecution?.Complete(error, status: "failed", exitCode: null);
             return error;
         }
@@ -114,12 +114,12 @@ public sealed class SandboxShellTools
         }
     }
 
-    private string FormatOutput(OpenSandbox.Models.Execution execution)
+    private string FormatOutput(SandboxCommandResult execution)
     {
         var result = new StringBuilder();
 
         // Collect stdout
-        foreach (var line in execution.Logs.Stdout)
+        foreach (var line in execution.Stdout)
         {
             if (line.Text != null)
                 result.AppendLine(line.Text);
@@ -127,7 +127,7 @@ public sealed class SandboxShellTools
 
         // Collect stderr
         var stderr = new StringBuilder();
-        foreach (var line in execution.Logs.Stderr)
+        foreach (var line in execution.Stderr)
         {
             if (line.Text != null)
                 stderr.AppendLine(line.Text);

--- a/src/DotCraft.Core/Tools/Sandbox/SandboxToolSource.cs
+++ b/src/DotCraft.Core/Tools/Sandbox/SandboxToolSource.cs
@@ -14,6 +14,7 @@ namespace DotCraft.Tools.Sandbox;
 /// <summary>Contributes thread-scoped sandbox file, shell, web, skill, and agent tools.</summary>
 public sealed class SandboxToolSource(
     AppConfig config,
+    ISandboxProvider sandboxProvider,
     ChatClientRegistry chatClientRegistry,
     SkillsLoader skillsLoader,
     IApprovalService approvalService,
@@ -42,6 +43,7 @@ public sealed class SandboxToolSource(
             context.ThreadId,
             _ => new SandboxSessionManager(
                 config.Tools.Sandbox,
+                sandboxProvider,
                 context.WorkspacePath,
                 context.WorkspaceRoots,
                 loggerFactory?.CreateLogger<SandboxSessionManager>()));

--- a/src/DotCraft.OpenSandbox/DotCraft.OpenSandbox.csproj
+++ b/src/DotCraft.OpenSandbox/DotCraft.OpenSandbox.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>DotCraft</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DebugSymbols>False</DebugSymbols>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Alibaba.OpenSandbox" Version="0.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotCraft.Core\DotCraft.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DotCraft.OpenSandbox.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/src/DotCraft.OpenSandbox/OpenSandboxProvider.cs
+++ b/src/DotCraft.OpenSandbox/OpenSandboxProvider.cs
@@ -1,0 +1,190 @@
+using DotCraft.Configuration;
+using DotCraft.Tools.Sandbox;
+using OpenSandbox;
+using OpenSandbox.Config;
+using OpenSandbox.Models;
+
+namespace DotCraft.OpenSandbox;
+
+/// <summary>Creates Core sandbox instances backed by Alibaba OpenSandbox.</summary>
+public sealed class OpenSandboxProvider(AppConfig.SandboxConfig config) : ISandboxProvider
+{
+    /// <inheritdoc />
+    public async Task<ISandboxInstance> CreateAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var createOptions = CreateOptions(config);
+            var sandbox = await global::OpenSandbox.Sandbox.CreateAsync(createOptions, cancellationToken).ConfigureAwait(false);
+            return new OpenSandboxInstance(sandbox);
+        }
+        catch (global::OpenSandbox.Core.SandboxException ex)
+        {
+            throw OpenSandboxExceptionMapper.Map(ex);
+        }
+    }
+
+    internal static SandboxCreateOptions CreateOptions(AppConfig.SandboxConfig value) => new()
+    {
+        ConnectionConfig = new ConnectionConfig(new ConnectionConfigOptions
+        {
+            Domain = value.Domain,
+            ApiKey = string.IsNullOrWhiteSpace(value.ApiKey) ? null : value.ApiKey,
+            Protocol = value.UseHttps ? ConnectionProtocol.Https : ConnectionProtocol.Http,
+            RequestTimeoutSeconds = 30,
+        }),
+        Image = value.Image,
+        TimeoutSeconds = value.TimeoutSeconds,
+        Resource = new Dictionary<string, string>
+        {
+            ["cpu"] = value.Cpu,
+            ["memory"] = value.Memory
+        },
+        NetworkPolicy = CreateNetworkPolicy(value)
+    };
+
+    internal static NetworkPolicy? CreateNetworkPolicy(AppConfig.SandboxConfig value) =>
+        value.NetworkPolicy.ToLowerInvariant() switch
+        {
+            "deny" => new NetworkPolicy
+            {
+                DefaultAction = NetworkRuleAction.Deny
+            },
+            "allow" => null,
+            "custom" when value.AllowedEgressDomains.Count > 0 => new NetworkPolicy
+            {
+                DefaultAction = NetworkRuleAction.Deny,
+                Egress = value.AllowedEgressDomains
+                    .Select(domain => new NetworkRule
+                    {
+                        Action = NetworkRuleAction.Allow,
+                        Target = domain
+                    })
+                    .ToList()
+            },
+            _ => null
+        };
+}
+
+internal sealed class OpenSandboxInstance(global::OpenSandbox.Sandbox sandbox) : ISandboxInstance
+{
+    public string Id => sandbox.Id;
+
+    public Task<SandboxCommandResult> RunCommandAsync(
+        string command,
+        SandboxCommandOptions? options = null,
+        SandboxCommandHandlers? handlers = null,
+        CancellationToken cancellationToken = default) =>
+        OpenSandboxExceptionMapper.RunAsync(async () =>
+        {
+            if (options == null && handlers == null)
+            {
+                var direct = await sandbox.Commands.RunAsync(command, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+                return MapExecution(direct);
+            }
+
+            var execution = await sandbox.Commands.RunAsync(
+                    command,
+                    new RunCommandOptions { TimeoutSeconds = options?.TimeoutSeconds ?? 0 },
+                    new ExecutionHandlers
+                    {
+                        OnInit = handlers?.OnInitialized == null
+                            ? null
+                            : init => handlers.OnInitialized(init.Id)
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return MapExecution(execution);
+        });
+
+    public Task InterruptCommandAsync(string executionId, CancellationToken cancellationToken = default) =>
+        OpenSandboxExceptionMapper.RunAsync(
+            () => sandbox.Commands.InterruptAsync(executionId, cancellationToken));
+
+    public Task<string> ReadFileAsync(string path, CancellationToken cancellationToken = default) =>
+        OpenSandboxExceptionMapper.RunAsync(
+            () => sandbox.Files.ReadFileAsync(path, cancellationToken: cancellationToken));
+
+    public Task CreateDirectoriesAsync(
+        IReadOnlyList<SandboxDirectoryEntry> entries,
+        CancellationToken cancellationToken = default) =>
+        OpenSandboxExceptionMapper.RunAsync(() => sandbox.Files.CreateDirectoriesAsync(
+            MapDirectoryEntries(entries),
+            cancellationToken));
+
+    public Task WriteFilesAsync(
+        IReadOnlyList<SandboxWriteEntry> entries,
+        CancellationToken cancellationToken = default) =>
+        OpenSandboxExceptionMapper.RunAsync(() => sandbox.Files.WriteFilesAsync(
+            MapWriteEntries(entries),
+            cancellationToken));
+
+    public Task KillAsync(CancellationToken cancellationToken = default) =>
+        OpenSandboxExceptionMapper.RunAsync(() => sandbox.KillAsync(cancellationToken));
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await sandbox.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (global::OpenSandbox.Core.SandboxException ex)
+        {
+            throw OpenSandboxExceptionMapper.Map(ex);
+        }
+    }
+
+    internal static SandboxCommandResult MapExecution(Execution execution) => new(
+        execution.Logs.Stdout.Select(line => new SandboxCommandLogLine(line.Text)).ToArray(),
+        execution.Logs.Stderr.Select(line => new SandboxCommandLogLine(line.Text)).ToArray(),
+        execution.Error == null
+            ? null
+            : new SandboxCommandError(execution.Error.Name, execution.Error.Value));
+
+    internal static List<CreateDirectoryEntry> MapDirectoryEntries(
+        IReadOnlyList<SandboxDirectoryEntry> entries) =>
+        entries.Select(entry => new CreateDirectoryEntry
+        {
+            Path = entry.Path,
+            Mode = entry.Mode
+        }).ToList();
+
+    internal static List<WriteEntry> MapWriteEntries(IReadOnlyList<SandboxWriteEntry> entries) =>
+        entries.Select(entry => new WriteEntry
+        {
+            Path = entry.Path,
+            Data = entry.Data,
+            Mode = entry.Mode
+        }).ToList();
+}
+
+internal static class OpenSandboxExceptionMapper
+{
+    public static SandboxProviderException Map(global::OpenSandbox.Core.SandboxException exception) =>
+        new(exception.Error.Code, exception.Error.Message ?? "OpenSandbox provider failure.", exception);
+
+    public static async Task RunAsync(Func<Task> operation)
+    {
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        catch (global::OpenSandbox.Core.SandboxException ex)
+        {
+            throw Map(ex);
+        }
+    }
+
+    public static async Task<T> RunAsync<T>(Func<Task<T>> operation)
+    {
+        try
+        {
+            return await operation().ConfigureAwait(false);
+        }
+        catch (global::OpenSandbox.Core.SandboxException ex)
+        {
+            throw Map(ex);
+        }
+    }
+}

--- a/src/DotCraft.OpenSandbox/OpenSandboxServiceCollectionExtensions.cs
+++ b/src/DotCraft.OpenSandbox/OpenSandboxServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using DotCraft.Configuration;
+using DotCraft.Tools.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotCraft.OpenSandbox;
+
+/// <summary>Registers the built-in OpenSandbox infrastructure adapter.</summary>
+public static class OpenSandboxServiceCollectionExtensions
+{
+    /// <summary>Adds the fixed OpenSandbox implementation for Core sandbox execution.</summary>
+    public static IServiceCollection AddOpenSandboxProvider(
+        this IServiceCollection services,
+        AppConfig.SandboxConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        services.AddSingleton<ISandboxProvider>(new OpenSandboxProvider(config));
+        return services;
+    }
+}

--- a/tests/DotCraft.Core.Tests/Tools/GeneratedToolFunctionParityTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/GeneratedToolFunctionParityTests.cs
@@ -183,7 +183,10 @@ public sealed class GeneratedToolFunctionParityTests : IDisposable
         var skillView = new SkillViewTool(new SkillsLoader(_tempRoot), variantModeEnabled: false, new SkillVariantTarget());
         var skillManage = CreateSkillManageTool();
         var cronTools = CreateCronTools();
-        var sandboxManager = new SandboxSessionManager(new AppConfig.SandboxConfig { IdleTimeoutSeconds = 0 }, _tempRoot);
+        var sandboxManager = new SandboxSessionManager(
+            new AppConfig.SandboxConfig { IdleTimeoutSeconds = 0 },
+            new StubSandboxProvider(),
+            _tempRoot);
         _asyncDisposables.Add(sandboxManager);
         var sandboxFileTools = new SandboxFileTools(sandboxManager);
         var sandboxShellTools = new SandboxShellTools(new StubSandboxCommandClient());

--- a/tests/DotCraft.Core.Tests/Tools/SandboxProviderBoundaryTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/SandboxProviderBoundaryTests.cs
@@ -1,0 +1,93 @@
+using DotCraft.Configuration;
+using DotCraft.Tools.Sandbox;
+using Xunit;
+
+namespace DotCraft.Tests.Tools;
+
+public sealed class SandboxProviderBoundaryTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(
+        Path.GetTempPath(),
+        "DotCraftSandboxProviderBoundaryTests_" + Guid.NewGuid().ToString("N"));
+
+    public SandboxProviderBoundaryTests() => Directory.CreateDirectory(_tempRoot);
+
+    [Fact]
+    public async Task ShellTool_FormatsProviderNeutralOutputAndError()
+    {
+        var client = new StubSandboxCommandClient
+        {
+            RunHandler = (_, options, _, _) =>
+            {
+                Assert.Equal(17, options.TimeoutSeconds);
+                return Task.FromResult(new SandboxCommandResult(
+                    [new SandboxCommandLogLine("output")],
+                    [new SandboxCommandLogLine("warning")],
+                    new SandboxCommandError("exit", "7")));
+            }
+        };
+
+        var result = await new SandboxShellTools(client, timeoutSeconds: 17).Exec("false");
+
+        Assert.Equal("output\n\nSTDERR:\nwarning\n\nError: exit: 7", result.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public async Task FileTool_WritesThroughProviderNeutralFileOperations()
+    {
+        var directories = new List<SandboxDirectoryEntry>();
+        var writes = new List<SandboxWriteEntry>();
+        var instance = new StubSandboxInstance
+        {
+            CreateDirectoriesHandler = (entries, _) =>
+            {
+                directories.AddRange(entries);
+                return Task.CompletedTask;
+            },
+            WriteFilesHandler = (entries, _) =>
+            {
+                writes.AddRange(entries);
+                return Task.CompletedTask;
+            }
+        };
+        await using var manager = new SandboxSessionManager(
+            new AppConfig.SandboxConfig { SyncWorkspace = false, IdleTimeoutSeconds = 0 },
+            new StubSandboxProvider(_ => Task.FromResult<ISandboxInstance>(instance)),
+            _tempRoot);
+
+        var result = await new SandboxFileTools(manager).WriteFile("src/app.cs", "content");
+
+        Assert.Contains(directories, entry => entry == new SandboxDirectoryEntry("/workspace/src", 755));
+        Assert.Contains(writes, entry => entry == new SandboxWriteEntry("/workspace/src/app.cs", "content", 644));
+        Assert.Contains("Successfully wrote", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FileTool_FormatsNormalizedProviderFailure()
+    {
+        var instance = new StubSandboxInstance
+        {
+            WriteFilesHandler = (_, _) => throw new SandboxProviderException("write_failed", "disk full")
+        };
+        await using var manager = new SandboxSessionManager(
+            new AppConfig.SandboxConfig { SyncWorkspace = false, IdleTimeoutSeconds = 0 },
+            new StubSandboxProvider(_ => Task.FromResult<ISandboxInstance>(instance)),
+            _tempRoot);
+
+        var result = await new SandboxFileTools(manager).WriteFile("app.cs", "content");
+
+        Assert.Equal("Sandbox error: [write_failed] disk full", result);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+        catch
+        {
+            // Best effort test cleanup.
+        }
+    }
+}

--- a/tests/DotCraft.Core.Tests/Tools/SandboxSessionManagerTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/SandboxSessionManagerTests.cs
@@ -1,0 +1,136 @@
+using DotCraft.Configuration;
+using DotCraft.Tools.Sandbox;
+using Xunit;
+
+namespace DotCraft.Tests.Tools;
+
+public sealed class SandboxSessionManagerTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(
+        Path.GetTempPath(),
+        "DotCraftSandboxSessionManagerTests_" + Guid.NewGuid().ToString("N"));
+
+    public SandboxSessionManagerTests() => Directory.CreateDirectory(_tempRoot);
+
+    [Fact]
+    public async Task GetOrCreateAsync_ReusesSessionAndIsolatesDifferentKeys()
+    {
+        var created = 0;
+        var provider = new StubSandboxProvider(_ => Task.FromResult<ISandboxInstance>(
+            new StubSandboxInstance { Id = $"sandbox-{++created}" }));
+        await using var manager = CreateManager(provider, syncWorkspace: false);
+
+        var first = await manager.GetOrCreateAsync("first");
+        var reused = await manager.GetOrCreateAsync("first");
+        var second = await manager.GetOrCreateAsync("second");
+
+        Assert.Same(first, reused);
+        Assert.NotSame(first, second);
+        Assert.Equal(2, created);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_SynchronizesWorkspaceThroughProviderNeutralOperations()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempRoot, "hello.txt"), "hello sandbox");
+        var directories = new List<SandboxDirectoryEntry>();
+        var writes = new List<SandboxWriteEntry>();
+        var instance = new StubSandboxInstance
+        {
+            CreateDirectoriesHandler = (entries, _) =>
+            {
+                directories.AddRange(entries);
+                return Task.CompletedTask;
+            },
+            WriteFilesHandler = (entries, _) =>
+            {
+                writes.AddRange(entries);
+                return Task.CompletedTask;
+            }
+        };
+        await using var manager = CreateManager(
+            new StubSandboxProvider(_ => Task.FromResult<ISandboxInstance>(instance)),
+            syncWorkspace: true);
+
+        await manager.GetOrCreateAsync();
+
+        Assert.Contains(directories, entry => entry.Path == "/workspace");
+        var write = Assert.Single(writes, entry => entry.Path == "/workspace/hello.txt");
+        Assert.Equal("hello sandbox", write.Data);
+    }
+
+    [Fact]
+    public async Task ReleaseAndDispose_KillAndDisposeOwnedInstances()
+    {
+        var killed = 0;
+        var disposed = 0;
+        var provider = new StubSandboxProvider(_ => Task.FromResult<ISandboxInstance>(new StubSandboxInstance
+        {
+            KillHandler = _ =>
+            {
+                killed++;
+                return Task.CompletedTask;
+            },
+            DisposeHandler = () =>
+            {
+                disposed++;
+                return ValueTask.CompletedTask;
+            }
+        }));
+        var manager = CreateManager(provider, syncWorkspace: false);
+        await manager.GetOrCreateAsync("released");
+        await manager.ReleaseAsync("released");
+        await manager.GetOrCreateAsync("shutdown");
+
+        await manager.DisposeAsync();
+
+        Assert.Equal(2, killed);
+        Assert.Equal(2, disposed);
+    }
+
+    [Fact]
+    public async Task CleanupIdleSandboxesAsync_ReleasesExpiredInstance()
+    {
+        var killed = false;
+        var config = CreateConfig(syncWorkspace: false);
+        config.IdleTimeoutSeconds = -1;
+        var instance = new StubSandboxInstance
+        {
+            KillHandler = _ =>
+            {
+                killed = true;
+                return Task.CompletedTask;
+            }
+        };
+        await using var manager = new SandboxSessionManager(
+            config,
+            new StubSandboxProvider(_ => Task.FromResult<ISandboxInstance>(instance)),
+            _tempRoot);
+        await manager.GetOrCreateAsync("idle");
+
+        await manager.CleanupIdleSandboxesAsync();
+
+        Assert.True(killed);
+    }
+
+    private SandboxSessionManager CreateManager(ISandboxProvider provider, bool syncWorkspace) =>
+        new(CreateConfig(syncWorkspace), provider, _tempRoot);
+
+    private static AppConfig.SandboxConfig CreateConfig(bool syncWorkspace) => new()
+    {
+        IdleTimeoutSeconds = 0,
+        SyncWorkspace = syncWorkspace
+    };
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+        catch
+        {
+            // Best effort test cleanup.
+        }
+    }
+}

--- a/tests/DotCraft.Core.Tests/Tools/SandboxShellToolsCancellationTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/SandboxShellToolsCancellationTests.cs
@@ -1,5 +1,4 @@
 using DotCraft.Tools.Sandbox;
-using OpenSandbox.Models;
 using Xunit;
 
 namespace DotCraft.Tests.Tools;
@@ -16,11 +15,7 @@ public sealed class SandboxShellToolsCancellationTests
         {
             RunHandler = async (_, _, handlers, cancellationToken) =>
             {
-                await handlers.OnInit!(new ExecutionInit
-                {
-                    Id = "execution_123",
-                    Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-                });
+                await handlers.OnInitialized!("execution_123");
                 initialized.TrySetResult();
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 throw new InvalidOperationException("Unreachable");

--- a/tests/DotCraft.Core.Tests/Tools/StubSandboxCommandClient.cs
+++ b/tests/DotCraft.Core.Tests/Tools/StubSandboxCommandClient.cs
@@ -1,18 +1,17 @@
 using DotCraft.Tools.Sandbox;
-using OpenSandbox.Models;
 
 namespace DotCraft.Tests.Tools;
 
 internal sealed class StubSandboxCommandClient : ISandboxCommandClient
 {
-    public Func<string, RunCommandOptions, ExecutionHandlers, CancellationToken, Task<Execution>>? RunHandler { get; init; }
+    public Func<string, SandboxCommandOptions, SandboxCommandHandlers, CancellationToken, Task<SandboxCommandResult>>? RunHandler { get; init; }
 
     public Func<string, CancellationToken, Task>? InterruptHandler { get; init; }
 
-    public Task<Execution> RunAsync(
+    public Task<SandboxCommandResult> RunAsync(
         string command,
-        RunCommandOptions options,
-        ExecutionHandlers handlers,
+        SandboxCommandOptions options,
+        SandboxCommandHandlers handlers,
         CancellationToken cancellationToken) =>
         RunHandler?.Invoke(command, options, handlers, cancellationToken)
         ?? throw new NotSupportedException();

--- a/tests/DotCraft.Core.Tests/Tools/StubSandboxProvider.cs
+++ b/tests/DotCraft.Core.Tests/Tools/StubSandboxProvider.cs
@@ -1,0 +1,59 @@
+using DotCraft.Tools.Sandbox;
+
+namespace DotCraft.Tests.Tools;
+
+internal sealed class StubSandboxProvider(Func<CancellationToken, Task<ISandboxInstance>>? create = null)
+    : ISandboxProvider
+{
+    public Task<ISandboxInstance> CreateAsync(CancellationToken cancellationToken = default) =>
+        create?.Invoke(cancellationToken) ?? throw new NotSupportedException();
+}
+
+internal sealed class StubSandboxInstance : ISandboxInstance
+{
+    public string Id { get; init; } = "sandbox-test";
+
+    public Func<string, SandboxCommandOptions?, SandboxCommandHandlers?, CancellationToken, Task<SandboxCommandResult>>?
+        RunCommandHandler { get; init; }
+
+    public Func<string, CancellationToken, Task>? InterruptCommandHandler { get; init; }
+
+    public Func<string, CancellationToken, Task<string>>? ReadFileHandler { get; init; }
+
+    public Func<IReadOnlyList<SandboxDirectoryEntry>, CancellationToken, Task>? CreateDirectoriesHandler { get; init; }
+
+    public Func<IReadOnlyList<SandboxWriteEntry>, CancellationToken, Task>? WriteFilesHandler { get; init; }
+
+    public Func<CancellationToken, Task>? KillHandler { get; init; }
+
+    public Func<ValueTask>? DisposeHandler { get; init; }
+
+    public Task<SandboxCommandResult> RunCommandAsync(
+        string command,
+        SandboxCommandOptions? options = null,
+        SandboxCommandHandlers? handlers = null,
+        CancellationToken cancellationToken = default) =>
+        RunCommandHandler?.Invoke(command, options, handlers, cancellationToken)
+        ?? Task.FromResult(new SandboxCommandResult([], []));
+
+    public Task InterruptCommandAsync(string executionId, CancellationToken cancellationToken = default) =>
+        InterruptCommandHandler?.Invoke(executionId, cancellationToken) ?? Task.CompletedTask;
+
+    public Task<string> ReadFileAsync(string path, CancellationToken cancellationToken = default) =>
+        ReadFileHandler?.Invoke(path, cancellationToken) ?? Task.FromResult(string.Empty);
+
+    public Task CreateDirectoriesAsync(
+        IReadOnlyList<SandboxDirectoryEntry> entries,
+        CancellationToken cancellationToken = default) =>
+        CreateDirectoriesHandler?.Invoke(entries, cancellationToken) ?? Task.CompletedTask;
+
+    public Task WriteFilesAsync(
+        IReadOnlyList<SandboxWriteEntry> entries,
+        CancellationToken cancellationToken = default) =>
+        WriteFilesHandler?.Invoke(entries, cancellationToken) ?? Task.CompletedTask;
+
+    public Task KillAsync(CancellationToken cancellationToken = default) =>
+        KillHandler?.Invoke(cancellationToken) ?? Task.CompletedTask;
+
+    public ValueTask DisposeAsync() => DisposeHandler?.Invoke() ?? ValueTask.CompletedTask;
+}

--- a/tests/DotCraft.OpenSandbox.Tests/DotCraft.OpenSandbox.Tests.csproj
+++ b/tests/DotCraft.OpenSandbox.Tests/DotCraft.OpenSandbox.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>DotCraft.OpenSandbox.Tests</AssemblyName>
+    <RootNamespace>DotCraft.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotCraft.OpenSandbox\DotCraft.OpenSandbox.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DotCraft.OpenSandbox.Tests/OpenSandboxMappingTests.cs
+++ b/tests/DotCraft.OpenSandbox.Tests/OpenSandboxMappingTests.cs
@@ -1,0 +1,127 @@
+using DotCraft.Configuration;
+using DotCraft.OpenSandbox;
+using DotCraft.Tools.Sandbox;
+using global::OpenSandbox.Config;
+using global::OpenSandbox.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DotCraft.Tests.OpenSandbox;
+
+public sealed class OpenSandboxMappingTests
+{
+    [Fact]
+    public void AddOpenSandboxProvider_RegistersFixedProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddOpenSandboxProvider(new AppConfig.SandboxConfig());
+
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<OpenSandboxProvider>(provider.GetRequiredService<ISandboxProvider>());
+    }
+
+    [Fact]
+    public void CreateOptions_MapsConnectionResourcesAndContainerSettings()
+    {
+        var config = new AppConfig.SandboxConfig
+        {
+            Domain = "sandbox.example:443",
+            ApiKey = "test-api-key",
+            UseHttps = true,
+            Image = "example/sandbox:test",
+            TimeoutSeconds = 321,
+            Cpu = "2",
+            Memory = "1Gi"
+        };
+
+        var options = OpenSandboxProvider.CreateOptions(config);
+
+        Assert.NotNull(options.ConnectionConfig);
+        Assert.Equal("sandbox.example:443", options.ConnectionConfig!.Domain);
+        Assert.Equal("test-api-key", options.ConnectionConfig.ApiKey);
+        Assert.Equal(ConnectionProtocol.Https, options.ConnectionConfig.Protocol);
+        Assert.Equal(30, options.ConnectionConfig.RequestTimeoutSeconds);
+        Assert.Equal("example/sandbox:test", options.Image);
+        Assert.Equal(321, options.TimeoutSeconds);
+        Assert.NotNull(options.Resource);
+        Assert.Equal("2", options.Resource!["cpu"]);
+        Assert.Equal("1Gi", options.Resource["memory"]);
+    }
+
+    [Fact]
+    public void CreateNetworkPolicy_MapsDenyAndCustomEgress()
+    {
+        var deny = OpenSandboxProvider.CreateNetworkPolicy(new AppConfig.SandboxConfig
+        {
+            NetworkPolicy = "deny"
+        });
+        var custom = OpenSandboxProvider.CreateNetworkPolicy(new AppConfig.SandboxConfig
+        {
+            NetworkPolicy = "custom",
+            AllowedEgressDomains = ["api.example.com", "packages.example.com"]
+        });
+
+        Assert.Equal(NetworkRuleAction.Deny, deny!.DefaultAction);
+        Assert.Equal(NetworkRuleAction.Deny, custom!.DefaultAction);
+        Assert.NotNull(custom.Egress);
+        Assert.Equal(
+            ["api.example.com", "packages.example.com"],
+            custom.Egress!.Select(rule => rule.Target).ToArray());
+    }
+
+    [Fact]
+    public void MapExecution_PreservesOutputAndFailureDetails()
+    {
+        var execution = new Execution
+        {
+            Error = new ExecutionError
+            {
+                Name = "exit",
+                Value = "7",
+                Timestamp = 0,
+                Traceback = []
+            }
+        };
+        execution.Logs.Stdout.Add(new OutputMessage { Text = "out", Timestamp = 0 });
+        execution.Logs.Stderr.Add(new OutputMessage { Text = "err", Timestamp = 0 });
+
+        var result = OpenSandboxInstance.MapExecution(execution);
+
+        Assert.Equal("out", Assert.Single(result.Stdout).Text);
+        Assert.Equal("err", Assert.Single(result.Stderr).Text);
+        Assert.Equal(new SandboxCommandError("exit", "7"), result.Error);
+    }
+
+    [Fact]
+    public void ExceptionMapper_PreservesProviderCodeAndMessage()
+    {
+        var sdkException = new global::OpenSandbox.Core.SandboxException(
+            "request failed",
+            new InvalidOperationException("transport"),
+            new global::OpenSandbox.Core.SandboxError("sandbox_unavailable", "backend unavailable"));
+
+        var exception = OpenSandboxExceptionMapper.Map(sdkException);
+
+        Assert.Equal("sandbox_unavailable", exception.Code);
+        Assert.Equal("backend unavailable", exception.Message);
+        Assert.Same(sdkException, exception.InnerException);
+    }
+
+    [Fact]
+    public void FileEntryMapping_PreservesPathsDataAndModes()
+    {
+        var directories = OpenSandboxInstance.MapDirectoryEntries(
+            [new SandboxDirectoryEntry("/workspace/src", 755)]);
+        var writes = OpenSandboxInstance.MapWriteEntries(
+            [new SandboxWriteEntry("/workspace/src/app.cs", "content", 644)]);
+
+        var directory = Assert.Single(directories);
+        Assert.Equal("/workspace/src", directory.Path);
+        Assert.Equal(755, directory.Mode);
+        var write = Assert.Single(writes);
+        Assert.Equal("/workspace/src/app.cs", write.Path);
+        Assert.Equal("content", write.Data);
+        Assert.Equal(644, write.Mode);
+    }
+}


### PR DESCRIPTION
## Summary

- keep Sandbox semantics, tools, configuration, and lifecycle in Core
- extract the Alibaba OpenSandbox SDK integration into `DotCraft.OpenSandbox`
- introduce minimal provider-neutral Sandbox contracts
- register OpenSandbox explicitly from the App composition root
- remove the Alibaba SDK dependency from `DotCraft.Core`