### PR TITLE
feat: Upgrade AI SDK integrations and harden provider compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ DotCraft turns projects into **extensible environments for AI agents**.
 
 ## Quick start
 
+DotCraft supports OpenAI, Anthropic model providers, or you can sign in using your ChatGPT subscription.
+
+![Every model has a way in — OpenAI protocol, Anthropic protocol, or a ChatGPT subscription](https://github.com/DotHarness/resources/raw/master/dotcraft/providers.png)
+
 ### Desktop
 
 1. Download the latest build from [GitHub Releases](https://github.com/DotHarness/dotcraft/releases).
 2. Open a real project folder as a workspace.
-3. Configure a supported OpenAI, Anthropic provider or sign in with a ChatGPT subscription.
-
-![Every model has a way in — OpenAI protocol, Anthropic protocol, or a ChatGPT subscription](https://github.com/DotHarness/resources/raw/master/dotcraft/providers.png)
+3. Configuration model providers and preferences.
 
 ### CLI
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -29,13 +29,15 @@ DotCraft 将项目转变为 **AI Agent 的可扩展运行环境**。
 
 ## 快速开始
 
+DotCraft 支持 OpenAI、Anthropic 模型提供商，或使用你的 ChatGPT 订阅登录。
+
+![每个模型都有一条接入之路 —— OpenAI 协议、Anthropic 协议、ChatGPT 订阅](https://github.com/DotHarness/resources/raw/master/dotcraft/providers.png)
+
 ### Desktop
 
 1. 从 [GitHub Releases](https://github.com/DotHarness/dotcraft/releases) 下载最新版本。
 2. 选择一个真实项目目录作为工作区。
-3. 配置支持的 OpenAI、Anthropic Provider，或使用 ChatGPT 订阅登录。
-
-![每个模型都有一条接入之路 —— OpenAI 协议、Anthropic 协议、ChatGPT 订阅](https://github.com/DotHarness/resources/raw/master/dotcraft/providers.png)
+3. 配置模型提供商和偏好。
 
 ### CLI
 

--- a/desktop/src/renderer/components/layout/ResizeEdgeGlow.tsx
+++ b/desktop/src/renderer/components/layout/ResizeEdgeGlow.tsx
@@ -2,8 +2,6 @@ interface ResizeEdgeGlowProps {
   /** Hovered or dragged. */
   active: boolean
   testId: string
-  /** Offset for edges that start below the chrome header rather than at the top. */
-  top?: string
 }
 
 /**
@@ -11,14 +9,14 @@ interface ResizeEdgeGlowProps {
  * rather than being re-declared beside each `DragHandle`. The rest state stays
  * the owning panel's own hairline; this only fades in over it.
  */
-export function ResizeEdgeGlow({ active, testId, top = '0' }: ResizeEdgeGlowProps): JSX.Element {
+export function ResizeEdgeGlow({ active, testId }: ResizeEdgeGlowProps): JSX.Element {
   return (
     <div
       aria-hidden
       data-testid={testId}
       style={{
         position: 'absolute',
-        top,
+        top: 0,
         bottom: 0,
         left: 0,
         width: 'var(--main-surface-edge-glow-width)',

--- a/desktop/src/renderer/components/layout/ThreePanel.tsx
+++ b/desktop/src/renderer/components/layout/ThreePanel.tsx
@@ -339,7 +339,7 @@ export function ThreePanel({ sidebar, conversation, detail }: ThreePanelProps): 
             data-testid="detail-divider-line"
             style={{
               position: 'absolute',
-              top: 'var(--chrome-header-height)',
+              top: 0,
               bottom: 0,
               left: 0,
               width: '1px',
@@ -358,7 +358,6 @@ export function ThreePanel({ sidebar, conversation, detail }: ThreePanelProps): 
           <ResizeEdgeGlow
             active={effectiveDetailPanelVisible && detailDividerHighlighted}
             testId="detail-divider-glow"
-            top="var(--chrome-header-height)"
           />
         </div>
 

--- a/desktop/src/renderer/components/layout/ThreePanel.tsx
+++ b/desktop/src/renderer/components/layout/ThreePanel.tsx
@@ -333,14 +333,16 @@ export function ThreePanel({ sidebar, conversation, detail }: ThreePanelProps): 
           )}
 
           {/* Keep the divider mounted through close so it rides the collapsing
-              shell all the way to the right edge, then becomes transparent. */}
+              shell all the way to the right edge, then becomes transparent.
+              Inset by the card frame's own 1px hairlines so the divider butts
+              against them instead of overpainting the top and bottom edges. */}
           <div
             aria-hidden
             data-testid="detail-divider-line"
             style={{
               position: 'absolute',
-              top: 0,
-              bottom: 0,
+              top: '1px',
+              bottom: '1px',
               left: 0,
               width: '1px',
               background: 'var(--glass-border)',

--- a/specs/architecture/openai-subscription-auth.md
+++ b/specs/architecture/openai-subscription-auth.md
@@ -110,6 +110,12 @@ preserves the installation id.
 | ChatGPT OAuth | `https://chatgpt.com/backend-api/codex` | `/responses`, `/responses/compact` | `Authorization: Bearer <access_token>` | `chatgpt-account-id: <account_id>`, `originator: codex_cli_rs`, `x-codex-installation-id: <uuid>`, `session-id: <root_thread_id>`, `thread-id: <current_thread_id>`, `x-client-request-id: <current_thread_id>`, `x-codex-window-id: <window_id>`, `x-codex-turn-metadata: <json>`, `x-codex-turn-state: <state>` when established in the same logical turn |
 | ChatGPT OAuth | `https://chatgpt.com/backend-api/codex` | `/models` | `Authorization: Bearer <access_token>` | `chatgpt-account-id: <account_id>`, `originator: codex_cli_rs` |
 
+ChatGPT OAuth requests intentionally remove the OpenAI .NET SDK's `X-Stainless-*` platform
+metadata headers before transport. The Codex-compatible path owns its request identity through the
+headers above and the DotCraft/Codex user agent; this keeps its wire shape aligned with the Codex
+client under `references/codex` without changing the SDK defaults used by API-key or compatible
+OpenAI endpoints.
+
 For HTTP Responses, DotCraft sends `session-id`, `thread-id`, and `x-client-request-id` plus the
 body-level `prompt_cache_key`. `session-id` and the default cache key use the root cache-session
 identity; `thread-id` and `x-client-request-id` use the currently executing DotCraft thread.

--- a/specs/protocols/appserver-protocol.md
+++ b/specs/protocols/appserver-protocol.md
@@ -5677,7 +5677,7 @@ The result preserves the raw MCP shape: `{ "content": any[], "structuredContent"
 
 OAuth credentials are stored only in the user-scoped protected MCP auth store, partitioned by origin/runtime name/endpoint identity. They MUST NOT be persisted in workspace config, Session items, or logs. Expired credentials that cannot refresh are reported as `failureReason: "reauthenticationRequired"`; clients restart the same login method.
 
-`mcpServer/oauthLogin/completed` with `success: true` is emitted only after an authorization URL was returned and the browser authorization flow completed. A server that completes ordinary MCP startup without requesting OAuth causes the login request itself to fail and MUST NOT produce a contradictory success notification or clear unrelated credentials.
+`mcpServer/oauthLogin/completed` with `success: true` is emitted only after an authorization URL was returned, the loopback callback supplied an authorization code and matching state, and the MCP SDK completed any authorization-server issuer validation. A missing or mismatched state, a mismatched issuer, or an OAuth callback error fails the login and MUST NOT produce a success notification. A server that completes ordinary MCP startup without requesting OAuth causes the login request itself to fail and MUST NOT produce a contradictory success notification or clear unrelated credentials.
 
 #### 22.8.5 `config/mcpServer/reload`
 

--- a/src/DotCraft.Agents.Anthropic/Agents/Providers/Anthropic/AnthropicClientProvider.cs
+++ b/src/DotCraft.Agents.Anthropic/Agents/Providers/Anthropic/AnthropicClientProvider.cs
@@ -55,7 +55,8 @@ public sealed class AnthropicClientProvider : IModelProvider, IModelCatalogProvi
             new Dictionary<Type, object>
             {
                 [typeof(IToolCallArgumentsDeltaExtractor)] = AnthropicToolCallArgumentsDeltaExtractor.Instance,
-                [typeof(IPromptCacheDialect)] = AnthropicPromptCacheDialect.Instance
+                [typeof(IPromptCacheDialect)] = AnthropicPromptCacheDialect.Instance,
+                [typeof(IProviderManagedContinuationPolicy)] = AnthropicManagedContinuationPolicy.Instance
             });
     }
 
@@ -146,6 +147,8 @@ public sealed class AnthropicClientProvider : IModelProvider, IModelCatalogProvi
             return null;
         if (serviceType == typeof(IPromptCacheDialect))
             return AnthropicPromptCacheDialect.Instance;
+        if (serviceType == typeof(IProviderManagedContinuationPolicy))
+            return AnthropicManagedContinuationPolicy.Instance;
         return serviceType.IsInstanceOfType(this) ? this : null;
     }
 

--- a/src/DotCraft.Agents.Anthropic/Agents/Providers/Anthropic/AnthropicManagedContinuationPolicy.cs
+++ b/src/DotCraft.Agents.Anthropic/Agents/Providers/Anthropic/AnthropicManagedContinuationPolicy.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Agents;
+
+internal sealed class AnthropicManagedContinuationPolicy : IProviderManagedContinuationPolicy
+{
+    private const int MaximumPauseTurnContinuations = 5;
+    private static readonly ChatFinishReason PauseTurn = new("pause_turn");
+
+    public static AnthropicManagedContinuationPolicy Instance { get; } = new();
+
+    public int MaximumContinuations => MaximumPauseTurnContinuations;
+
+    public bool ShouldContinue(ChatResponse response) => response.FinishReason == PauseTurn;
+}

--- a/src/DotCraft.Agents.Anthropic/Agents/Providers/Anthropic/AnthropicProviderContentChatClient.cs
+++ b/src/DotCraft.Agents.Anthropic/Agents/Providers/Anthropic/AnthropicProviderContentChatClient.cs
@@ -1,4 +1,7 @@
 using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Anthropic.Models.Beta.Messages;
 using Microsoft.Extensions.AI;
 
@@ -6,6 +9,8 @@ namespace DotCraft.Agents;
 
 internal sealed class AnthropicProviderContentChatClient(IChatClient innerClient) : DelegatingChatClient(innerClient)
 {
+    private const string ServerToolInputProperty = "dotcraft.anthropic.server_tool_input";
+
     public override Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,
         ChatOptions? options = null,
@@ -17,8 +22,48 @@ internal sealed class AnthropicProviderContentChatClient(IChatClient innerClient
         ChatOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        Dictionary<long, StringBuilder>? serverToolInputs = null;
         await foreach (var update in base.GetStreamingResponseAsync(Rewrite(messages), options, cancellationToken))
+        {
+            var rawEvent = update.RawRepresentation is BetaRawMessageStreamEvent streamEvent
+                ? streamEvent.Value
+                : update.RawRepresentation;
+            switch (rawEvent)
+            {
+                case BetaRawContentBlockStartEvent
+                {
+                    ContentBlock.Value: BetaServerToolUseBlock
+                } start:
+                    (serverToolInputs ??= [])[start.Index] = new StringBuilder();
+                    break;
+                case BetaRawContentBlockDeltaEvent
+                {
+                    Delta.Value: BetaInputJsonDelta delta
+                } contentDelta when serverToolInputs?.TryGetValue(contentDelta.Index, out var input) == true:
+                    input.Append(delta.PartialJson);
+                    break;
+                case BetaRawContentBlockStopEvent stop
+                    when serverToolInputs?.Remove(stop.Index, out var completedInput) == true
+                         && completedInput.Length > 0:
+                    try
+                    {
+                        using var document = JsonDocument.Parse(completedInput.ToString());
+                        foreach (var content in update.Contents.Where(static item =>
+                                     item.RawRepresentation is BetaServerToolUseBlock))
+                        {
+                            (content.AdditionalProperties ??= [])[ServerToolInputProperty] =
+                                document.RootElement.Clone();
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Truncated tool input is a legal partial stream; preserve the start block.
+                    }
+                    break;
+            }
+
             yield return update;
+        }
     }
 
     private static IReadOnlyList<ChatMessage> Rewrite(IEnumerable<ChatMessage> source)
@@ -67,6 +112,27 @@ internal sealed class AnthropicProviderContentChatClient(IChatClient innerClient
 
     private static AIContent Rewrite(AIContent content)
     {
+        if (content.RawRepresentation is BetaServerToolUseBlock serverToolUse)
+        {
+            // Anthropic 12.42 projects response blocks to hosted-tool content, but its request
+            // mapper only accepts BetaContentBlockParam. Rehydrate the raw block for pause_turn.
+            var requestBlock = JsonSerializer.SerializeToNode(serverToolUse.RawData)?.AsObject()
+                               ?? new JsonObject();
+            if (content.AdditionalProperties?.TryGetValue(ServerToolInputProperty, out var input) == true
+                && input is JsonElement { ValueKind: JsonValueKind.Object } inputElement)
+            {
+                requestBlock["input"] = JsonNode.Parse(inputElement.GetRawText());
+            }
+
+            return new AIContent
+            {
+                AdditionalProperties = content.AdditionalProperties,
+                Annotations = content.Annotations,
+                RawRepresentation = new BetaContentBlockParam(
+                    JsonSerializer.SerializeToElement(requestBlock))
+            };
+        }
+
         if (content is DeferredToolReferenceContent reference)
         {
             return new TextContent(string.Empty)

--- a/src/DotCraft.Agents.Anthropic/DotCraft.Agents.Anthropic.csproj
+++ b/src/DotCraft.Agents.Anthropic/DotCraft.Agents.Anthropic.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.40.0" />
+    <PackageReference Include="Anthropic" Version="12.42.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotCraft.Agents.OpenAI/Agents/Providers/OpenAI/IChatGptResponsesCompactTransport.cs
+++ b/src/DotCraft.Agents.OpenAI/Agents/Providers/OpenAI/IChatGptResponsesCompactTransport.cs
@@ -30,8 +30,8 @@ internal sealed class SdkChatGptResponsesCompactTransport(ResponsesClient respon
             requestBody,
             ChatGptResponsesCompactJson.Options);
         var result = await responsesClient.CompactResponseAsync(
-                "application/json",
                 BinaryContent.Create(BinaryData.FromBytes(requestBytes)),
+                "application/json",
                 requestOptions)
             .ConfigureAwait(false);
         var rawResponse = result.GetRawResponse();

--- a/src/DotCraft.Agents.OpenAI/Agents/Providers/OpenAI/OpenAIOAuthPipelinePolicy.cs
+++ b/src/DotCraft.Agents.OpenAI/Agents/Providers/OpenAI/OpenAIOAuthPipelinePolicy.cs
@@ -24,6 +24,15 @@ internal sealed class OpenAIOAuthPipelinePolicy : PipelinePolicy
     internal const string BetaFeaturesValue = "remote_compaction_v2";
     private const string ResponsesPathSuffix = "/responses";
     private const string ResponsesCompactPathSuffix = "/responses/compact";
+    private static readonly string[] SdkPlatformMetadataHeaders =
+    [
+        "X-Stainless-Lang",
+        "X-Stainless-Package-Version",
+        "X-Stainless-Runtime",
+        "X-Stainless-Runtime-Version",
+        "X-Stainless-OS",
+        "X-Stainless-Arch"
+    ];
 
     private readonly IOpenAIAuthService _authService;
     private readonly string? _configuredAccountId;
@@ -112,6 +121,7 @@ internal sealed class OpenAIOAuthPipelinePolicy : PipelinePolicy
         OpenAIResponsesRoutingIdentity? routingIdentity,
         OpenAIResponsesCodexMetadataSnapshot? codexMetadata)
     {
+        RemoveSdkPlatformMetadataHeaders(message);
         message.Request.Headers.Set("Authorization", $"Bearer {accessToken}");
         var accountId = ResolveAccountId();
         if (!string.IsNullOrEmpty(accountId))
@@ -164,6 +174,12 @@ internal sealed class OpenAIOAuthPipelinePolicy : PipelinePolicy
         }
 
         ApplyExperimentalHeaders(message, isResponsesRequest);
+    }
+
+    private static void RemoveSdkPlatformMetadataHeaders(PipelineMessage message)
+    {
+        foreach (var headerName in SdkPlatformMetadataHeaders)
+            message.Request.Headers.Remove(headerName);
     }
 
     private static void CaptureTurnState(PipelineMessage message)

--- a/src/DotCraft.Agents.OpenAI/Agents/Providers/OpenAI/ResponsesToolSearchMapper.cs
+++ b/src/DotCraft.Agents.OpenAI/Agents/Providers/OpenAI/ResponsesToolSearchMapper.cs
@@ -307,7 +307,7 @@ internal static partial class ResponsesToolSearchMapper
     }
 
     internal static void PatchResponsePromptCacheKey(CreateResponseOptions options, string promptCacheKey) =>
-        PatchValue(options, "$.prompt_cache_key", promptCacheKey);
+        options.PromptCacheKey = promptCacheKey;
 
     internal static void PatchResponseServiceTier(CreateResponseOptions options, string serviceTier) =>
         PatchValue(options, "$.service_tier", serviceTier);

--- a/src/DotCraft.Agents.OpenAI/DotCraft.Agents.OpenAI.csproj
+++ b/src/DotCraft.Agents.OpenAI/DotCraft.Agents.OpenAI.csproj
@@ -21,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" NoWarn="NU1608" />
+    <PackageReference Include="OpenAI" Version="2.13.0" NoWarn="NU1608" />
     <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 

--- a/src/DotCraft.Agents/ChatClients/ToolCalling/StreamingFunctionInvokingChatClient.cs
+++ b/src/DotCraft.Agents/ChatClients/ToolCalling/StreamingFunctionInvokingChatClient.cs
@@ -144,12 +144,21 @@ public sealed partial class StreamingFunctionInvokingChatClient(IChatClient inne
         var originalMessages = messages.ToList();
         var providerHistoryBridge = ProviderRequestContextScope.Current?.History
                                     ?? GetService(typeof(IProviderConversationHistory)) as IProviderConversationHistory;
+        var providerManagedContinuationPolicy =
+            GetService(typeof(IProviderManagedContinuationPolicy)) as IProviderManagedContinuationPolicy;
+        var providerManagedContinuationLimit = providerManagedContinuationPolicy?.MaximumContinuations ?? 0;
+        if (providerManagedContinuationLimit < 0)
+        {
+            throw new InvalidOperationException(
+                "provider_continuation_policy_invalid: The provider-managed continuation limit must be non-negative.");
+        }
         var currentMessages = (IEnumerable<ChatMessage>)originalMessages;
         List<ChatMessage>? augmentedHistory = null;
         List<ChatMessage>? responseMessages = null;
         var consecutiveErrorCount = 0;
         var lastIterationHadConversationId = false;
         var guidanceContinuationCount = 0;
+        var providerManagedContinuationCount = 0;
         var toolMessageId = Guid.NewGuid().ToString("N");
         var hasAnyEffectiveProviderOutput = false;
         var awaitingPostToolContinuation = false;
@@ -277,6 +286,20 @@ public sealed partial class StreamingFunctionInvokingChatClient(IChatClient inne
                     augmentedHistory ?? throw new InvalidOperationException("Augmented history was not initialized."));
 
                 var history = augmentedHistory ?? throw new InvalidOperationException("Augmented history was not initialized.");
+                if (providerManagedContinuationPolicy?.ShouldContinue(response) == true)
+                {
+                    if (providerManagedContinuationCount >= providerManagedContinuationLimit)
+                    {
+                        throw new InvalidOperationException(
+                            "provider_continuation_limit: The model provider exceeded the managed continuation limit.");
+                    }
+
+                    providerManagedContinuationCount++;
+                    currentMessages = history;
+                    UpdateOptionsForNextIteration(ref options, response.ConversationId);
+                    continue;
+                }
+
                 if (guidanceContinuationCount < MaximumGuidanceContinuationsPerRequest &&
                     await TryAppendAnswerBoundaryMessageAsync(history, cancellationToken))
                 {

--- a/src/DotCraft.Agents/DotCraft.Agents.csproj
+++ b/src/DotCraft.Agents/DotCraft.Agents.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
   </ItemGroup>
 

--- a/src/DotCraft.Agents/Providers/IProviderManagedContinuationPolicy.cs
+++ b/src/DotCraft.Agents/Providers/IProviderManagedContinuationPolicy.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.AI;
+
+namespace DotCraft.Agents;
+
+/// <summary>
+/// Determines whether a provider response requires another sampling request before an agent turn is complete.
+/// </summary>
+public interface IProviderManagedContinuationPolicy
+{
+    /// <summary>
+    /// Gets the maximum number of additional provider requests allowed after the initial request.
+    /// The value must be non-negative; zero rejects the first response that requires continuation.
+    /// </summary>
+    int MaximumContinuations { get; }
+
+    /// <summary>Returns whether the response must be appended to history and continued by the provider.</summary>
+    bool ShouldContinue(ChatResponse response);
+}

--- a/src/DotCraft.ContextExport/DotCraft.ContextExport.csproj
+++ b/src/DotCraft.ContextExport/DotCraft.ContextExport.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotCraft.Core/DotCraft.Core.csproj
+++ b/src/DotCraft.Core/DotCraft.Core.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>

--- a/src/DotCraft.Core/Mcp/McpClientManager.cs
+++ b/src/DotCraft.Core/Mcp/McpClientManager.cs
@@ -1395,6 +1395,7 @@ public sealed class McpClientManager : IMcpToolInvocationCoordinator, IAsyncDisp
             {
                 Endpoint = new Uri(server.Url),
                 Name = server.Name,
+                TransportMode = HttpTransportMode.AutoDetect,
             };
 
             if (oauthOptions == null)
@@ -1407,7 +1408,7 @@ public sealed class McpClientManager : IMcpToolInvocationCoordinator, IAsyncDisp
                     {
                         RedirectUri = new Uri("http://127.0.0.1/callback"),
                         TokenCache = tokenStore,
-                        AuthorizationRedirectDelegate = (_, _, _) =>
+                        AuthorizationCallbackHandler = (_, _) =>
                             throw new McpAuthenticationRequiredException(hadTokens)
                     };
                 }
@@ -1464,16 +1465,10 @@ public sealed class McpClientManager : IMcpToolInvocationCoordinator, IAsyncDisp
                 Command = server.Command,
                 Name = server.Name,
                 Arguments = server.Arguments is { Count: > 0 } ? server.Arguments : null,
-                EnvironmentVariables = environmentVariables.Count > 0 ? environmentVariables : null
+                EnvironmentVariables = environmentVariables.Count > 0 ? environmentVariables : null,
+                InheritEnvironmentVariables = true,
+                WorkingDirectory = string.IsNullOrWhiteSpace(server.Cwd) ? null : server.Cwd
             };
-
-            if (!string.IsNullOrWhiteSpace(server.Cwd))
-            {
-                var prop = typeof(StdioClientTransportOptions).GetProperty("WorkingDirectory")
-                    ?? typeof(StdioClientTransportOptions).GetProperty("CurrentDirectory");
-                if (prop is { CanWrite: true })
-                    prop.SetValue(options, server.Cwd);
-            }
 
             transport = new StdioClientTransport(options);
         }

--- a/src/DotCraft.Core/Mcp/McpOAuthLoginCoordinator.cs
+++ b/src/DotCraft.Core/Mcp/McpOAuthLoginCoordinator.cs
@@ -1,5 +1,7 @@
+using System.Collections.Specialized;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
 using ModelContextProtocol.Authentication;
 
 namespace DotCraft.Mcp;
@@ -45,12 +47,12 @@ public static class McpOAuthLoginCoordinator
             RedirectUri = redirectUri,
             TokenCache = tokenCache,
             Scopes = scopes,
-            AuthorizationRedirectDelegate = async (url, _, ct) =>
+            AuthorizationCallbackHandler = async (context, ct) =>
             {
-                if (!IsSafeAuthorizationUrl(url))
+                if (!IsSafeAuthorizationUrl(context.AuthorizationUri))
                     throw new InvalidOperationException("The MCP authorization URL must use HTTPS or loopback HTTP.");
-                authorizationUrl.TrySetResult(url.AbsoluteUri);
-                return await WaitForAuthorizationCodeAsync(listener, ct);
+                authorizationUrl.TrySetResult(context.AuthorizationUri.AbsoluteUri);
+                return await WaitForAuthorizationResultAsync(listener, ct);
             }
         };
 
@@ -104,29 +106,57 @@ public static class McpOAuthLoginCoordinator
         }
     }
 
-    private static async Task<string> WaitForAuthorizationCodeAsync(
+    private static async Task<AuthorizationResult> WaitForAuthorizationResultAsync(
         HttpListener listener,
         CancellationToken cancellationToken)
     {
         var context = await listener.GetContextAsync().WaitAsync(cancellationToken);
         var query = context.Request.QueryString;
-        var error = query["error"];
-        var code = query["code"];
-        var responseText = string.IsNullOrWhiteSpace(error) && !string.IsNullOrWhiteSpace(code)
+        AuthorizationResult? result = null;
+        ExceptionDispatchInfo? callbackError = null;
+        try
+        {
+            result = ParseAuthorizationResult(query);
+        }
+        catch (Exception ex)
+        {
+            callbackError = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        var responseText = callbackError is null
             ? "Authentication complete. You can return to DotCraft."
             : "Authentication failed. You can return to DotCraft.";
         var bytes = System.Text.Encoding.UTF8.GetBytes(responseText);
-        context.Response.StatusCode = string.IsNullOrWhiteSpace(error) ? 200 : 400;
+        context.Response.StatusCode = callbackError is null ? 200 : 400;
         context.Response.ContentType = "text/plain; charset=utf-8";
         context.Response.ContentLength64 = bytes.Length;
         await context.Response.OutputStream.WriteAsync(bytes, cancellationToken);
         context.Response.Close();
 
+        if (callbackError is not null)
+            callbackError.Throw();
+        return result!;
+    }
+
+    internal static AuthorizationResult ParseAuthorizationResult(NameValueCollection query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var error = query["error"];
+        var code = query["code"];
+        var state = query["state"];
+        var issuer = query["iss"];
         if (!string.IsNullOrWhiteSpace(error))
             throw new InvalidOperationException($"MCP OAuth authorization failed: {error}.");
         if (string.IsNullOrWhiteSpace(code))
             throw new InvalidOperationException("MCP OAuth callback did not contain an authorization code.");
-        return code;
+        if (string.IsNullOrWhiteSpace(state))
+            throw new InvalidOperationException("MCP OAuth callback did not contain state.");
+        return new AuthorizationResult
+        {
+            Code = code,
+            State = state,
+            Iss = string.IsNullOrWhiteSpace(issuer) ? null : issuer
+        };
     }
 
     private static int ReserveLoopbackPort()

--- a/src/DotCraft.Core/Resources/models.json
+++ b/src/DotCraft.Core/Resources/models.json
@@ -96,6 +96,14 @@
         ]
       }
     },
+    "claude-opus-5": {
+      "contextWindow": 1000000,
+      "fast": {
+        "protocols": [
+          "anthropic"
+        ]
+      }
+    },
     "claude-sonnet-5": {
       "contextWindow": 1000000
     },

--- a/src/DotCraft.Harness/DotCraft.Harness.csproj
+++ b/src/DotCraft.Harness/DotCraft.Harness.csproj
@@ -30,13 +30,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.40.0" />
+    <PackageReference Include="Anthropic" Version="12.42.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" NoWarn="NU1608" />
+    <PackageReference Include="OpenAI" Version="2.13.0" NoWarn="NU1608" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />

--- a/src/DotCraft.Runtime/DotCraft.Runtime.csproj
+++ b/src/DotCraft.Runtime/DotCraft.Runtime.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotCraft.TraceViewer/DotCraft.TraceViewer.csproj
+++ b/src/DotCraft.TraceViewer/DotCraft.TraceViewer.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260529003" />
   </ItemGroup>
 

--- a/tests/DotCraft.Agents.Anthropic.Tests/Providers/Anthropic/AnthropicClientProviderTests.cs
+++ b/tests/DotCraft.Agents.Anthropic.Tests/Providers/Anthropic/AnthropicClientProviderTests.cs
@@ -1,5 +1,6 @@
 using DotCraft.Agents;
 using DotCraft.Configuration;
+using Microsoft.Extensions.AI;
 using ModelPreference = DotCraft.Configuration.ModelPreference;
 using Xunit;
 
@@ -67,7 +68,7 @@ public sealed class AnthropicClientProviderTests
         var config = new AppConfig
         {
             ProviderId = "anthropic-main",
-            ProviderPreferences = new() { ["anthropic-main"] = new ModelPreference { Model = "claude-sonnet-4-5"  } },
+            ProviderPreferences = new() { ["anthropic-main"] = new ModelPreference { Model = "claude-sonnet-4-5" } },
             Providers =
             {
                 ["anthropic-main"] = new AppConfig.ModelProviderConfig
@@ -91,6 +92,23 @@ public sealed class AnthropicClientProviderTests
 
         Assert.True(capabilities.PromptCacheRequestShaping);
         Assert.True(capabilities.NativeDeferredToolLoading);
+    }
+
+    [Fact]
+    public void CreateChatClient_RegistersPauseTurnContinuationPolicy()
+    {
+        var provider = new AnthropicClientProvider();
+        using var client = provider.CreateChatClient(Runtime(ModelProviderProtocols.Anthropic));
+
+        var policy = Assert.IsAssignableFrom<IProviderManagedContinuationPolicy>(
+            client.GetService(typeof(IProviderManagedContinuationPolicy)));
+        var paused = new ChatResponse([new ChatMessage(ChatRole.Assistant, "partial")])
+        {
+            FinishReason = new ChatFinishReason("pause_turn")
+        };
+
+        Assert.Equal(5, policy.MaximumContinuations);
+        Assert.True(policy.ShouldContinue(paused));
     }
 
     private static EffectiveModelRuntime Runtime(string protocol, int networkTimeoutSeconds = 600) => new(

--- a/tests/DotCraft.Agents.OpenAI.Tests/Providers/OpenAI/OpenAIResponsesLiteChatClientTests.cs
+++ b/tests/DotCraft.Agents.OpenAI.Tests/Providers/OpenAI/OpenAIResponsesLiteChatClientTests.cs
@@ -1,5 +1,7 @@
+using System.ClientModel.Primitives;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using DotCraft.Agents;
 using Microsoft.Extensions.AI;
 using OpenAI.Responses;
@@ -35,9 +37,13 @@ public sealed class OpenAIResponsesLiteChatClientTests
                 MaxOutputTokens = 123
             });
 #pragma warning disable SCME0001
+        var standardBody = JsonNode.Parse(ModelReaderWriter.Write(options).ToString())!.AsObject();
+        var patchedInput = standardBody["input"]!.AsArray();
+        patchedInput[0]!["content"]!.AsArray().Add(JsonNode.Parse(
+            """{"type":"input_image","image_url":"data:image/png;base64,AA==","detail":"high"}"""));
         options.Patch.Set(
-            "$.input[0].content[1]"u8,
-            BinaryData.FromString("""{"type":"input_image","image_url":"data:image/png;base64,AA==","detail":"high"}"""));
+            "$.input"u8,
+            BinaryData.FromString(patchedInput.ToJsonString()));
         options.Patch.Set(
             "$.tools"u8,
             BinaryData.FromString("""[{"type":"function","name":"nullable","parameters":{"type":"object","properties":{"value":{"type":["string","null"]}}}}]"""));

--- a/tests/DotCraft.ContextExport.Tests/DotCraft.ContextExport.Tests.csproj
+++ b/tests/DotCraft.ContextExport.Tests/DotCraft.ContextExport.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.1" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/DotCraft.Core.Tests/ChatClient/ToolCalling/StreamingFunctionInvokingChatClientManagedContinuationTests.cs
+++ b/tests/DotCraft.Core.Tests/ChatClient/ToolCalling/StreamingFunctionInvokingChatClientManagedContinuationTests.cs
@@ -1,0 +1,112 @@
+using DotCraft.Agents;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace DotCraft.Tests.Agents;
+
+public sealed partial class StreamingFunctionInvokingChatClientTests
+{
+    [Fact]
+    public async Task GetStreamingResponseAsync_ProviderManagedContinuation_AppendsResponseAndContinues()
+    {
+        var inner = new ManagedContinuationFakeChatClient(pauseCount: 5, maximumContinuations: 5);
+        var client = new StreamingFunctionInvokingChatClient(inner);
+
+        var updates = await CollectAsync(client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "start")]));
+
+        Assert.Equal(6, inner.Calls.Count);
+        Assert.Equal(5, inner.Calls[5].Count(message => message.Role == ChatRole.Assistant));
+        Assert.Equal(
+            ["partial-1", "partial-2", "partial-3", "partial-4", "partial-5", "done"],
+            updates.SelectMany(update => update.Contents).OfType<TextContent>().Select(content => content.Text));
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ProviderManagedContinuation_ThrowsAtLimit()
+    {
+        var inner = new ManagedContinuationFakeChatClient(pauseCount: 3, maximumContinuations: 2);
+        var client = new StreamingFunctionInvokingChatClient(inner);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => CollectAsync(
+            client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "start")])));
+
+        Assert.StartsWith("provider_continuation_limit:", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(3, inner.Calls.Count);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ProviderManagedContinuation_ZeroRejectsFirstContinuation()
+    {
+        var inner = new ManagedContinuationFakeChatClient(pauseCount: 1, maximumContinuations: 0);
+        var client = new StreamingFunctionInvokingChatClient(inner);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => CollectAsync(
+            client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "start")])));
+
+        Assert.StartsWith("provider_continuation_limit:", exception.Message, StringComparison.Ordinal);
+        Assert.Single(inner.Calls);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ProviderManagedContinuation_RejectsNegativePolicyBeforeSampling()
+    {
+        var inner = new ManagedContinuationFakeChatClient(pauseCount: 1, maximumContinuations: -1);
+        var client = new StreamingFunctionInvokingChatClient(inner);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => CollectAsync(
+            client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "start")])));
+
+        Assert.StartsWith("provider_continuation_policy_invalid:", exception.Message, StringComparison.Ordinal);
+        Assert.Empty(inner.Calls);
+    }
+
+    private sealed class ManagedContinuationFakeChatClient(
+        int pauseCount,
+        int maximumContinuations) : IChatClient
+    {
+        private static readonly ChatFinishReason PauseTurn = new("pause_turn");
+        private readonly TestManagedContinuationPolicy _policy = new(maximumContinuations);
+
+        public List<List<ChatMessage>> Calls { get; } = [];
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new ChatResponse([new ChatMessage(ChatRole.Assistant, "unused")]));
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> chatMessages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            Calls.Add(chatMessages.ToList());
+            var call = Calls.Count;
+            yield return new ChatResponseUpdate(ChatRole.Assistant, call <= pauseCount ? $"partial-{call}" : "done")
+            {
+                FinishReason = call <= pauseCount ? PauseTurn : ChatFinishReason.Stop
+            };
+            await Task.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) =>
+            serviceKey is null && serviceType == typeof(IProviderManagedContinuationPolicy)
+                ? _policy
+                : null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestManagedContinuationPolicy(int maximumContinuations)
+        : IProviderManagedContinuationPolicy
+    {
+        private static readonly ChatFinishReason PauseTurn = new("pause_turn");
+
+        public int MaximumContinuations => maximumContinuations;
+
+        public bool ShouldContinue(ChatResponse response) => response.FinishReason == PauseTurn;
+    }
+}

--- a/tests/DotCraft.Core.Tests/Mcp/McpOAuthCallbackTests.cs
+++ b/tests/DotCraft.Core.Tests/Mcp/McpOAuthCallbackTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Specialized;
+using DotCraft.Mcp;
+using Xunit;
+
+namespace DotCraft.Tests.Mcp;
+
+public sealed class McpOAuthCallbackTests
+{
+    [Fact]
+    public void ParseAuthorizationResult_PreservesCodeStateAndIssuer()
+    {
+        var result = McpOAuthLoginCoordinator.ParseAuthorizationResult(new NameValueCollection
+        {
+            ["code"] = "code-1",
+            ["state"] = "state-1",
+            ["iss"] = "https://issuer.example"
+        });
+
+        Assert.Equal("code-1", result.Code);
+        Assert.Equal("state-1", result.State);
+        Assert.Equal("https://issuer.example", result.Iss);
+    }
+
+    [Theory]
+    [InlineData(null, "state-1", null, "authorization code")]
+    [InlineData("code-1", null, null, "state")]
+    [InlineData("code-1", "state-1", "access_denied", "access_denied")]
+    public void ParseAuthorizationResult_RejectsInvalidCallback(
+        string? code,
+        string? state,
+        string? error,
+        string expectedMessage)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            McpOAuthLoginCoordinator.ParseAuthorizationResult(new NameValueCollection
+            {
+                ["code"] = code,
+                ["state"] = state,
+                ["error"] = error
+            }));
+
+        Assert.Contains(expectedMessage, exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/DotCraft.Core.Tests/Mcp/McpStreamableHttpSessionRecoveryIntegrationTests.cs
+++ b/tests/DotCraft.Core.Tests/Mcp/McpStreamableHttpSessionRecoveryIntegrationTests.cs
@@ -12,6 +12,33 @@ namespace DotCraft.Tests.Mcp;
 public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
 {
     [Fact]
+    public async Task AutoDetect_ModernServer_UsesDiscoveryMetadataWithoutLegacySession()
+    {
+        await using var server = MockStreamableHttpMcpServer.Start(new MockStreamableHttpMcpServer.Options
+        {
+            SupportsModernDiscovery = true
+        });
+        await using var manager = new McpClientManager();
+
+        await manager.ConnectAsync([CreateServerConfig(server)]);
+        await manager.WaitForStartupCompletionAsync();
+        var statuses = await manager.ListStatusesAsync();
+        Assert.True(manager.Tools.Count > 0, CreateDiagnosticMessage(server, statuses));
+        var tool = Assert.IsAssignableFrom<AIFunction>(Assert.Single(manager.Tools));
+
+        await tool.InvokeAsync(new AIFunctionArguments());
+
+        Assert.Single(server.DiscoverRequests);
+        Assert.Equal(0, server.InitializeCount);
+        Assert.Single(server.ToolsListRequests);
+        Assert.Single(server.ToolCallRequests);
+        Assert.All(server.Requests, request => Assert.Null(request.SessionId));
+        AssertModernRequestMetadata(server.DiscoverRequests[0]);
+        AssertModernRequestMetadata(server.ToolsListRequests[0]);
+        AssertModernRequestMetadata(server.ToolCallRequests[0]);
+    }
+
+    [Fact]
     public async Task ToolCall_StaleSessionBody404_StartsNewSessionAndRetriesOnce()
     {
         await using var server = MockStreamableHttpMcpServer.Start(new MockStreamableHttpMcpServer.Options
@@ -80,6 +107,7 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
 
         Assert.True(manager.Tools.Count > 0, CreateDiagnosticMessage(server, statuses));
         Assert.Single(manager.Tools);
+        Assert.NotEmpty(server.DiscoverRequests);
         Assert.Equal(2, server.InitializeCount);
         Assert.Equal(2, server.ToolsListCount);
         Assert.All(server.InitializeRequests, request => Assert.False(request.Headers.ContainsKey("Mcp-Session-Id")));
@@ -107,6 +135,21 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
             ToolTimeoutSec = 10
         };
 
+    private static void AssertModernRequestMetadata(RecordedHttpRequest request)
+    {
+        using var document = JsonDocument.Parse(request.Body);
+        var metadata = document.RootElement.GetProperty("params").GetProperty("_meta");
+        Assert.Equal(
+            "2026-07-28",
+            metadata.GetProperty("io.modelcontextprotocol/protocolVersion").GetString());
+        var clientInfo = metadata.GetProperty("io.modelcontextprotocol/clientInfo");
+        Assert.False(string.IsNullOrWhiteSpace(clientInfo.GetProperty("name").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(clientInfo.GetProperty("version").GetString()));
+        Assert.Equal(
+            JsonValueKind.Object,
+            metadata.GetProperty("io.modelcontextprotocol/clientCapabilities").ValueKind);
+    }
+
     private sealed class MockStreamableHttpMcpServer : IAsyncDisposable
     {
         private readonly TcpListener _listener;
@@ -131,6 +174,7 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
         public int ToolsCallCount { get; private set; }
 
         public List<RecordedHttpRequest> Requests { get; } = [];
+        public List<RecordedHttpRequest> DiscoverRequests { get; } = [];
         public List<RecordedHttpRequest> InitializeRequests { get; } = [];
         public List<RecordedHttpRequest> ToolsListRequests { get; } = [];
         public List<RecordedHttpRequest> ToolCallRequests { get; } = [];
@@ -214,12 +258,35 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
 
             return method switch
             {
+                "server/discover" => HandleDiscover(request, root),
                 "initialize" => HandleInitialize(request, root),
                 "notifications/initialized" => Empty(HttpStatusCode.Accepted),
                 "tools/list" => HandleToolsList(request, root),
                 "tools/call" => HandleToolsCall(request, root),
                 _ => JsonError(root, HttpStatusCode.BadRequest, -32601, "Method not found")
             };
+        }
+
+        private ResponseSpec HandleDiscover(RecordedHttpRequest request, JsonElement root)
+        {
+            DiscoverRequests.Add(request);
+            if (!_options.SupportsModernDiscovery)
+                return JsonError(root, HttpStatusCode.BadRequest, -32601, "Method not found");
+
+            var body = $$"""
+                {
+                  "jsonrpc": "2.0",
+                  "id": {{GetIdRaw(root)}},
+                  "result": {
+                    "type": "complete",
+                    "supportedVersions": ["2026-07-28"],
+                    "capabilities": { "tools": {} },
+                    "ttlMs": 0,
+                    "cacheScope": "private"
+                  }
+                }
+                """;
+            return Json(HttpStatusCode.OK, body);
         }
 
         private ResponseSpec HandleInitialize(RecordedHttpRequest request, JsonElement root)
@@ -260,7 +327,7 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
                 return StaleSession(root, bare404: false);
             }
 
-            if (!HasActiveSession(request))
+            if (!_options.SupportsModernDiscovery && !HasActiveSession(request))
                 return JsonError(root, HttpStatusCode.BadRequest, -32600, "Missing or invalid session");
 
             var body = $$"""
@@ -291,7 +358,7 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
                 return StaleSession(root, _options.BareStaleToolCall404);
             }
 
-            if (!HasActiveSession(request))
+            if (!_options.SupportsModernDiscovery && !HasActiveSession(request))
                 return JsonError(root, HttpStatusCode.BadRequest, -32600, "Missing or invalid session");
 
             var body = $$"""
@@ -525,6 +592,7 @@ public sealed class McpStreamableHttpSessionRecoveryIntegrationTests
 
         public sealed class Options
         {
+            public bool SupportsModernDiscovery { get; init; }
             public bool ExpireFirstToolCall { get; init; }
             public bool BareStaleToolCall404 { get; init; }
             public bool ExpireFirstToolsList { get; init; }

--- a/tests/DotCraft.Core.Tests/Mcp/McpToolRuntimeResultBudgetTests.cs
+++ b/tests/DotCraft.Core.Tests/Mcp/McpToolRuntimeResultBudgetTests.cs
@@ -29,6 +29,22 @@ public sealed class McpToolRuntimeResultBudgetTests
         Assert.Equal(meta.GetRawText(), bounded.Meta?.GetRawText());
     }
 
+    [Theory]
+    [InlineData("[1,2,3]")]
+    [InlineData("\"value\"")]
+    [InlineData("42")]
+    [InlineData("true")]
+    [InlineData("null")]
+    public void BoundPersistedResult_PreservesNonObjectStructuredContent(string structuredJson)
+    {
+        var raw = JsonSerializer.SerializeToElement(new { content = Array.Empty<object>(), isError = false });
+        var structured = JsonDocument.Parse(structuredJson).RootElement.Clone();
+
+        var bounded = McpToolRuntime.BoundPersistedResult(raw, structured, meta: null, isError: false);
+
+        Assert.Equal(structured.GetRawText(), bounded.Structured?.GetRawText());
+    }
+
     [Fact]
     public void BoundPersistedResult_CollapsesOversizedRawResultWithoutChangingErrorState()
     {

--- a/tests/DotCraft.Core.Tests/Providers/Anthropic/AnthropicEagerToolInputStreamingChatClientTests.cs
+++ b/tests/DotCraft.Core.Tests/Providers/Anthropic/AnthropicEagerToolInputStreamingChatClientTests.cs
@@ -140,6 +140,40 @@ public sealed class AnthropicEagerToolInputStreamingChatClientTests
     }
 
     [Fact]
+    public async Task ProviderManagedContinuation_EchoesPausedServerToolUseInNextRequest()
+    {
+        var handler = new PausedServerToolContinuationHandler();
+        using var sdkClient = CreateBetaClient(handler);
+        using var client = new StreamingFunctionInvokingChatClient(
+            new ProviderServiceChatClient(
+                new AnthropicProviderContentChatClient(sdkClient),
+                new Dictionary<System.Type, object>
+                {
+                    [typeof(IProviderManagedContinuationPolicy)] = AnthropicManagedContinuationPolicy.Instance
+                }));
+
+        await foreach (var _ in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "search for the latest SDK")]))
+        {
+        }
+
+        Assert.Equal(2, handler.Requests.Count);
+        using var request = JsonDocument.Parse(handler.Requests[1]);
+        var messages = request.RootElement.GetProperty("messages").EnumerateArray().ToArray();
+        var assistant = Assert.Single(messages, static message =>
+            message.GetProperty("role").GetString() == "assistant");
+        var serverToolUse = Assert.Single(assistant.GetProperty("content").EnumerateArray());
+        Assert.Equal("server_tool_use", serverToolUse.GetProperty("type").GetString());
+        Assert.Equal("srvtoolu_pause_01", serverToolUse.GetProperty("id").GetString());
+        Assert.Equal("web_search", serverToolUse.GetProperty("name").GetString());
+        Assert.Equal("latest SDK", serverToolUse.GetProperty("input").GetProperty("query").GetString());
+        Assert.DoesNotContain(
+            messages.SelectMany(static message => message.GetProperty("content").EnumerateArray()),
+            static content => content.TryGetProperty("type", out var type)
+                              && type.GetString() == "tool_result");
+    }
+
+    [Fact]
     public async Task ToolSchemaMatchesSdkMappingExceptForEagerInputStreaming()
     {
         var function = new SchemaFunction("SchemaParity", "Schema parity.", RichSchema);
@@ -332,6 +366,69 @@ public sealed class AnthropicEagerToolInputStreamingChatClientTests
                     Encoding.UTF8,
                     "text/event-stream")
             });
+    }
+
+    private sealed class PausedServerToolContinuationHandler : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(await request.Content!.ReadAsStringAsync(cancellationToken));
+            return Requests.Count == 1
+                ? StreamingResponse(
+                    """
+                    event: message_start
+                    data: {"type":"message_start","message":{"id":"msg_pause_server_tool","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+                    event: content_block_start
+                    data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"srvtoolu_pause_01","name":"web_search","caller":{"type":"direct"},"input":{}}}
+
+                    event: content_block_delta
+                    data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":\""}}
+
+                    event: content_block_delta
+                    data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"latest SDK\"}"}}
+
+                    event: content_block_stop
+                    data: {"type":"content_block_stop","index":0}
+
+                    event: message_delta
+                    data: {"type":"message_delta","delta":{"stop_reason":"pause_turn","stop_sequence":null},"usage":{"output_tokens":1}}
+
+                    event: message_stop
+                    data: {"type":"message_stop"}
+
+                    """)
+                : StreamingResponse(
+                    """
+                    event: message_start
+                    data: {"type":"message_start","message":{"id":"msg_pause_server_tool_done","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":0}}}
+
+                    event: content_block_start
+                    data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+                    event: content_block_delta
+                    data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}
+
+                    event: content_block_stop
+                    data: {"type":"content_block_stop","index":0}
+
+                    event: message_delta
+                    data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}
+
+                    event: message_stop
+                    data: {"type":"message_stop"}
+
+                    """);
+        }
+
+        private static HttpResponseMessage StreamingResponse(string content) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "text/event-stream")
+        };
     }
 
     private sealed class CapturingChatClient : IChatClient

--- a/tests/DotCraft.Core.Tests/Providers/Anthropic/AnthropicEagerToolInputStreamingChatClientTests.cs
+++ b/tests/DotCraft.Core.Tests/Providers/Anthropic/AnthropicEagerToolInputStreamingChatClientTests.cs
@@ -120,6 +120,26 @@ public sealed class AnthropicEagerToolInputStreamingChatClientTests
     }
 
     [Fact]
+    public async Task AnthropicSdkStreaming_PreservesPauseTurnFinishReason()
+    {
+        using var client = CreateBetaClient(new PauseTurnStreamingHandler());
+
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(
+            [new ChatMessage(ChatRole.User, "continue the server tool")]))
+        {
+            updates.Add(update);
+        }
+
+        Assert.Contains(
+            updates,
+            update => update.Contents.OfType<TextContent>().Any(content => content.Text == "partial"));
+        Assert.Equal(
+            "pause_turn",
+            updates.Last(update => update.FinishReason is not null).FinishReason!.Value.ToString());
+    }
+
+    [Fact]
     public async Task ToolSchemaMatchesSdkMappingExceptForEagerInputStreaming()
     {
         var function = new SchemaFunction("SchemaParity", "Schema parity.", RichSchema);
@@ -215,7 +235,7 @@ public sealed class AnthropicEagerToolInputStreamingChatClientTests
         return Assert.IsType<JsonObject>(Assert.Single(root["tools"]!.AsArray()));
     }
 
-    private static IChatClient CreateBetaClient(CaptureHandler handler)
+    private static IChatClient CreateBetaClient(HttpMessageHandler handler)
     {
         var anthropicClient = new AnthropicClient
         {
@@ -279,6 +299,39 @@ public sealed class AnthropicEagerToolInputStreamingChatClientTests
                     "application/json")
             };
         }
+    }
+
+    private sealed class PauseTurnStreamingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    event: message_start
+                    data: {"type":"message_start","message":{"id":"msg_pause_turn_test","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+                    event: content_block_start
+                    data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+                    event: content_block_delta
+                    data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}
+
+                    event: content_block_stop
+                    data: {"type":"content_block_stop","index":0}
+
+                    event: message_delta
+                    data: {"type":"message_delta","delta":{"stop_reason":"pause_turn","stop_sequence":null},"usage":{"output_tokens":1}}
+
+                    event: message_stop
+                    data: {"type":"message_stop"}
+
+                    """,
+                    Encoding.UTF8,
+                    "text/event-stream")
+            });
     }
 
     private sealed class CapturingChatClient : IChatClient

--- a/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIClientProviderTests.cs
+++ b/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIClientProviderTests.cs
@@ -75,6 +75,8 @@ public sealed class OpenAIClientProviderTests : IDisposable
         Assert.Contains("GET /v1/models", request, StringComparison.Ordinal);
         Assert.Contains("User-Agent: DotCraft/", request, StringComparison.Ordinal);
         Assert.DoesNotContain("User-Agent: OpenAI/", request, StringComparison.Ordinal);
+        foreach (var headerName in SdkPlatformMetadataHeaders)
+            Assert.Contains($"{headerName}:", request, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -184,6 +186,7 @@ public sealed class OpenAIClientProviderTests : IDisposable
         Assert.Equal(
             OpenAIOAuthPipelinePolicy.BetaFeaturesValue,
             request.Headers[OpenAIOAuthPipelinePolicy.BetaFeaturesHeader]);
+        AssertNoSdkPlatformMetadataHeaders(request);
         Assert.False(request.Headers.ContainsKey(
             OpenAIResponsesLiteHeadersPipelinePolicy.ResponsesLiteHeader));
         Assert.False(request.Headers.ContainsKey("Content-Encoding"));
@@ -463,6 +466,7 @@ public sealed class OpenAIClientProviderTests : IDisposable
             Assert.False(request.Headers.ContainsKey(OpenAIAuthConstants.TurnStateHeader));
             Assert.StartsWith("DotCraft/", request.Headers["User-Agent"], StringComparison.Ordinal);
             Assert.False(request.Headers.ContainsKey("OpenAI-Beta"));
+            AssertNoSdkPlatformMetadataHeaders(request);
 
             using var document = JsonDocument.Parse(request.Body);
             Assert.Equal(sessionKey, document.RootElement.GetProperty("prompt_cache_key").GetString());
@@ -598,10 +602,10 @@ public sealed class OpenAIClientProviderTests : IDisposable
             Assert.Equal("repository contents", input[3].GetProperty("output").GetString());
 
             Assert.Equal(
-                "58cb79548e1ce09cdf80f62a2be4d7e7d80365401dd13a1b6d5e2187e52361bf",
+                "8286d566efdbd853027d48410cd3821676c023cb2b4dc084254f7fffcc092d03",
                 ComputeSha256(request.Body));
             Assert.Equal(
-                "08572d865e83c3a9294c8fae459645435976038e42ea8799c8c4e3e7b6f90c8f",
+                "d5bd5d24df340c3a54ffdaaeed16d5f1bd0810b21f643b389eb901ade9c885ec",
                 ComputeSha256(BuildSanitizedCacheWireSnapshot(request)));
         }
         finally
@@ -1271,6 +1275,22 @@ public sealed class OpenAIClientProviderTests : IDisposable
 
     private static string ComputeSha256(string value) =>
         Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    private static void AssertNoSdkPlatformMetadataHeaders(RecordedHttpRequest request)
+    {
+        foreach (var headerName in SdkPlatformMetadataHeaders)
+            Assert.False(request.Headers.ContainsKey(headerName), $"Unexpected header: {headerName}");
+    }
+
+    private static readonly string[] SdkPlatformMetadataHeaders =
+    [
+        "X-Stainless-Lang",
+        "X-Stainless-Package-Version",
+        "X-Stainless-Runtime",
+        "X-Stainless-Runtime-Version",
+        "X-Stainless-OS",
+        "X-Stainless-Arch"
+    ];
 
     private const string SuccessfulResponseJson = """
         {

--- a/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIResponsesRequestBodyCanonicalizerTests.cs
+++ b/tests/DotCraft.Core.Tests/Providers/OpenAI/OpenAIResponsesRequestBodyCanonicalizerTests.cs
@@ -15,7 +15,7 @@ namespace DotCraft.Tests.Agents;
 public sealed class OpenAIResponsesRequestBodyCanonicalizerTests
 {
     [Fact]
-    public void Canonicalize_RemovesDuplicateResponsePatchKeysAndPreservesPromptCacheFields()
+    public void SdkGeneratedResponse_HasUniqueKeysAndPreservesPromptCacheFields()
     {
         var registry = new DeferredToolRegistry([AIFunctionFactory.Create(
             (string path) => $"read {path}",
@@ -41,16 +41,14 @@ public sealed class OpenAIResponsesRequestBodyCanonicalizerTests
 
             var original = SerializeOptions(options);
 
-            Assert.Equal(2, CountTopLevelKeyOccurrences(original, "input"));
-            Assert.Equal(2, CountTopLevelKeyOccurrences(original, "tools"));
+            Assert.Equal(1, CountTopLevelKeyOccurrences(original, "input"));
+            Assert.Equal(1, CountTopLevelKeyOccurrences(original, "tools"));
 
             var rewritten = OpenAIResponsesRequestBodyCanonicalizer.Canonicalize(original);
 
-            Assert.NotNull(rewritten);
-            Assert.Equal(1, CountTopLevelKeyOccurrences(rewritten!, "input"));
-            Assert.Equal(1, CountTopLevelKeyOccurrences(rewritten!, "tools"));
+            Assert.Null(rewritten);
 
-            using var document = JsonDocument.Parse(rewritten!);
+            using var document = JsonDocument.Parse(original);
             var root = document.RootElement;
             Assert.False(root.GetProperty("store").GetBoolean());
             Assert.True(root.GetProperty("stream").GetBoolean());
@@ -72,6 +70,22 @@ public sealed class OpenAIResponsesRequestBodyCanonicalizerTests
         {
             TracingChatClient.CurrentSessionKey = previous;
         }
+    }
+
+    [Fact]
+    public void Canonicalize_RemovesDuplicateResponsePatchKeys()
+    {
+        const string original =
+            """{"model":"gpt-test","input":[{"id":"old"}],"tools":[{"name":"old"}],"input":[{"id":"current"}],"tools":[{"name":"current"}]}""";
+
+        var rewritten = OpenAIResponsesRequestBodyCanonicalizer.Canonicalize(original);
+
+        Assert.NotNull(rewritten);
+        Assert.Equal(1, CountTopLevelKeyOccurrences(rewritten!, "input"));
+        Assert.Equal(1, CountTopLevelKeyOccurrences(rewritten!, "tools"));
+        using var document = JsonDocument.Parse(rewritten!);
+        Assert.Equal("current", document.RootElement.GetProperty("input")[0].GetProperty("id").GetString());
+        Assert.Equal("current", document.RootElement.GetProperty("tools")[0].GetProperty("name").GetString());
     }
 
     [Fact]

--- a/tests/DotCraft.Harness.Consumer/DotCraft.Harness.Consumer.csproj
+++ b/tests/DotCraft.Harness.Consumer/DotCraft.Harness.Consumer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <ProjectReference Include="..\..\src\DotCraft.Harness\DotCraft.Harness.csproj" />
     <ProjectReference Include="..\..\src\DotCraft.Runtime\DotCraft.Runtime.csproj" />
   </ItemGroup>

--- a/tests/DotCraft.Harness.Tests/DotCraft.Harness.Tests.csproj
+++ b/tests/DotCraft.Harness.Tests/DotCraft.Harness.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/DotCraft.Runtime.Tests/DotCraft.Runtime.Tests.csproj
+++ b/tests/DotCraft.Runtime.Tests/DotCraft.Runtime.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
## Summary

- Upgrade Microsoft.Extensions.AI to 10.9, OpenAI to 2.13, Anthropic to 12.42, and MCP SDK to 2.2.
- Preserve the Codex/ChatGPT subscription wire shape by removing SDK-added `X-Stainless-*` headers only on OAuth requests.
- Support Anthropic `pause_turn` through bounded provider-managed continuation.
- Adapt MCP HTTP transport to 2026-07-28 discovery with legacy protocol fallback.
- Update provider compatibility tests and model metadata.
- Fix the Desktop detail divider layout.

Closes #218 