### PR TITLE
feat: support remote execution of .NET plugin tools

### DIFF
--- a/docs/developing/architecture/remote-tool-host.md
+++ b/docs/developing/architecture/remote-tool-host.md
@@ -1,6 +1,6 @@
 # Remote Tool Host
 
-Remote Tool Host executes an Agent's file, Shell, and LSP tools on another machine on the same network. This page targets integrators and operators who set a pairing up outside DotCraft Desktop.
+Remote Tool Host executes an Agent's file, Shell, LSP, and RPC-enabled .NET plugin tools on another machine. This page targets integrators and operators who set a pairing up outside DotCraft Desktop.
 
 ![The Agent Runtime keeps the model loop and tool identities while Remote Tool Host executes eligible Core file, Shell, and LSP tools beside the target workspace](/remote-tool-host-topology.svg)
 
@@ -88,9 +88,13 @@ Transfers use the existing connection and enforce both machines' file policies. 
 
 ## Skill and plugin resources
 
-Skills and plugin packages stay on the Agent machine. `SkillView` reads local instructions, and the Skill catalog gives the effective local path, including variants. Use `ReadFile` with `target: "local"` for supporting files while connected.
+RPC-enabled .NET plugin tools use the Agent's accepted plugin bundles and effective settings. Connect prepares the complete bundles and their .NET dependencies on the remote workspace automatically, including deferred tools. No separate plugin installation is needed there. Changes are prepared before the next Turn uses its tool snapshot. MCP and runtime dynamic tools remain local.
 
-The Agent uses `Transfer` to copy scripts, directories, or CLI files needed remotely, preserving their relative dependencies and using the effective Skill variant where applicable. Transferred files remain after disconnect, with destinations and overwrites chosen explicitly. Copying a plugin package does not activate it or install dependencies. Executables must support the remote OS.
+Under workspace-preferred authorization, the remote owner approves the exact plugin fingerprints before any plugin code loads. Full access permits automatic activation. Disconnect releases the thread's plugin state, and the last workspace lease drains the plugin runtime. Verified bundle files remain available for reuse.
+
+Skills stay on the Agent machine. `SkillView` reads local instructions, and the Skill catalog gives the effective local path, including variants. Use `ReadFile` with `target: "local"` for supporting files while connected.
+
+The Agent uses `Transfer` to copy scripts, directories, or CLI files needed remotely, preserving their relative dependencies and using the effective Skill variant where applicable. Transferred files remain after disconnect, with destinations and overwrites chosen explicitly. Executables must support the remote OS.
 
 Connect negotiates tools and file transfer support before publishing the route. If connection setup fails, the previous route remains. Upgrade Satellites that lack file transfer support before connecting.
 

--- a/docs/developing/integrations/dotnet-plugin-reference.md
+++ b/docs/developing/integrations/dotnet-plugin-reference.md
@@ -97,6 +97,8 @@ internal sealed class SummaryTool(ReviewJournal journal) : IToolSource, IToolRun
 
 Report expected failures with `ToolExecutionResult.Failed` and a `ToolError`, whose code stays stable. A thrown exception's text is discarded and reaches the model only as an unspecified tool failure. The boundary is JSON-only in both directions: the host copies the arguments in, and copies the text, the structured content, and the error out.
 
+For remote execution, mark a generated tool or `[ToolDeclaration]` with `[ToolRpc]`. Hand-written definitions use `RemoteToolMetadata.RpcEligibleAnnotation` set to JSON `true`. The plugin must activate with the execution host's tool services and dependency exports, without requiring Agent, Session, or provider services. [Remote Tool Host](../architecture/remote-tool-host#skill-and-plugin-resources) owns bundle preparation and remote authorization.
+
 ### Tier A — add a slash command
 
 A plugin contributes a slash command through `ICodeCommand`: a name, optional aliases, a description, and an `Expand` that turns one invocation into the text the turn runs on.

--- a/docs/zh/developing/architecture/remote-tool-host.md
+++ b/docs/zh/developing/architecture/remote-tool-host.md
@@ -1,6 +1,6 @@
 # Remote Tool Host
 
-Remote Tool Host 在同一内网的另一台机器上执行 Agent 的文件、Shell 和 LSP 工具。本页面向不使用 DotCraft Desktop、直接配置配对的集成方和运维人员。
+Remote Tool Host 在另一台机器上执行 Agent 的文件、Shell、LSP 工具及支持 RPC 的 .NET 插件工具。本页面向不使用 DotCraft Desktop、直接配置配对的集成方和运维人员。
 
 ![Agent Runtime 保留模型循环和工具身份，Remote Tool Host 在目标工作区旁执行符合条件的 Core 文件、Shell 和 LSP 工具](/remote-tool-host-topology.svg)
 
@@ -88,9 +88,13 @@ RPC 工具接受 `target: "local"` 或 `target: "remote"`，省略时沿用当�
 
 ## Skill 与插件资源
 
-Skill 和插件包保留在 Agent 机器上。`SkillView` 读取本地指令，Skill 目录提供实际生效的本地路径，包括变体路径。连接远端时，可以通过 `ReadFile` 的 `target: "local"` 读取配套文件。
+支持 RPC 的 .NET 插件工具使用 Agent 已接纳的插件包和生效配置。Connect 自动在远端工作区准备完整插件包及其 .NET 依赖，包括延迟工具，无需在远端另行安装插件。插件发生变化时，会在下一 Turn 使用工具快照之前完成准备。MCP 和运行时动态工具仍在本地执行。
 
-Agent 按需使用 `Transfer` 复制远端需要的脚本、目录或 CLI 文件，保留相对依赖关系，并在适用时选用 Skill 的生效变体。传输的文件在断开后保留，目标位置和覆盖行为由 Agent 显式选择。复制插件包不会激活插件或安装依赖，可执行文件须支持远端操作系统。
+在工作区优先授权下，远端所有者需要批准确切的插件指纹，随后才会加载插件代码。完全访问授权允许自动激活。断开连接会释放当前线程的插件状态，工作区最后一个租约结束时会等待插件运行时停止。已校验的插件文件会保留供后续复用。
+
+Skill 保留在 Agent 机器上。`SkillView` 读取本地指令，Skill 目录提供实际生效的本地路径，包括变体路径。连接远端时，可以通过 `ReadFile` 的 `target: "local"` 读取配套文件。
+
+Agent 按需使用 `Transfer` 复制远端需要的脚本、目录或 CLI 文件，保留相对依赖关系，并在适用时选用 Skill 的生效变体。传输的文件在断开后保留，目标位置和覆盖行为由 Agent 显式选择。可执行文件须支持远端操作系统。
 
 Connect 协商工具和文件传输能力后才发布路由，连接建立失败时保留之前的路由。不支持文件传输的卫星需要先升级再连接。
 

--- a/docs/zh/developing/integrations/dotnet-plugin-reference.md
+++ b/docs/zh/developing/integrations/dotnet-plugin-reference.md
@@ -97,6 +97,8 @@ internal sealed class SummaryTool(ReviewJournal journal) : IToolSource, IToolRun
 
 预期内的失败请用 `ToolExecutionResult.Failed` 配一个 `ToolError` 返回，这样它的稳定错误码得以保留。抛出异常的正文会被丢弃，模型只会看到未指明的工具失败。边界两个方向都只走 JSON：宿主把参数复制进去，把文本、结构化内容和错误复制出来。
 
+需要远端执行时，在生成式工具或 `[ToolDeclaration]` 上标注 `[ToolRpc]`。手写定义则将 `RemoteToolMetadata.RpcEligibleAnnotation` 设置为 JSON `true`。插件需要仅使用执行宿主提供的工具服务和依赖导出完成激活，不依赖 Agent、Session 或 provider 服务。插件包准备与远端授权由 [Remote Tool Host](../architecture/remote-tool-host#skill-与插件资源) 负责。
+
 ### Tier A —— 增加一个斜杠命令
 
 插件通过 `ICodeCommand` 贡献斜杠命令：一个名字、可选的别名、一段描述，以及把一次调用展开成本轮输入文本的 `Expand`。

--- a/specs/architecture/dotnet-plugins.md
+++ b/specs/architecture/dotnet-plugins.md
@@ -451,6 +451,13 @@ active. Source changes take effect only after `Build`.
 
 ## 8. Tool containment
 
+Remote execution reuses this lifecycle through Runtime's provider-free execution host. The Agent
+exports accepted bundle bytes, active dependency closure, and generation settings, never running
+objects or machine trust. The Host admits those exact bytes under its own lease-scoped authorization
+and provides only tool execution services and contribution contracts. Source and remote generation
+bindings remain distinct even when their tool schemas match. Synchronization and owner approval are
+defined by [Remote Tool Host](remote-tool-host.md#13-prepared-net-plugin-execution).
+
 Plugin tools use `IToolSource`, but raw plugin registrations never enter a frozen
 `EffectiveToolSnapshot`. A host aggregate source:
 

--- a/specs/architecture/remote-tool-host.md
+++ b/specs/architecture/remote-tool-host.md
@@ -59,13 +59,14 @@ control, or recording; the read-only screen view defined in
 ## 3. RPC eligibility
 
 `ToolRpcAttribute` is a parameterless method marker used alongside `ToolAttribute` or
-`GeneratedToolAttribute`. It means that a Core Native tool MAY be exported by a Remote Tool Host
+`GeneratedToolAttribute` or `ToolDeclarationAttribute`. It means that a Core Native tool or an
+accepted .NET plugin tool MAY be exported by a Remote Tool Host
 and that an Agent Host MAY route the tool's runtime binding remotely. It grants no authority,
 changes no approval policy, and has no effect on direct method calls.
 
 The generated tool declaration and generated catalog descriptor MUST carry an `RpcEligible`
 boolean derived from the attribute. Reflection-based discovery MUST produce the same value. A
-method carrying `ToolRpcAttribute` without either supported tool attribute is invalid and SHOULD
+method carrying `ToolRpcAttribute` without a supported tool attribute is invalid and SHOULD
 produce a generator diagnostic.
 
 The initial Core RPC-eligible set is:
@@ -93,7 +94,9 @@ The hash excludes runtime-binding identity, presentation metadata, workspace pat
 instance provenance, and connection state. Object properties are ordinally sorted recursively and
 numbers use their canonical JSON representation before SHA-256 is calculated.
 
-The Host exports only RPC-eligible Core Native registrations. Every exported MCP tool carries the
+The Host exports RPC-eligible Core Native registrations and prepared .NET plugin registrations.
+A `PluginNative` label alone does not qualify a source: the Agent runtime must own its accepted
+bundle and live generation. Every exported MCP tool carries the
 following metadata:
 
 ```json
@@ -223,7 +226,7 @@ Their static descriptions are:
 ```text
 Namespace: Manage this thread's remote workspace connection.
 List: List registered Remote Tool Hosts, their workspaces, and this thread's current connection.
-Connect: Connect this thread to a remote workspace. Skill/plugin files remain local; read with target="local" and Transfer as needed.
+Connect: Connect this thread to a remote workspace. RPC plugin tools are prepared automatically. Skill files remain local; read with target="local" and Transfer as needed.
 Disconnect: Disconnect this thread from its remote workspace.
 Transfer: Upload or download files and directories between local and connected remote workspaces; directories merge into the destination.
 Connect.hostId: Remote Tool Host id.
@@ -606,17 +609,57 @@ Connect acquires a candidate lease, negotiates tools and the `files-v1` capabili
 the route. Failure preserves the previous route. Repeating Connect returns the current connection
 without emitting a duplicate route transition. Hosts lacking file transfer support require upgrading.
 
-Skills and plugin packages remain on the Agent machine. SkillView reads effective local instructions,
+Skills remain on the Agent machine. SkillView reads effective local instructions,
 and the Skill catalog identifies the effective local file, including variants. Supporting files are
 read with `target: "local"`; the Agent uses Transfer for files needed by remote execution, preserving
 relative dependencies and selecting the effective variant when applicable. The Connect description
-provides this guidance before same-Turn remote calls. Connecting, turn preparation, and SkillView
-do not copy resources or manage remote snapshots.
+provides this guidance before same-Turn remote calls. SkillView does not prepare executable plugins.
 
 Transferred files survive disconnect. The Agent chooses destinations and explicit overwrites;
 Transfer does not provide automatic version isolation or cleanup. Copying a plugin package does not
 activate it or install CLI dependencies. Local binary/env availability is not evidence of remote
 availability. Neither arbitrary shell commands nor Skill prose are rewritten.
+
+## 13. Prepared .NET plugin execution
+
+The Agent's accepted plugin bundles and effective tool snapshot are authoritative. Before publishing
+a connection, and before sampling a new Turn on an existing connection, the Agent prepares every
+RPC-eligible .NET source in that thread's effective snapshot, including deferred tools. Tool search
+and ordinary snapshot reads do not deploy code. MCP and Runtime Dynamic sources remain local.
+
+Preparation transfers complete immutable bundles, their actual dependency closure, and plugin-only
+effective settings through the existing leased chunked file-transfer machinery. Source files remain
+pinned until preparation finishes. The Host chooses its installation paths and substitutes its own
+workspace and data roots. It reuses identical verified files across connections; it does not require
+preinstallation, copy machine trust or Agent configuration, or create a model-facing install tool.
+
+The `plugins-v1` capability and internal prepare messages travel over the existing Hub data session.
+A Host without that capability cannot execute plugin RPC. Product versions do not select a fallback.
+Full-access authorization permits automatic preparation. Workspace-preferred authorization requires
+the Host owner's approval of the exact bundle fingerprints before any plugin code loads. Approval is
+lease-scoped and is not persisted as local plugin trust.
+
+Runtime owns a provider-free plugin execution host using the ordinary bundle preflight, dependency
+planner, generation gates, proxies, and teardown. RemoteTools consumes that host; Runtime does not
+depend on RemoteTools. The execution host supports tool sources, dependency exports, plugin lifetime,
+and its explicitly provided host services, not Agent, Session, or provider contributions.
+
+Catalogs are thread- and snapshot-scoped. A leased workspace has one active generation per plugin.
+Threads may share that generation, but one thread cannot replace a newer source with an older
+snapshot or remove another thread's sources. Each invocation binds its prepared remote generation
+as well as the original contract hash. Identical schemas never authorize retargeting an old call to
+new code. Revocation blocks dispatch immediately; the current Turn retains its schema and the next
+Turn adopts and prepares new sources through the existing snapshot invalidation lifecycle.
+
+Routing captures the selected target before checking executor availability, while source authority
+is checked for either target. The Host validates schema, generation lease, canonical identity,
+contract, and local policy before execution. Originating thread and mode context remain explicit;
+the Agent alone owns Session recording and hooks. Failed preparation never publishes a candidate
+route or silently uses stale code, local execution, or automatic replay.
+
+Release, expiry, pause, revocation, and shutdown revoke and drain plugin calls and resources before
+another owner acquires the workspace. Thread release invokes thread-scoped cleanup; final lease
+release disposes the complete execution runtime. Verified package files may remain on disk.
 
 ## Generated image artifacts
 

--- a/specs/architecture/runtime-module-boundaries.md
+++ b/specs/architecture/runtime-module-boundaries.md
@@ -39,7 +39,8 @@ Embedded application
   Protocol, but does not require Runtime as its host.
 - `DotCraft.App` is the official composition root. It selects entry points, providers, optional
   features, logging, process policy, and exit behavior.
-- `DotCraft.RemoteTools` owns the Remote Tool Host feature and depends on Core, the MCP ASP.NET
+- `DotCraft.RemoteTools` owns the Remote Tool Host feature and depends on Core, Runtime's provider-free
+  plugin execution facade, the MCP ASP.NET
   transport, and the `DotCraft.Protocol.ScreenView` contracts in Protocol for the screen view frame
   format. A Remote Tool Host is an application-selected provider-free host. Its feature implementation owns
   remote-tool transport, registry, leases, and Host policy; `DotCraft.App` owns CLI and process

--- a/specs/architecture/tools-architecture.md
+++ b/specs/architecture/tools-architecture.md
@@ -75,7 +75,7 @@ The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** ar
 
 **Runtime Dynamic Tool** is the canonical term for client-owned callbacks. App Binding tools use binding-scoped MCP sessions.
 
-Remote execution of an existing Core Native registration is governed by the
+Remote execution of an existing Core Native or accepted .NET plugin registration is governed by the
 [Remote Tool Host specification](remote-tool-host.md). It replaces the runtime route behind a
 stable definition and MUST NOT be represented as a Runtime Dynamic Tool, MCP source, or additional
 `ToolSourceKind`.
@@ -274,6 +274,12 @@ The following changes invalidate the next snapshot:
 - mode or profile changes that truly alter the runtime surface.
 
 Immediate safety checks are not frozen. Revocation, disconnect, expired authority, binding removal, and execution-policy invalidation MUST block dispatch immediately, including an invocation named in an older snapshot.
+
+Remote plugin preparation uses the final thread snapshot, including deferred registrations, before
+Turn sampling or same-Turn connection publication. It never runs as a side effect of tool search or
+snapshot inspection. A call retains both source-generation authority and its prepared remote
+generation binding. Target selection precedes executor availability checks and does not bypass
+source revocation. See [Remote Tool Host](remote-tool-host.md#13-prepared-net-plugin-execution).
 
 Adapter-declared channel tools are connection-bound. Their `RuntimeBindingId`, descriptor set, lease, and executor must refer to the same initialized adapter connection. A lease check followed by invocation must not retarget the call to a newer connection. When the connection changes, the current Turn keeps its immutable snapshot but loses dispatch authority; the next Turn rebuilds against the new connection.
 

--- a/src/DotCraft.AppServer/Handlers/RemoteToolHostRequestHandler.cs
+++ b/src/DotCraft.AppServer/Handlers/RemoteToolHostRequestHandler.cs
@@ -49,6 +49,11 @@ internal sealed class RemoteToolHostRequestHandler(
         var hostId = Require(request.Params.HostId, "'hostId' is required.");
         var workspaceId = Require(request.Params.WorkspaceId, "'workspaceId' is required.");
         await RequireIdleThreadAsync(threadId, ct);
+        var thread = await sessionService.GetThreadAsync(threadId, ct);
+        var snapshots = sessionService as IThreadToolSnapshotService
+            ?? throw new InvalidOperationException("Remote execution requires a thread tool snapshot service.");
+        var snapshot = await snapshots.GetEffectiveToolSnapshotAsync(threadId, ct);
+        client.UpdateRemoteToolSnapshot(threadId, snapshot, thread!.Configuration?.Mode ?? "agent");
 
         RemoteToolConnectResult connected;
         try

--- a/src/DotCraft.Core/Sessions/Runtime/SessionService.TurnResources.cs
+++ b/src/DotCraft.Core/Sessions/Runtime/SessionService.TurnResources.cs
@@ -1,0 +1,22 @@
+namespace DotCraft.Sessions;
+
+public sealed partial class SessionService
+{
+    private async Task<TurnExecutionResources> CaptureTurnExecutionResourcesAsync(ThreadRuntime runtime, CancellationToken ct)
+    {
+        if (!_hasExplicitDefaultAgent || _forcePerThreadAgents)
+            await EnsurePerThreadAgentIfMissingAsync(runtime.Thread.Id, runtime.Thread, ct).ConfigureAwait(false);
+        TurnExecutionResources resources;
+        using (await AcquireThreadAgentLockAsync(runtime.Thread.Id, ct).ConfigureAwait(false))
+        {
+            if (!_runtimeRegistry.IsCurrent(runtime.Thread.Id, runtime))
+                throw new InvalidOperationException($"Thread '{runtime.Thread.Id}' runtime was replaced during Turn admission.");
+            resources = new(runtime.Agent ?? DefaultAgent, runtime.LatestToolSnapshot);
+        }
+        return resources;
+    }
+
+    private ValueTask PrepareRemoteTurnAsync(string threadId, DotCraft.Tools.EffectiveToolSnapshot? snapshot,
+        string mode, CancellationToken ct) => snapshot is not null && agentFactory?.RemoteToolHostClient is { } remote
+            ? remote.PrepareTurnAsync(threadId, snapshot, mode, ct) : ValueTask.CompletedTask;
+}

--- a/src/DotCraft.Core/Sessions/Runtime/SessionService.cs
+++ b/src/DotCraft.Core/Sessions/Runtime/SessionService.cs
@@ -1734,22 +1734,6 @@ public sealed partial class SessionService(
             callerCt);
     }
 
-    private async Task<TurnExecutionResources> CaptureTurnExecutionResourcesAsync(
-        ThreadRuntime runtime,
-        CancellationToken ct)
-    {
-        if (!_hasExplicitDefaultAgent || _forcePerThreadAgents)
-            await EnsurePerThreadAgentIfMissingAsync(runtime.Thread.Id, runtime.Thread, ct).ConfigureAwait(false);
-        using (await AcquireThreadAgentLockAsync(runtime.Thread.Id, ct).ConfigureAwait(false))
-        {
-            if (!_runtimeRegistry.IsCurrent(runtime.Thread.Id, runtime))
-                throw new InvalidOperationException($"Thread '{runtime.Thread.Id}' runtime was replaced during Turn admission.");
-            return new TurnExecutionResources(
-                runtime.Agent ?? DefaultAgent,
-                runtime.LatestToolSnapshot);
-        }
-    }
-
     private SessionEventChannel AdmitTurn(
         ThreadRuntime admittedRuntime,
         TurnExecutionContext turnContext,
@@ -2612,6 +2596,8 @@ public sealed partial class SessionService(
                 var executionResources = await turnContext.Resources.WaitAsync(executionCt).ConfigureAwait(false);
                 var agent = executionResources.Agent;
                 turnRuntime.ToolSnapshot = executionResources.ToolSnapshot;
+                await PrepareRemoteTurnAsync(threadId, executionResources.ToolSnapshot, turnContext.Configuration.Mode, executionCt)
+                    .ConfigureAwait(false);
 
                 // Bind tracing and token tracking before model history reconstruction.
                 if (traceCollector != null && thread.Source.SubAgent is { } subAgentSource)

--- a/src/DotCraft.Core/Tools/Architecture/RemoteToolMetadata.cs
+++ b/src/DotCraft.Core/Tools/Architecture/RemoteToolMetadata.cs
@@ -3,15 +3,28 @@ namespace DotCraft.Tools;
 /// <summary>Stable annotation names used by the Remote Tool Host profile.</summary>
 public static class RemoteToolMetadata
 {
-    /// <summary>Annotation set to JSON <see langword="true"/> for RPC-eligible Core definitions.</summary>
+    /// <summary>Annotation set to JSON <see langword="true"/> for RPC-eligible native definitions.</summary>
     public const string RpcEligibleAnnotation = "dotcraft/rpcEligible";
 
-    /// <summary>Returns whether a Core definition is eligible for remote routing.</summary>
+    /// <summary>Returns whether a native definition opts into remote routing; plugin bindings also require an accepted source.</summary>
     public static bool IsRpcEligible(ToolDefinition definition)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        return definition.Id.Kind == ToolSourceKind.CoreNative
+        return definition.Id.Kind is ToolSourceKind.CoreNative or ToolSourceKind.PluginNative
                && definition.Annotations.TryGetValue(RpcEligibleAnnotation, out var value)
                && value.ValueKind == System.Text.Json.JsonValueKind.True;
     }
+
+    public static bool IsRpcEligible(ToolRegistration registration) =>
+        IsRpcEligible(registration.Definition)
+        && (registration.Definition.Id.Kind == ToolSourceKind.CoreNative
+            || registration.Binding.Runtime is IRemoteToolSourceBinding
+            || registration.Binding.Runtime is RemoteRoutableToolRuntime { Source: not null });
+
+    public static ToolDefinition NativeDefinition(ToolRegistration registration) =>
+        registration.Binding.Runtime is RemoteRoutableToolRuntime routed ? routed.NativeDefinition : registration.Definition;
+
+    public static IRemoteToolSourceBinding? SourceBinding(ToolRegistration registration) =>
+        registration.Binding.Runtime is RemoteRoutableToolRuntime routed
+            ? routed.Source : registration.Binding.Runtime as IRemoteToolSourceBinding;
 }

--- a/src/DotCraft.Core/Tools/Architecture/ToolDispatcher.cs
+++ b/src/DotCraft.Core/Tools/Architecture/ToolDispatcher.cs
@@ -150,6 +150,19 @@ public sealed class ToolDispatcher(
                 $"Tool '{toolName}' is hidden from model invocation."))).ConfigureAwait(false);
         }
 
+        if (registration.Binding.Runtime is RemoteRoutableToolRuntime preparation)
+        {
+            try
+            {
+                invocationContext = preparation.Prepare(invocationContext, arguments);
+            }
+            catch (RemoteToolHostException ex)
+            {
+                return await CompleteWithoutRuntimeAsync(invocationContext, registration, recorder,
+                    ToolExecutionResult.Failed(new ToolError(ex.Code, ex.Message))).ConfigureAwait(false);
+            }
+        }
+
         if (registration.Binding.Availability != ToolBindingAvailability.Available)
         {
             return await CompleteWithoutRuntimeAsync(invocationContext, registration, recorder, ToolExecutionResult.Failed(new ToolError(
@@ -160,9 +173,9 @@ public sealed class ToolDispatcher(
         ToolBindingLeaseResult lease;
         try
         {
-            lease = await registration.Binding.Lease
-                .CheckAsync(invocationContext, cancellationToken)
-                .ConfigureAwait(false);
+            lease = registration.Binding.Runtime is RemoteRoutableToolRuntime routed
+                ? await routed.CheckBindingAsync(invocationContext, registration.Binding.Lease, cancellationToken).ConfigureAwait(false)
+                : await registration.Binding.Lease.CheckAsync(invocationContext, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -220,19 +233,6 @@ public sealed class ToolDispatcher(
                 return await CompleteWithoutRuntimeAsync(invocationContext, registration, recorder, ToolExecutionResult.Failed(new ToolError(
                     ToolErrorCodes.InputInvalid,
                     $"Tool '{toolName}' arguments are invalid: {validationError}"))).ConfigureAwait(false);
-            }
-        }
-
-        if (registration.Binding.Runtime is RemoteRoutableToolRuntime preparation)
-        {
-            try
-            {
-                invocationContext = preparation.Prepare(invocationContext, arguments);
-            }
-            catch (RemoteToolHostException ex)
-            {
-                return await CompleteWithoutRuntimeAsync(invocationContext, registration, recorder,
-                    ToolExecutionResult.Failed(new ToolError(ex.Code, ex.Message))).ConfigureAwait(false);
             }
         }
 

--- a/src/DotCraft.Core/Tools/Remote/RemoteRoutableToolRuntime.cs
+++ b/src/DotCraft.Core/Tools/Remote/RemoteRoutableToolRuntime.cs
@@ -10,13 +10,25 @@ namespace DotCraft.Tools;
 internal sealed class RemoteRoutableToolRuntime(
     ToolDefinition definition,
     IToolRuntime localRuntime,
-    IRemoteToolHostClient remoteClient) : IToolRuntime
+    IRemoteToolHostClient remoteClient,
+    ToolBindingAvailability localAvailability = ToolBindingAvailability.Available) : IToolRuntime
 {
     private readonly ToolDefinition _definition = definition ?? throw new ArgumentNullException(nameof(definition));
     private readonly IToolRuntime _localRuntime = localRuntime ?? throw new ArgumentNullException(nameof(localRuntime));
     private readonly IRemoteToolHostClient _remoteClient = remoteClient ?? throw new ArgumentNullException(nameof(remoteClient));
     private readonly string _contractHash = RemoteToolContractHasher.Compute(definition);
     internal ToolDefinition NativeDefinition => _definition;
+    internal IRemoteToolSourceBinding? Source => localRuntime as IRemoteToolSourceBinding;
+
+    internal ValueTask<ToolBindingLeaseResult> CheckBindingAsync(ToolInvocationContext context,
+        IToolBindingLease lease, CancellationToken cancellationToken)
+    {
+        if (context.ExecutionLocation?.Route is not null && Source is null)
+            return ValueTask.FromResult(ToolBindingLeaseResult.Available);
+        if (context.ExecutionLocation?.Route is null && localAvailability != ToolBindingAvailability.Available)
+            return ValueTask.FromResult(ToolBindingLeaseResult.Unavailable("The local executor is unavailable."));
+        return lease.CheckAsync(context, cancellationToken);
+    }
 
     public ToolInvocationContext Prepare(ToolInvocationContext context, JsonObject arguments)
     {
@@ -58,6 +70,8 @@ internal sealed class RemoteRoutableToolRuntime(
             return await _remoteClient.InvokeAsync(route, _definition, _contractHash, context,
                 nativeArguments, cancellationToken).ConfigureAwait(false);
         }
+        if (localAvailability != ToolBindingAvailability.Available)
+            return ToolExecutionResult.Failed(new ToolError(ToolErrorCodes.Unavailable, "The local executor is unavailable."));
         var result = await _localRuntime.InvokeAsync(context, nativeArguments, cancellationToken).ConfigureAwait(false);
         var meta = result.Meta is { ValueKind: JsonValueKind.Object } existing
             ? JsonNode.Parse(existing.GetRawText())!.AsObject() : new JsonObject();
@@ -79,23 +93,16 @@ internal static class RemoteToolRegistrationRouter
         if (remoteClient is null)
             return registrations;
 
-        remoteClient.UpdateRemoteToolDefinitions(
-            registrations
-                .Where(registration => RemoteToolMetadata.IsRpcEligible(registration.Definition))
-                .Select(registration => registration.Binding.Runtime is RemoteRoutableToolRuntime routed
-                    ? routed.NativeDefinition : registration.Definition)
-                .ToArray());
-
         return registrations.Select(registration =>
         {
-            if (!RemoteToolMetadata.IsRpcEligible(registration.Definition)
+            if (!RemoteToolMetadata.IsRpcEligible(registration)
                 || registration.Binding.Runtime is RemoteRoutableToolRuntime)
             {
                 return registration;
             }
 
             var targetDescription = registration.Definition.Id is
-                { Kind: ToolSourceKind.CoreNative, SourceId: "core-native", SourceToolId.Value: "WriteStdin" }
+            { Kind: ToolSourceKind.CoreNative, SourceId: "core-native", SourceToolId.Value: "WriteStdin" }
                 ? "Use the target of the Exec call that created the terminal."
                 : null;
             var projectedDefinition = RpcToolSchemaPostProcessor.Process(registration.Definition, targetDescription);
@@ -103,11 +110,11 @@ internal static class RemoteToolRegistrationRouter
             var routedBinding = new ToolRuntimeBinding(
                 binding.Id,
                 binding.DefinitionId,
-                new RemoteRoutableToolRuntime(registration.Definition, binding.Runtime, remoteClient),
+                new RemoteRoutableToolRuntime(registration.Definition, binding.Runtime, remoteClient, binding.Availability),
                 binding.Lease,
                 binding.AuthorityReference,
                 binding.Revision,
-                binding.Availability,
+                ToolBindingAvailability.Available,
                 binding.Timeout);
             return new ToolRegistration(
                 projectedDefinition,

--- a/src/DotCraft.Core/Tools/Remote/RemoteToolHostContracts.cs
+++ b/src/DotCraft.Core/Tools/Remote/RemoteToolHostContracts.cs
@@ -124,8 +124,12 @@ public interface IRemoteToolHostClient
     /// </summary>
     event Action<RemoteToolRouteChange>? RouteChanged;
 
-    /// <summary>Replaces the current trusted set of RPC-eligible definitions.</summary>
-    void UpdateRemoteToolDefinitions(IReadOnlyList<ToolDefinition> definitions);
+    /// <summary>Publishes one thread's final tool snapshot without performing network work.</summary>
+    void UpdateRemoteToolSnapshot(string threadId, EffectiveToolSnapshot snapshot, string mode);
+
+    /// <summary>Prepares the captured snapshot before the next Turn samples on an existing route.</summary>
+    ValueTask PrepareTurnAsync(string threadId, EffectiveToolSnapshot snapshot, string mode,
+        CancellationToken cancellationToken = default);
 
     /// <summary>Lists registered Hosts and refreshes their safe workspace catalogs.</summary>
     ValueTask<RemoteToolHostCatalog> ListAsync(

--- a/src/DotCraft.Core/Tools/Remote/RemoteToolHostControlSource.cs
+++ b/src/DotCraft.Core/Tools/Remote/RemoteToolHostControlSource.cs
@@ -75,7 +75,7 @@ internal sealed class RemoteToolHostTools(IRemoteToolHostClient client)
     }
 
     [GeneratedTool(Name = "Connect")]
-    [Description("Connect this thread to a remote workspace. Skill/plugin files remain local; read with target=\"local\" and Transfer as needed.")]
+    [Description("Connect this thread to a remote workspace. RPC plugin tools are prepared automatically. Skill files remain local; read with target=\"local\" and Transfer as needed.")]
     public async Task<string> Connect(
         [Description("Remote Tool Host id.")] string hostId,
         [Description("Remote workspace id.")] string workspaceId,

--- a/src/DotCraft.Core/Tools/Remote/RemoteToolSource.cs
+++ b/src/DotCraft.Core/Tools/Remote/RemoteToolSource.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+
+namespace DotCraft.Tools;
+
+/// <summary>A host-owned binding to an accepted source generation, not a plugin-supplied descriptor.</summary>
+public interface IRemoteToolSourceBinding
+{
+    string SourceId { get; }
+    ValueTask<RemoteToolSourceExport> ExportAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record RemotePluginBundle(
+    string PluginId,
+    string SourceGeneration,
+    long SourceRevision,
+    string ContentFingerprint,
+    string DotnetFingerprint,
+    JsonElement Settings);
+
+public sealed record RemotePluginBundleFiles(RemotePluginBundle Bundle, string RootPath);
+
+/// <summary>Owns immutable file copies until the consumer finishes preparing the remote source.</summary>
+public sealed class RemoteToolSourceExport(
+    IReadOnlyList<RemotePluginBundleFiles> bundles,
+    Action release) : IDisposable
+{
+    private Action? _release = release;
+    public IReadOnlyList<RemotePluginBundleFiles> Bundles { get; } = bundles;
+    public void Dispose() => Interlocked.Exchange(ref _release, null)?.Invoke();
+}

--- a/src/DotCraft.Generators/ToolGeneratorValidator.cs
+++ b/src/DotCraft.Generators/ToolGeneratorValidator.cs
@@ -88,8 +88,8 @@ internal static class ToolGeneratorValidator
 
     private static readonly DiagnosticDescriptor InvalidRpcMarker = new(
         "DCGEN011",
-        "Remote tool marker requires a generated tool",
-        "Method '{0}' uses ToolRpcAttribute without ToolAttribute or GeneratedToolAttribute",
+        "Remote tool marker requires a tool declaration",
+        "Method '{0}' uses ToolRpcAttribute without ToolAttribute, GeneratedToolAttribute, or ToolDeclarationAttribute",
         "DotCraft.Generators",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -97,7 +97,8 @@ internal static class ToolGeneratorValidator
     public static void ValidateRpcMarker(SourceProductionContext context, IMethodSymbol method)
     {
         if (ToolSchemaEmitter.FindAttribute(method, "DotCraft.Tools.ToolAttribute") != null
-            || ToolSchemaEmitter.FindAttribute(method, "DotCraft.Tools.GeneratedToolAttribute") != null)
+            || ToolSchemaEmitter.FindAttribute(method, "DotCraft.Tools.GeneratedToolAttribute") != null
+            || ToolSchemaEmitter.FindAttribute(method, "DotCraft.Tools.ToolDeclarationAttribute") != null)
         {
             return;
         }

--- a/src/DotCraft.RemoteTools/DotCraft.RemoteTools.csproj
+++ b/src/DotCraft.RemoteTools/DotCraft.RemoteTools.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotCraft.Core\DotCraft.Core.csproj" />
+    <ProjectReference Include="..\DotCraft.Runtime\DotCraft.Runtime.csproj" />
     <ProjectReference Include="..\DotCraft.Protocol\DotCraft.Protocol.csproj" />
     <ProjectReference Include="..\DotCraft.Generators\DotCraft.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/src/DotCraft.RemoteTools/FileTransferSession.cs
+++ b/src/DotCraft.RemoteTools/FileTransferSession.cs
@@ -11,6 +11,7 @@ internal sealed class FileTransferSession(string root, TransferFileManifest mani
     internal CancellationTokenSource Stopping { get; } = new();
     internal string Root => root;
     internal bool Write => write;
+    internal bool IsComplete => _completed.Count == manifest.Entries.Count;
 
     internal async Task PrepareAsync(long maxBytes, Func<string, string, CancellationToken, Task> authorize, CancellationToken ct)
     {

--- a/src/DotCraft.RemoteTools/HostWorkspaceRuntime.cs
+++ b/src/DotCraft.RemoteTools/HostWorkspaceRuntime.cs
@@ -12,25 +12,42 @@ internal sealed class HostWorkspaceRuntime : IAsyncDisposable
     private const string CatalogProbeWorkspaceId = "catalog";
     private readonly BackgroundTerminalService _terminals;
     private readonly LspServerManager? _lsp;
+    private readonly Lazy<PluginExecutionWorkspace> _plugins;
+    private readonly object _lifetimeGate = new();
+    private Task? _disposal;
 
     private HostWorkspaceRuntime(
         string workspacePath,
-        long catalogRevision,
         IReadOnlyList<ToolRegistration> registrations,
         BackgroundTerminalService terminals,
-        LspServerManager? lsp)
+        LspServerManager? lsp,
+        Func<PluginExecutionWorkspace> plugins)
     {
         WorkspacePath = workspacePath;
-        CatalogRevision = catalogRevision;
         Registrations = registrations;
         _terminals = terminals;
         _lsp = lsp;
+        _plugins = new(plugins);
     }
 
     public string WorkspacePath { get; }
-    public long CatalogRevision { get; }
     public IReadOnlyList<ToolRegistration> Registrations { get; }
     public IBackgroundTerminalService Terminals => _terminals;
+    internal PluginExecutionWorkspace Plugins
+    {
+        get
+        {
+            lock (_lifetimeGate)
+            {
+                ObjectDisposedException.ThrowIf(_disposal is not null, this);
+                return _plugins.Value;
+            }
+        }
+    }
+    internal IReadOnlyList<ToolRegistration> PluginRegistrations(string? threadId) =>
+        _plugins.IsValueCreated ? _plugins.Value.List(threadId) : [];
+    internal Task ReleasePluginThreadAsync(string threadId, CancellationToken ct) =>
+        _plugins.IsValueCreated ? _plugins.Value.ReleaseThreadAsync(threadId, ct) : Task.CompletedTask;
 
     public Task InitializeLspAsync(CancellationToken ct) => _lsp?.InitializeAsync(ct) ?? Task.CompletedTask;
 
@@ -66,10 +83,11 @@ internal sealed class HostWorkspaceRuntime : IAsyncDisposable
             .ConfigureAwait(false);
         return new HostWorkspaceRuntime(
             workspacePath,
-            catalogRevision,
             [.. registrations.Where(item => RemoteToolMetadata.IsRpcEligible(item.Definition))],
             terminals,
-            lsp);
+            lsp,
+            () => new PluginExecutionWorkspace(
+                DotCraftPaths.CreateForExecutionHost(workspacePath, workspaceData, workspaceData), config, terminals));
     }
 
     /// <summary>
@@ -112,8 +130,14 @@ internal sealed class HostWorkspaceRuntime : IAsyncDisposable
         }
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
+        lock (_lifetimeGate) return new(_disposal ??= DisposeCoreAsync());
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        if (_plugins.IsValueCreated) await _plugins.Value.DisposeAsync().ConfigureAwait(false);
         foreach (var terminal in await _terminals.ListAsync().ConfigureAwait(false))
         {
             if (string.Equals(terminal.Status, BackgroundTerminalStatus.Running, StringComparison.Ordinal))

--- a/src/DotCraft.RemoteTools/PluginExecutionWorkspace.cs
+++ b/src/DotCraft.RemoteTools/PluginExecutionWorkspace.cs
@@ -1,0 +1,134 @@
+using DotCraft.Configuration;
+using DotCraft.Runtime;
+using DotCraft.Security;
+using DotCraft.Tools;
+using DotCraft.Tools.BackgroundTerminals;
+using DotCraft.Workspaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotCraft.RemoteTools;
+
+internal sealed class PluginExecutionWorkspace : IAsyncDisposable
+{
+    private readonly PluginExecutionHost _host;
+    private readonly ServiceProvider _services;
+    private readonly DotCraftPaths _paths;
+    private readonly SemaphoreSlim _preparing = new(1, 1);
+    private readonly object _gate = new();
+    private readonly Dictionary<string, RemotePluginBundle> _sources = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ThreadCatalog> _catalogs = new(StringComparer.Ordinal);
+
+    internal PluginExecutionWorkspace(DotCraftPaths paths, AppConfig config, IBackgroundTerminalService terminals)
+    {
+        _paths = paths;
+        _services = new ServiceCollection().AddLogging().AddSingleton(paths).AddSingleton(config)
+            .AddSingleton<IApprovalService>(new HostInvocationApprovalService())
+            .AddSingleton(terminals).BuildServiceProvider();
+        _host = new PluginExecutionHost(paths, _services);
+    }
+
+    internal async Task<PluginActivateResponse> PrepareAsync(PluginPrepareRequest request,
+        IReadOnlyList<RemotePluginBundleFiles> files, CancellationToken ct, Action? store = null)
+    {
+        await _preparing.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            lock (_gate)
+            {
+                if (_catalogs.TryGetValue(request.ThreadId, out var previous) && previous.Revision > request.SnapshotRevision)
+                    throw Unavailable("A newer thread snapshot is already prepared.");
+                foreach (var file in files)
+                {
+                    var incoming = file.Bundle;
+                    if (_sources.TryGetValue(incoming.PluginId, out var current)
+                        && (current.SourceRevision > incoming.SourceRevision
+                            || (current.SourceRevision == incoming.SourceRevision
+                                && (current.SourceGeneration != incoming.SourceGeneration
+                                    || current.ContentFingerprint != incoming.ContentFingerprint
+                                    || current.Settings.GetRawText() != incoming.Settings.GetRawText()))))
+                        throw Unavailable("A newer or different plugin source is already prepared.");
+                }
+                foreach (var file in files) _sources[file.Bundle.PluginId] = file.Bundle;
+                _catalogs.Remove(request.ThreadId);
+            }
+            try { await _host.PrepareAsync(files, ct).ConfigureAwait(false); }
+            catch (InvalidOperationException exception) { throw Unavailable(exception.Message); }
+            var registrations = await _host.GetRegistrationsAsync(new ToolPlanningContext(request.ThreadId, null,
+                _paths.WorkspacePath, _paths.Data.RootPath, request.Mode, null, [], request.SnapshotRevision,
+                workspaceRoots: [_paths.WorkspacePath]), ct).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            var tools = new Dictionary<string, PreparedTool>(StringComparer.Ordinal);
+            foreach (var expected in request.Tools)
+            {
+                var registration = registrations.SingleOrDefault(item => item.Definition.Id.ToString() == expected.DefinitionId
+                    && RemoteToolMetadata.IsRpcEligible(item));
+                if (registration is null)
+                    throw Unavailable($"The prepared plugin does not export '{expected.ToolName}'.");
+                var hash = RemoteToolContractHasher.Compute(registration.Definition);
+                if (hash != expected.ContractHash || registration.Definition.Name.ToString() != expected.ToolName)
+                    throw new RemoteToolHostException(RemoteToolErrorCodes.ToolContractMismatch,
+                        $"The prepared plugin contract differs for '{expected.ToolName}'.");
+                var source = files.Single(file => file.Bundle.PluginId == registration.Definition.Id.SourceId).Bundle;
+                tools.Add(expected.DefinitionId, new(registration, source.SourceGeneration,
+                    new(expected.DefinitionId, hash, "binding_" + Guid.NewGuid().ToString("N"))));
+            }
+            store?.Invoke();
+            lock (_gate)
+            {
+                _catalogs[request.ThreadId] = new(request.SnapshotRevision, tools);
+            }
+            return new(tools.Values.Select(tool => tool.Binding).ToArray());
+        }
+        finally { _preparing.Release(); }
+    }
+
+    internal IReadOnlyList<ToolRegistration> List(string? threadId)
+    {
+        lock (_gate)
+            return threadId is not null && _catalogs.TryGetValue(threadId, out var catalog)
+                ? catalog.Tools.Values.Where(IsCurrent).Select(tool => tool.Registration).ToArray() : [];
+    }
+
+    internal ToolRegistration Resolve(RemoteInvocationMeta invocation)
+    {
+        lock (_gate)
+        {
+            if (invocation.ThreadId is null || !_catalogs.TryGetValue(invocation.ThreadId, out var catalog)
+                || catalog.Revision != invocation.SnapshotRevision
+                || !catalog.Tools.TryGetValue(invocation.DefinitionId, out var tool)
+                || tool.Binding.BindingId != invocation.PreparedBinding || !IsCurrent(tool))
+                throw Unavailable("The prepared plugin binding is no longer available.");
+            return tool.Registration;
+        }
+    }
+
+    private bool IsCurrent(PreparedTool tool) => _sources.TryGetValue(tool.Registration.Definition.Id.SourceId, out var source)
+        && source.SourceGeneration == tool.SourceGeneration;
+
+    internal async Task ReleaseThreadAsync(string threadId, CancellationToken ct)
+    {
+        await _preparing.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            lock (_gate) _catalogs.Remove(threadId);
+            await _host.ReleaseThreadAsync(threadId, ct).ConfigureAwait(false);
+        }
+        finally { _preparing.Release(); }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _preparing.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            lock (_gate) _catalogs.Clear();
+            await _host.DisposeAsync().ConfigureAwait(false);
+            await _services.DisposeAsync().ConfigureAwait(false);
+        }
+        finally { _preparing.Release(); }
+    }
+
+    private static RemoteToolHostException Unavailable(string message) => new(RemoteToolErrorCodes.RemoteToolUnavailable, message);
+    private sealed record PreparedTool(ToolRegistration Registration, string SourceGeneration, PluginPreparedBinding Binding);
+    private sealed record ThreadCatalog(long Revision, IReadOnlyDictionary<string, PreparedTool> Tools);
+}

--- a/src/DotCraft.RemoteTools/RemotePluginProtocol.cs
+++ b/src/DotCraft.RemoteTools/RemotePluginProtocol.cs
@@ -1,0 +1,23 @@
+using DotCraft.Tools;
+
+namespace DotCraft.RemoteTools;
+
+internal static class RemotePluginProtocol
+{
+    internal const string Capability = "plugins-v1";
+    internal const string Prepare = "dotcraft/remoteToolHost/plugins/prepare";
+    internal const string Activate = "dotcraft/remoteToolHost/plugins/activate";
+    internal const string Abort = "dotcraft/remoteToolHost/plugins/abort";
+    internal const string ReleaseThread = "dotcraft/remoteToolHost/plugins/releaseThread";
+}
+
+internal sealed record PluginBundleTransfer(RemotePluginBundle Bundle, TransferFileManifest Manifest);
+internal sealed record PluginPrepareRequest(string LeaseId, string WorkspaceId, string ThreadId,
+    long SnapshotRevision, string Mode, IReadOnlyList<PluginBundleTransfer> Bundles,
+    IReadOnlyList<RemoteToolContractSummary> Tools);
+internal sealed record PluginUpload(string PluginId, string? TransferId);
+internal sealed record PluginPrepareResponse(string PreparationId, IReadOnlyList<PluginUpload> Uploads);
+internal sealed record PluginActivateRequest(string PreparationId);
+internal sealed record PluginPreparedBinding(string DefinitionId, string ContractHash, string BindingId);
+internal sealed record PluginActivateResponse(IReadOnlyList<PluginPreparedBinding> Bindings);
+internal sealed record PluginThreadRelease(string LeaseId, string WorkspaceId, string ThreadId);

--- a/src/DotCraft.RemoteTools/RemoteToolHostClient.Connection.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostClient.Connection.cs
@@ -11,7 +11,8 @@ internal sealed partial class RemoteToolHostClient
         if (TryGetRoute(threadId, out var existing) && existing.HostId == hostId && existing.WorkspaceId == workspaceId)
         {
             RequireLease(existing);
-            var summary = await BuildMatchSummaryAsync(existing, cancellationToken).ConfigureAwait(false);
+            await PreparePluginsAsync(threadId, RequireLease(existing), cancellationToken).ConfigureAwait(false);
+            var summary = await BuildMatchSummaryAsync(threadId, existing, cancellationToken).ConfigureAwait(false);
             return (summary with { AlreadyConnected = true }, null);
         }
         var session = await GetSessionAsync(hostId, cancellationToken).ConfigureAwait(false);
@@ -50,9 +51,11 @@ internal sealed partial class RemoteToolHostClient
                 lease.OperatingSystem = info.Os;
                 lease.UserName = info.Username;
                 lease.BuildVersion = info.BuildVersion;
+                lease.SupportsPlugins = info.Capabilities.Contains(RemotePluginProtocol.Capability);
             }
             RequireLease(lease.Route);
-            var summary = await BuildMatchSummaryAsync(lease.Route, cancellationToken).ConfigureAwait(false);
+            await PreparePluginsAsync(threadId, lease, cancellationToken).ConfigureAwait(false);
+            var summary = await BuildMatchSummaryAsync(threadId, lease.Route, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             RemoteToolRoute? previous;
             lock (_stateGate)
@@ -63,11 +66,16 @@ internal sealed partial class RemoteToolHostClient
                 lease.ReferenceCount++;
             }
             if (previous is not null)
+            {
+                await ReleasePluginThreadAsync(threadId, previous, CancellationToken.None).ConfigureAwait(false);
                 await ReleaseRouteReferenceAsync(previous, CancellationToken.None).ConfigureAwait(false);
+            }
             return (summary, lease.Route);
         }
         catch
         {
+            if (lease is not null && (!TryGetRoute(threadId, out var current) || current != lease.Route))
+                await ReleasePluginThreadAsync(threadId, lease.Route, CancellationToken.None).ConfigureAwait(false);
             if (created && lease is not null && lease.ReferenceCount == 0)
             {
                 lock (_stateGate) _leases.Remove(key);

--- a/src/DotCraft.RemoteTools/RemoteToolHostClient.Plugins.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostClient.Plugins.cs
@@ -1,0 +1,180 @@
+using System.Text.Json.Nodes;
+using DotCraft.Security;
+using DotCraft.Tools;
+
+namespace DotCraft.RemoteTools;
+
+internal sealed partial class RemoteToolHostClient
+{
+    private readonly Dictionary<string, ThreadRemoteSnapshot> _snapshots = new(StringComparer.Ordinal);
+    private readonly Dictionary<(string ThreadId, string LeaseId), PreparedSnapshot> _preparedSnapshots = new();
+    private readonly Dictionary<(string ThreadId, string LeaseId), PreparationFailure> _preparationFailures = new();
+
+    public void UpdateRemoteToolSnapshot(string threadId, EffectiveToolSnapshot snapshot, string mode)
+    {
+        var visible = snapshot.ModelVisibleDefinitions.Concat(snapshot.DeferredDefinitions.Values.SelectMany(items => items))
+            .Select(definition => definition.Id).ToHashSet();
+        var registrations = snapshot.Registrations.Values
+            .Where(item => visible.Contains(item.Definition.Id) && RemoteToolMetadata.IsRpcEligible(item)).ToArray();
+        lock (_stateGate)
+        {
+            if (_snapshots.TryGetValue(threadId, out var previous) && previous.Revision >= snapshot.Revision) return;
+            _snapshots[threadId] = new(snapshot.Revision, mode, registrations);
+        }
+    }
+
+    public async ValueTask PrepareTurnAsync(string threadId, EffectiveToolSnapshot snapshot, string mode,
+        CancellationToken cancellationToken = default)
+    {
+        await _routeGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            UpdateRemoteToolSnapshot(threadId, snapshot, mode);
+            if (!TryGetRoute(threadId, out var route)) return;
+            await PreparePluginsAsync(threadId, RequireLease(route), cancellationToken, snapshot.Revision).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            lock (_stateGate)
+                if (_routes.TryGetValue(threadId, out var current))
+                {
+                    var key = (threadId, current.LeaseId);
+                    _preparedSnapshots.Remove(key);
+                    _preparationFailures[key] = new(snapshot.Revision,
+                        ex is RemoteToolHostException remote ? remote.Code : RemoteToolErrorCodes.RemoteToolUnavailable,
+                        ex.Message);
+                }
+        }
+        finally { _routeGate.Release(); }
+    }
+
+    private async Task PreparePluginsAsync(string threadId, SharedLease lease, CancellationToken ct, long? expectedRevision = null)
+    {
+        ThreadRemoteSnapshot? snapshot;
+        lock (_stateGate)
+        {
+            _snapshots.TryGetValue(threadId, out snapshot);
+            if (expectedRevision is not null && snapshot?.Revision != expectedRevision)
+                throw new RemoteToolHostException(RemoteToolErrorCodes.RemoteToolUnavailable, "The captured tool snapshot is no longer current.");
+            if (snapshot is null || (_preparedSnapshots.TryGetValue((threadId, lease.Route.LeaseId), out var prepared)
+                && ReferenceEquals(prepared.Snapshot, snapshot))) return;
+            _preparedSnapshots.Remove((threadId, lease.Route.LeaseId));
+            _preparationFailures.Remove((threadId, lease.Route.LeaseId));
+        }
+        var sources = snapshot.Registrations.Select(RemoteToolMetadata.SourceBinding)
+            .OfType<IRemoteToolSourceBinding>().DistinctBy(source => source.SourceId).ToArray();
+        if (sources.Length == 0)
+        {
+            if (lease.SupportsPlugins)
+                await SendAsync<PluginThreadRelease, JsonObject>(lease.Session.Client, RemotePluginProtocol.ReleaseThread,
+                    new(lease.Route.LeaseId, lease.Route.WorkspaceId, threadId), ct).ConfigureAwait(false);
+            return;
+        }
+        if (!lease.SupportsPlugins)
+            throw new RemoteToolHostException(RemoteToolErrorCodes.ProtocolMismatch, "The remote Host does not support plugin preparation.");
+
+        var exports = new List<RemoteToolSourceExport>();
+        PluginPrepareResponse? pending = null;
+        try
+        {
+            foreach (var source in sources) exports.Add(await source.ExportAsync(ct).ConfigureAwait(false));
+            var bundles = exports.SelectMany(export => export.Bundles).GroupBy(files => files.Bundle.PluginId, StringComparer.Ordinal)
+                .Select(group =>
+                {
+                    if (group.Select(files => files.Bundle.SourceGeneration).Distinct().Count() != 1)
+                        throw new RemoteToolHostException(RemoteToolErrorCodes.RemoteToolUnavailable, "Plugin sources changed during preparation.");
+                    return group.First();
+                }).ToArray();
+            var manifests = new List<PluginBundleTransfer>();
+            foreach (var files in bundles)
+                manifests.Add(new(files.Bundle, await TransferFileTree.DescribeAsync(files.RootPath,
+                    new FileAccessGuard(files.RootPath), _maxTransferBytes, ct).ConfigureAwait(false)));
+            var contracts = snapshot.Registrations.Select(RemoteToolMetadata.NativeDefinition)
+                .Where(definition => definition.Id.Kind == ToolSourceKind.PluginNative)
+                .Select(definition => new RemoteToolContractSummary(definition.Id.ToString(), definition.Name.ToString(),
+                    RemoteToolContractHasher.Compute(definition))).ToArray();
+            pending = await SendAsync<PluginPrepareRequest, PluginPrepareResponse>(lease.Session.Client,
+                RemotePluginProtocol.Prepare, new(lease.Route.LeaseId, lease.Route.WorkspaceId, threadId,
+                    snapshot.Revision, snapshot.Mode, manifests, contracts), ct).ConfigureAwait(false);
+            foreach (var upload in pending.Uploads.Where(upload => upload.TransferId is not null))
+            {
+                var files = bundles.Single(files => files.Bundle.PluginId == upload.PluginId);
+                var manifest = manifests.Single(item => item.Bundle.PluginId == upload.PluginId).Manifest;
+                await UploadPluginAsync(lease, upload.TransferId!, files.RootPath, manifest, ct).ConfigureAwait(false);
+            }
+            var activated = await SendAsync<PluginActivateRequest, PluginActivateResponse>(lease.Session.Client,
+                RemotePluginProtocol.Activate, new(pending.PreparationId), ct).ConfigureAwait(false);
+            var bindings = activated.Bindings.ToDictionary(binding => binding.DefinitionId, StringComparer.Ordinal);
+            foreach (var contract in contracts)
+                if (!bindings.TryGetValue(contract.DefinitionId, out var binding) || binding.ContractHash != contract.ContractHash)
+                    throw new RemoteToolHostException(RemoteToolErrorCodes.ToolContractMismatch, "Prepared plugin contracts do not match the captured snapshot.");
+            RequireLease(lease.Route);
+            lock (_stateGate)
+                _preparedSnapshots[(threadId, lease.Route.LeaseId)] = new(snapshot, bindings);
+        }
+        finally
+        {
+            foreach (var export in exports) export.Dispose();
+            if (pending is not null)
+            {
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await SendAsync<PluginActivateRequest, JsonObject>(lease.Session.Client, RemotePluginProtocol.Abort,
+                        new(pending.PreparationId), timeout.Token).ConfigureAwait(false);
+                }
+                catch { }
+            }
+        }
+    }
+
+    private async Task UploadPluginAsync(SharedLease lease, string transferId, string root,
+        TransferFileManifest manifest, CancellationToken ct)
+    {
+        for (var index = 0; index < manifest.Entries.Count; index++)
+        {
+            var entry = manifest.Entries[index];
+            if (!entry.IsDirectory)
+            {
+                await using var file = TransferFileTree.OpenRead(TransferFileTree.ResolveEntry(root, entry.Path));
+                long offset = 0;
+                do
+                {
+                    RequireLease(lease.Route);
+                    var bytes = new byte[(int)Math.Min(RemoteFileTransferProtocol.ChunkBytes, entry.Length - offset)];
+                    await file.ReadExactlyAsync(bytes, ct).ConfigureAwait(false);
+                    await SendAsync<FileTransferPart, JsonObject>(lease.Session.Client, RemoteFileTransferProtocol.Write,
+                        new(transferId, index, offset, Convert.ToBase64String(bytes)), ct).ConfigureAwait(false);
+                    offset += bytes.Length;
+                } while (offset < entry.Length);
+            }
+            await SendAsync<FileTransferPart, JsonObject>(lease.Session.Client, RemoteFileTransferProtocol.Commit,
+                new(transferId, index), ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ReleasePluginThreadAsync(string threadId, RemoteToolRoute route, CancellationToken ct)
+    {
+        try
+        {
+            var lease = RequireLease(route);
+            if (lease.SupportsPlugins)
+                await SendAsync<PluginThreadRelease, JsonObject>(lease.Session.Client, RemotePluginProtocol.ReleaseThread,
+                    new(route.LeaseId, route.WorkspaceId, threadId), ct).ConfigureAwait(false);
+        }
+        catch { }
+        finally
+        {
+            lock (_stateGate)
+            {
+                _preparedSnapshots.Remove((threadId, route.LeaseId));
+                _preparationFailures.Remove((threadId, route.LeaseId));
+            }
+        }
+    }
+
+    private sealed record ThreadRemoteSnapshot(long Revision, string Mode, IReadOnlyList<ToolRegistration> Registrations);
+    private sealed record PreparedSnapshot(ThreadRemoteSnapshot Snapshot,
+        IReadOnlyDictionary<string, PluginPreparedBinding> Bindings);
+    private sealed record PreparationFailure(long Revision, string Code, string Message);
+}

--- a/src/DotCraft.RemoteTools/RemoteToolHostClient.Session.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostClient.Session.cs
@@ -83,6 +83,7 @@ internal sealed partial class RemoteToolHostClient
         public string OperatingSystem { get; set; } = "unknown";
         public string UserName { get; set; } = "unknown";
         public string BuildVersion { get; set; } = "unknown";
+        public bool SupportsPlugins { get; set; }
 
         public void StartHeartbeat() => _heartbeatTask = RunHeartbeatAsync();
 

--- a/src/DotCraft.RemoteTools/RemoteToolHostClient.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostClient.cs
@@ -20,6 +20,7 @@ internal sealed partial class RemoteToolHostClient :
     private readonly IApprovalService _approvalService;
     private readonly int _defaultMaxResultChars;
     private readonly int _spillPreviewLines;
+    private readonly long _maxTransferBytes;
     private readonly string _clientInstanceId = "agent_" + Guid.NewGuid().ToString("N");
     private readonly SemaphoreSlim _routeGate = new(1, 1);
     private readonly object _stateGate = new();
@@ -27,8 +28,6 @@ internal sealed partial class RemoteToolHostClient :
     private readonly Dictionary<RouteKey, SharedLease> _leases = new();
     private readonly ConcurrentDictionary<string, HostSession> _sessions = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, IApprovalService> _pendingApprovals = new(StringComparer.Ordinal);
-    private IReadOnlyDictionary<string, ToolDefinition> _definitions =
-        new Dictionary<string, ToolDefinition>(StringComparer.Ordinal);
     private bool _disposed;
 
     public RemoteToolHostClient(
@@ -38,19 +37,11 @@ internal sealed partial class RemoteToolHostClient :
     {
         _directory = directory;
         _approvalService = approvalService;
-        var limits = (config ?? new AppConfig()).Tools.ResultLimits;
+        var tools = (config ?? new AppConfig()).Tools;
+        var limits = tools.ResultLimits;
         _defaultMaxResultChars = limits.MaxToolResultChars;
         _spillPreviewLines = limits.SpillPreviewLines;
-    }
-
-    public void UpdateRemoteToolDefinitions(IReadOnlyList<ToolDefinition> definitions)
-    {
-        lock (_stateGate)
-        {
-            _definitions = definitions.ToDictionary(
-                definition => definition.Id.ToString(),
-                StringComparer.Ordinal);
-        }
+        _maxTransferBytes = tools.File.MaxTransferBytes;
     }
 
     /// <summary>Reads the Hub catalog without opening a data connection to a paired machine.</summary>
@@ -130,7 +121,10 @@ internal sealed partial class RemoteToolHostClient :
                 _routes.Remove(threadId, out previous);
             }
             if (previous is not null)
-                await ReleaseRouteReferenceAsync(previous, cancellationToken).ConfigureAwait(false);
+            {
+                try { await ReleasePluginThreadAsync(threadId, previous, cancellationToken).ConfigureAwait(false); }
+                finally { await ReleaseRouteReferenceAsync(previous, cancellationToken).ConfigureAwait(false); }
+            }
         }
         finally
         {
@@ -208,6 +202,30 @@ internal sealed partial class RemoteToolHostClient :
         }
 
         var invocationId = "rti_" + Guid.NewGuid().ToString("N");
+        string? preparedBinding = null;
+        long? snapshotRevision = null;
+        if (definition.Id.Kind == ToolSourceKind.PluginNative)
+        {
+            ToolRegistration registration;
+            lock (_stateGate)
+            {
+                if (_preparationFailures.TryGetValue((context.ThreadId, route.LeaseId), out var failure)
+                    && failure.Revision == context.SnapshotRevision)
+                    return Failure(failure.Code, failure.Message);
+                if (!_preparedSnapshots.TryGetValue((context.ThreadId, route.LeaseId), out var prepared)
+                    || prepared.Snapshot.Revision != context.SnapshotRevision
+                    || !prepared.Snapshot.Registrations.Any(item => item.Binding.Id == context.RuntimeBindingId)
+                    || !prepared.Bindings.TryGetValue(definition.Id.ToString(), out var binding)
+                    || binding.ContractHash != contractHash)
+                    return Failure(RemoteToolErrorCodes.RemoteToolUnavailable, "This plugin snapshot has not been prepared on the remote Host.");
+                preparedBinding = binding.BindingId;
+                snapshotRevision = prepared.Snapshot.Revision;
+                registration = prepared.Snapshot.Registrations.Single(item => item.Binding.Id == context.RuntimeBindingId);
+            }
+            var authority = await registration.Binding.Lease.CheckAsync(context, cancellationToken).ConfigureAwait(false);
+            if (!authority.IsAvailable)
+                return Failure(RemoteToolErrorCodes.RemoteToolUnavailable, authority.Error?.Message ?? "The plugin source is no longer active.");
+        }
         var meta = new RemoteInvocationMeta(
             route.LeaseId,
             route.WorkspaceId,
@@ -217,7 +235,7 @@ internal sealed partial class RemoteToolHostClient :
             context.ThreadId,
             context.TurnId,
             ResolveRemoteResultLimit(definition),
-            Math.Clamp(_spillPreviewLines, 1, 500));
+            Math.Clamp(_spillPreviewLines, 1, 500), preparedBinding, snapshotRevision);
         var request = new CallToolRequestParams
         {
             Name = definition.Name.ToString(),
@@ -317,16 +335,19 @@ internal sealed partial class RemoteToolHostClient :
     }
 
     private async Task<RemoteToolConnectResult> BuildMatchSummaryAsync(
+        string threadId,
         RemoteToolRoute route,
         CancellationToken cancellationToken)
     {
         var key = new RouteKey(route.HostId, route.WorkspaceId);
         SharedLease lease;
-        IReadOnlyDictionary<string, ToolDefinition> definitions;
+        IReadOnlyList<ToolDefinition> definitions;
         lock (_stateGate)
         {
             lease = _leases[key];
-            definitions = _definitions;
+            definitions = _snapshots.TryGetValue(threadId, out var snapshot)
+                ? snapshot.Registrations.Select(RemoteToolMetadata.NativeDefinition).ToArray()
+                : [];
         }
         var catalog = await lease.Session.Client.ListToolsAsync(
             new ListToolsRequestParams
@@ -334,7 +355,7 @@ internal sealed partial class RemoteToolHostClient :
                 Meta = new JsonObject
                 {
                     ["dotcraft"] = JsonSerializer.SerializeToNode(
-                        new RemoteCatalogScope(route.LeaseId, route.WorkspaceId),
+                        new RemoteCatalogScope(route.LeaseId, route.WorkspaceId, threadId),
                         RemoteToolHostProtocol.JsonOptions)
                 }
             },
@@ -347,7 +368,7 @@ internal sealed partial class RemoteToolHostClient :
         var matched = new List<string>();
         var unavailable = new List<string>();
         var reasons = new List<RemoteToolUnavailableReason>();
-        foreach (var definition in definitions.Values.OrderBy(item => item.Name.ToString(), StringComparer.Ordinal))
+        foreach (var definition in definitions.OrderBy(item => item.Name.ToString(), StringComparer.Ordinal))
         {
             var name = definition.Name.ToString();
             var expected = RemoteToolContractHasher.Compute(definition);

--- a/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Authorization.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Authorization.cs
@@ -9,7 +9,7 @@ internal sealed partial class RemoteToolHostMcpHandlers
     public async Task DrainWorkspaceAsync(string workspaceId)
     {
         _leases.ReleaseWorkspace(workspaceId);
-        await DisposeRuntimeAsync(workspaceId).ConfigureAwait(false);
+        await _leases.WaitForDrainAsync(workspaceId).ConfigureAwait(false);
     }
 
     private RemoteToolHubPeer RequirePeer(RemoteToolHostState state, string peerId, string? workspaceId = null)

--- a/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Dispatch.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Dispatch.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotCraft.Tools;
+
+namespace DotCraft.RemoteTools;
+
+internal sealed partial class RemoteToolHostMcpHandlers
+{
+    private sealed class HostDispatchPolicy(RemoteToolHostMcpHandlers owner, RemoteToolHostState state,
+        RemoteToolHubPeer peer, RemoteInvocationMeta invocation, HostInvocationApprovalService.Invocation approval,
+        HostWorkspaceRuntime runtime) : IToolPolicyEvaluator, IToolApprovalEvaluator
+    {
+        public async ValueTask<ToolDispatchDecision> EvaluateAsync(ToolInvocationContext context,
+            ToolRegistration registration, JsonObject arguments, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var native = arguments.ToDictionary(pair => pair.Key, pair => JsonSerializer.SerializeToElement(pair.Value));
+                await owner.AuthorizeAsync(registration.Definition.Name.ToString(), native, state, approval,
+                    runtime.WorkspacePath, cancellationToken).ConfigureAwait(false);
+                return ValidateAuthority();
+            }
+            catch (RemoteToolHostException exception) { return ToolDispatchDecision.Deny(exception.Code, exception.Message); }
+        }
+
+        public async ValueTask<ToolDispatchDecision> RequestAsync(ToolInvocationContext context,
+            ToolRegistration registration, JsonObject arguments, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (registration.Definition.Id.Kind == ToolSourceKind.PluginNative)
+                    await approval.RequestAsync("tool", registration.Definition.Name.ToString(), arguments.ToJsonString())
+                        .ConfigureAwait(false);
+                var decision = ValidateAuthority();
+                if (decision.Allowed && registration.Definition.Name.ToString() == "LSP")
+                    await runtime.InitializeLspAsync(cancellationToken).ConfigureAwait(false);
+                return decision;
+            }
+            catch (RemoteToolHostException exception) { return ToolDispatchDecision.Deny(exception.Code, exception.Message); }
+        }
+
+        private ToolDispatchDecision ValidateAuthority()
+        {
+            owner._leases.Validate(invocation.LeaseId, invocation.WorkspaceId);
+            var current = owner.RequirePeer(owner.RequireState(), peer.PeerId, invocation.WorkspaceId);
+            return current.AuthorizationRevision == peer.AuthorizationRevision
+                ? ToolDispatchDecision.Allow
+                : ToolDispatchDecision.Deny(RemoteToolErrorCodes.RemotePolicyDenied, "Authorization changed.");
+        }
+    }
+}

--- a/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Files.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Files.cs
@@ -14,6 +14,9 @@ internal sealed partial class RemoteToolHostMcpHandlers
     private async ValueTask<JsonNode?> OpenFileTransferAsync(JsonRpcRequest request, string peerId, CancellationToken ct)
     {
         var input = Deserialize<FileTransferOpen>(request);
+        using var call = _leases.EnterCall(input.LeaseId, input.WorkspaceId);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, call.Token);
+        ct = linked.Token;
         var root = _leases.Validate(input.LeaseId, input.WorkspaceId);
         var peer = RequirePeer(RequireState(), peerId, input.WorkspaceId);
         var config = HostWorkspaceRuntime.LoadWorkspaceConfig(_storage.GlobalConfigPath, root);
@@ -54,13 +57,14 @@ internal sealed partial class RemoteToolHostMcpHandlers
         var input = Deserialize<FileTransferPart>(request);
         if (!_transfers.TryGetValue(input.TransferId, out var transfer) || transfer.PeerId != peerId)
             throw new RemoteToolHostException(RemoteToolErrorCodes.LeaseLost, "File transfer is unavailable.");
+        using var call = _leases.EnterCall(transfer.Open.LeaseId, transfer.Open.WorkspaceId);
         if (operation == RemoteFileTransferProtocol.Close)
         {
             if (_transfers.TryRemove(input.TransferId, out _)) await transfer.Session.DisposeAsync().ConfigureAwait(false);
             return new JsonObject();
         }
         var session = transfer.Session;
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, session.Stopping.Token);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, session.Stopping.Token, call.Token);
         var token = linked.Token;
         await session.Gate.WaitAsync(token).ConfigureAwait(false);
         try
@@ -106,16 +110,11 @@ internal sealed partial class RemoteToolHostMcpHandlers
         var state = RequireState();
         var peer = RequirePeer(state, transfer.PeerId, transfer.Open.WorkspaceId);
         var tool = transfer.Session.Write ? "WriteFile" : "ReadFile";
-        if (peer.AuthorizationRevision != transfer.Revision || state.ToolPolicies.GetValueOrDefault(tool) == "deny")
+        if (peer.AuthorizationRevision != transfer.Revision
+            || (!transfer.PluginBundle && state.ToolPolicies.GetValueOrDefault(tool) == "deny"))
             throw new RemoteToolHostException(RemoteToolErrorCodes.RemotePolicyDenied, "Transfer authorization changed.");
     }
 
-    internal void ReleaseFileTransfers(string leaseId)
-    {
-        foreach (var (id, transfer) in _transfers)
-            if (transfer.Open.LeaseId == leaseId && _transfers.TryRemove(id, out _))
-                _ = transfer.Session.DisposeAsync().AsTask();
-    }
-
-    private sealed record HostTransfer(FileTransferOpen Open, string PeerId, long Revision, FileTransferSession Session);
+    private sealed record HostTransfer(FileTransferOpen Open, string PeerId, long Revision, FileTransferSession Session,
+        bool PluginBundle = false);
 }

--- a/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Images.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Images.cs
@@ -11,6 +11,9 @@ internal sealed partial class RemoteToolHostMcpHandlers
     private async ValueTask<JsonNode?> WriteImageAsync(JsonRpcRequest request, string peerId, CancellationToken ct)
     {
         var input = Deserialize<RemoteImageWriteRequest>(request);
+        using var call = _leases.EnterCall(input.LeaseId, input.WorkspaceId);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, call.Token);
+        ct = linked.Token;
         var root = _leases.Validate(input.LeaseId, input.WorkspaceId);
         var state = RequireState();
         var peer = RequirePeer(state, peerId, input.WorkspaceId);

--- a/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Plugins.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.Plugins.cs
@@ -1,0 +1,247 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotCraft.Plugins;
+using DotCraft.Runtime;
+using DotCraft.Tools;
+using ModelContextProtocol.Protocol;
+
+namespace DotCraft.RemoteTools;
+
+internal sealed partial class RemoteToolHostMcpHandlers
+{
+    private readonly ConcurrentDictionary<string, PluginPreparation> _pluginPreparations = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, HashSet<string>> _pluginApprovals = new(StringComparer.Ordinal);
+
+    private async ValueTask<JsonNode?> PreparePluginsAsync(JsonRpcRequest request, string peerId, CancellationToken ct)
+    {
+        var input = Deserialize<PluginPrepareRequest>(request);
+        using var call = _leases.EnterCall(input.LeaseId, input.WorkspaceId);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, call.Token);
+        ct = linked.Token;
+        var workspace = _leases.Validate(input.LeaseId, input.WorkspaceId);
+        var peer = RequirePeer(RequireState(), peerId, input.WorkspaceId);
+        if (string.IsNullOrWhiteSpace(input.ThreadId) || string.IsNullOrWhiteSpace(input.Mode)
+            || input.Bundles.Count is 0 or > 128 || input.Tools.Count is 0 or > 10000
+            || input.Bundles.Select(item => item.Bundle.PluginId).Distinct(StringComparer.Ordinal).Count() != input.Bundles.Count)
+            throw new RemoteToolHostException(ToolErrorCodes.InputInvalid, "Invalid plugin preparation manifest.");
+        var id = "prepare_" + Guid.NewGuid().ToString("N");
+        var root = Path.Combine(_storage.RootPath, "workspaces", input.WorkspaceId, "plugins");
+        var stagedRoot = Path.Combine(_storage.RootPath, "workspaces", input.WorkspaceId, "plugin-staging", id);
+        var files = new List<RemotePluginBundleFiles>();
+        var uploads = new List<PluginUpload>();
+        var preparation = new PluginPreparation(input, peerId, peer.AuthorizationRevision, files, uploads, stagedRoot, root);
+        try
+        {
+            var limit = HostWorkspaceRuntime.LoadWorkspaceConfig(_storage.GlobalConfigPath, workspace).Tools.File.MaxTransferBytes;
+            long total = 0;
+            foreach (var item in input.Bundles)
+            {
+                var bundle = item.Bundle;
+                if (PluginIds.Canonicalize(bundle.PluginId) != bundle.PluginId
+                    || bundle.Settings.ValueKind != JsonValueKind.Object || bundle.SourceRevision < 1
+                    || string.IsNullOrWhiteSpace(bundle.SourceGeneration))
+                    throw new RemoteToolHostException(ToolErrorCodes.InputInvalid, "Invalid plugin bundle identity or settings.");
+                var destination = TransferFileTree.ResolveEntry(root, bundle.PluginId);
+                TransferFileTree.RejectLinks(destination);
+                if (Directory.Exists(destination) && PluginExecutionHost.MatchesBundle(destination, bundle))
+                {
+                    files.Add(new(bundle, destination));
+                    uploads.Add(new(bundle.PluginId, null));
+                    continue;
+                }
+                var staged = TransferFileTree.ResolveEntry(stagedRoot, bundle.PluginId);
+                var session = new FileTransferSession(staged, item.Manifest, true, false);
+                try
+                {
+                    await session.PrepareAsync(limit - total, (_, _, _) => Task.CompletedTask, ct).ConfigureAwait(false);
+                    total += item.Manifest.Entries.Sum(entry => entry.Length);
+                    var transferId = "plugin_" + Guid.NewGuid().ToString("N");
+                    var open = new FileTransferOpen(input.LeaseId, input.WorkspaceId, staged, true, false, item.Manifest);
+                    _leases.CommitArtifact(input.LeaseId, input.WorkspaceId, () =>
+                    {
+                        _transfers[transferId] = new(open, peerId, peer.AuthorizationRevision, session, PluginBundle: true);
+                    });
+                    uploads.Add(new(bundle.PluginId, transferId));
+                    files.Add(new(bundle, staged));
+                }
+                catch { await session.DisposeAsync().ConfigureAwait(false); throw; }
+            }
+            _leases.CommitArtifact(input.LeaseId, input.WorkspaceId, () =>
+            {
+                if (_pluginPreparations.Count >= 32) throw new IOException("Too many plugin preparations are pending.");
+                _pluginPreparations[id] = preparation;
+            });
+            return JsonSerializer.SerializeToNode(new PluginPrepareResponse(id, uploads), RemoteToolHostProtocol.JsonOptions);
+        }
+        catch
+        {
+            await CleanupPreparationAsync(preparation).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async ValueTask<JsonNode?> ActivatePluginsAsync(JsonRpcRequest request, string peerId, CancellationToken ct)
+    {
+        var input = Deserialize<PluginActivateRequest>(request);
+        if (!_pluginPreparations.TryGetValue(input.PreparationId, out var pending) || pending.PeerId != peerId)
+            throw new RemoteToolHostException(RemoteToolErrorCodes.RemoteToolUnavailable, "The plugin preparation is unavailable.");
+        using var call = _leases.EnterCall(pending.Input.LeaseId, pending.Input.WorkspaceId);
+        if (!pending.TryStart())
+            throw new RemoteToolHostException(RemoteToolErrorCodes.RemoteToolUnavailable, "The plugin preparation is unavailable.");
+        try
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, call.Token, pending.Stopping.Token);
+            ct = linked.Token;
+            var workspace = _leases.Validate(pending.Input.LeaseId, pending.Input.WorkspaceId);
+            var peer = RequirePeer(RequireState(), peerId, pending.Input.WorkspaceId);
+            if (peer.AuthorizationRevision != pending.AuthorizationRevision)
+                throw new RemoteToolHostException(RemoteToolErrorCodes.RemotePolicyDenied, "Authorization changed.");
+            foreach (var upload in pending.Uploads.Where(upload => upload.TransferId is not null))
+            {
+                if (!_transfers.TryRemove(upload.TransferId!, out var transfer))
+                    throw new RemoteToolHostException(RemoteToolErrorCodes.RemoteToolUnavailable, "A plugin upload is incomplete.");
+                await transfer.Session.DisposeAsync().ConfigureAwait(false);
+                if (!transfer.Session.IsComplete)
+                    throw new RemoteToolHostException(RemoteToolErrorCodes.RemoteToolUnavailable, "A plugin upload is incomplete.");
+            }
+            foreach (var files in pending.Files)
+                if (!PluginExecutionHost.MatchesBundle(files.RootPath, files.Bundle))
+                    throw new RemoteToolHostException(ToolErrorCodes.InputInvalid, "Plugin bundle fingerprint mismatch.");
+            var approval = new HostInvocationApprovalService.Invocation(peer, input.PreparationId, workspace, _approvalPresenter, ct);
+            using var approvalScope = HostInvocationApprovalService.Begin(approval);
+            var required = pending.Files.Where(file => !IsPluginApproved(pending.Input.LeaseId, file.Bundle)).ToArray();
+            if (required.Length > 0)
+                await approval.RequestAsync("plugin", "activate", string.Join("\n", required.Select(file =>
+                    file.Bundle.PluginId + " " + file.Bundle.ContentFingerprint))).ConfigureAwait(false);
+            if (RequirePeer(RequireState(), peerId, pending.Input.WorkspaceId).AuthorizationRevision != peer.AuthorizationRevision)
+                throw new RemoteToolHostException(RemoteToolErrorCodes.RemotePolicyDenied, "Authorization changed.");
+            ct.ThrowIfCancellationRequested();
+            var runtime = await GetRuntimeAsync(pending.Input.LeaseId, pending.Input.WorkspaceId, workspace, RequireState(), ct).ConfigureAwait(false);
+            var result = await runtime.Plugins.PrepareAsync(pending.Input, pending.Files, ct,
+                () => _leases.CommitArtifact(pending.Input.LeaseId, pending.Input.WorkspaceId, () =>
+                {
+                    if (RequirePeer(RequireState(), peerId, pending.Input.WorkspaceId).AuthorizationRevision != peer.AuthorizationRevision)
+                        throw new RemoteToolHostException(RemoteToolErrorCodes.RemotePolicyDenied, "Authorization changed.");
+                    StorePreparedBundles(pending);
+                })).ConfigureAwait(false);
+            _leases.CommitArtifact(pending.Input.LeaseId, pending.Input.WorkspaceId, () =>
+            {
+                lock (_gate)
+                {
+                    if (!_pluginApprovals.TryGetValue(pending.Input.LeaseId, out var grants))
+                        _pluginApprovals[pending.Input.LeaseId] = grants = new(StringComparer.Ordinal);
+                    foreach (var file in required) grants.Add(ApprovalKey(file.Bundle));
+                }
+            });
+            return JsonSerializer.SerializeToNode(result, RemoteToolHostProtocol.JsonOptions);
+        }
+        finally
+        {
+            _pluginPreparations.TryRemove(input.PreparationId, out _);
+            await CleanupPreparationAsync(pending).ConfigureAwait(false);
+        }
+    }
+
+    private bool IsPluginApproved(string leaseId, RemotePluginBundle bundle)
+    {
+        lock (_gate) return _pluginApprovals.TryGetValue(leaseId, out var grants) && grants.Contains(ApprovalKey(bundle));
+    }
+
+    private static string ApprovalKey(RemotePluginBundle bundle) => bundle.PluginId + ":" + bundle.ContentFingerprint;
+
+    private static void StorePreparedBundles(PluginPreparation preparation)
+    {
+        Directory.CreateDirectory(preparation.InstallRoot);
+        foreach (var upload in preparation.Uploads.Where(upload => upload.TransferId is not null))
+        {
+            var source = preparation.Files.Single(file => file.Bundle.PluginId == upload.PluginId).RootPath;
+            var destination = TransferFileTree.ResolveEntry(preparation.InstallRoot, upload.PluginId);
+            TransferFileTree.RejectLinks(destination);
+            var backup = Path.Combine(preparation.StagedRoot, Guid.NewGuid().ToString("N"));
+            if (Directory.Exists(destination)) Directory.Move(destination, backup);
+            try { Directory.Move(source, destination); }
+            catch
+            {
+                if (Directory.Exists(backup)) Directory.Move(backup, destination);
+                throw;
+            }
+        }
+    }
+
+    private async Task CleanupPreparationAsync(PluginPreparation preparation)
+    {
+        try
+        {
+            foreach (var upload in preparation.Uploads.Where(upload => upload.TransferId is not null))
+                if (_transfers.TryRemove(upload.TransferId!, out var transfer))
+                    await transfer.Session.DisposeAsync().ConfigureAwait(false);
+            if (Directory.Exists(preparation.StagedRoot)) Directory.Delete(preparation.StagedRoot, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) { }
+        finally
+        {
+            preparation.Stopping.Dispose();
+            preparation.Completed.TrySetResult();
+        }
+    }
+
+    private async ValueTask<JsonNode?> AbortPluginsAsync(JsonRpcRequest request, string peerId, CancellationToken ct)
+    {
+        var input = Deserialize<PluginActivateRequest>(request);
+        if (_pluginPreparations.TryGetValue(input.PreparationId, out var pending) && pending.PeerId == peerId)
+        {
+            using var call = _leases.EnterCall(pending.Input.LeaseId, pending.Input.WorkspaceId);
+            if (pending.TryAbortPending())
+            {
+                if (_pluginPreparations.TryRemove(input.PreparationId, out _))
+                    await CleanupPreparationAsync(pending).ConfigureAwait(false);
+            }
+            else
+            {
+                await pending.Stopping.CancelAsync().ConfigureAwait(false);
+                await pending.Completed.Task.WaitAsync(ct).ConfigureAwait(false);
+            }
+        }
+        return new JsonObject();
+    }
+
+    private async ValueTask<JsonNode?> ReleasePluginThreadAsync(JsonRpcRequest request, string peerId, CancellationToken ct)
+    {
+        var input = Deserialize<PluginThreadRelease>(request);
+        using var call = _leases.EnterCall(input.LeaseId, input.WorkspaceId);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, call.Token);
+        var workspace = _leases.Validate(input.LeaseId, input.WorkspaceId);
+        RequirePeer(RequireState(), peerId, input.WorkspaceId);
+        var runtime = await GetRuntimeAsync(input.LeaseId, input.WorkspaceId, workspace, RequireState(), linked.Token).ConfigureAwait(false);
+        await runtime.ReleasePluginThreadAsync(input.ThreadId, linked.Token).ConfigureAwait(false);
+        return new JsonObject();
+    }
+
+    private async Task DrainLeaseResourcesAsync(WorkspaceLeaseReleased released, Task callsDrained)
+    {
+        var runtimeDrain = DisposeRuntimeAsync(released.WorkspaceId);
+        await callsDrained.ConfigureAwait(false);
+        foreach (var (id, pending) in _pluginPreparations)
+            if (pending.Input.LeaseId == released.LeaseId && _pluginPreparations.TryRemove(id, out _))
+                await CleanupPreparationAsync(pending).ConfigureAwait(false);
+        foreach (var (id, transfer) in _transfers)
+            if (transfer.Open.LeaseId == released.LeaseId && _transfers.TryRemove(id, out _))
+                await transfer.Session.DisposeAsync().ConfigureAwait(false);
+        await runtimeDrain.ConfigureAwait(false);
+        lock (_gate) _pluginApprovals.Remove(released.LeaseId);
+    }
+
+    private sealed record PluginPreparation(PluginPrepareRequest Input, string PeerId, long AuthorizationRevision,
+        IReadOnlyList<RemotePluginBundleFiles> Files, IReadOnlyList<PluginUpload> Uploads, string StagedRoot, string InstallRoot)
+    {
+        private const int Pending = 0;
+        private const int Activating = 1;
+        private const int Aborted = 2;
+        private int _state;
+        internal CancellationTokenSource Stopping { get; } = new();
+        internal TaskCompletionSource Completed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal bool TryStart() => Interlocked.CompareExchange(ref _state, Activating, Pending) == Pending;
+        internal bool TryAbortPending() => Interlocked.CompareExchange(ref _state, Aborted, Pending) == Pending;
+    }
+}

--- a/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostMcpHandlers.cs
@@ -34,11 +34,16 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
         _activity = activity;
         _approvalPresenter = approvalPresenter;
         _isPaused = isPaused;
+        _leases.DrainResourcesAsync = DrainLeaseResourcesAsync;
     }
 
     /// <summary>The Hub-assigned peer id is the host identity every Agent-side surface sees.</summary>
     public IReadOnlyList<McpServerRequestHandler> CreateExtensionHandlers(string peerId) =>
     [
+        Raw(RemotePluginProtocol.Prepare, (request, ct) => PreparePluginsAsync(request, peerId, ct)),
+        Raw(RemotePluginProtocol.Activate, (request, ct) => ActivatePluginsAsync(request, peerId, ct)),
+        Raw(RemotePluginProtocol.Abort, (request, ct) => AbortPluginsAsync(request, peerId, ct)),
+        Raw(RemotePluginProtocol.ReleaseThread, (request, ct) => ReleasePluginThreadAsync(request, peerId, ct)),
         Raw(RemoteFileTransferProtocol.Open, (request, ct) => OpenFileTransferAsync(request, peerId, ct)),
         Raw(RemoteFileTransferProtocol.Read, (request, ct) => FileTransferPartAsync(request, peerId, RemoteFileTransferProtocol.Read, ct)),
         Raw(RemoteFileTransferProtocol.Write, (request, ct) => FileTransferPartAsync(request, peerId, RemoteFileTransferProtocol.Write, ct)),
@@ -76,14 +81,18 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
                 RemoteToolErrorCodes.ProtocolMismatch,
                 "tools/list requires an active workspace lease.");
 
+        using var call = _leases.EnterCall(scope.LeaseId, scope.WorkspaceId);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, call.Token);
+        cancellationToken = linked.Token;
         var workspacePath = _leases.Validate(scope.LeaseId, scope.WorkspaceId);
         var state = RequireState();
         RequirePeer(state, peerId, scope.WorkspaceId);
-        var runtime = await GetRuntimeAsync(scope.WorkspaceId, workspacePath, state, cancellationToken)
+        var runtime = await GetRuntimeAsync(scope.LeaseId, scope.WorkspaceId, workspacePath, state, cancellationToken)
             .ConfigureAwait(false);
         return new ListToolsResult
         {
-            Tools = runtime.Registrations.Select(registration => ToMcpTool(registration, state)).ToList()
+            Tools = runtime.Registrations.Concat(runtime.PluginRegistrations(scope.ThreadId))
+                .Select(registration => ToMcpTool(registration, state)).ToList()
         };
     }
 
@@ -97,6 +106,9 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
         try
         {
             invocation = ParseInvocationMeta(request.Params.Meta);
+            using var leaseCall = _leases.EnterCall(invocation.LeaseId, invocation.WorkspaceId);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, leaseCall.Token);
+            cancellationToken = linked.Token;
             var workspacePath = _leases.Validate(invocation.LeaseId, invocation.WorkspaceId);
             var state = RequireState();
             var peer = RequirePeer(state, peerId, invocation.WorkspaceId);
@@ -110,12 +122,15 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
             }
 
             var runtime = await GetRuntimeAsync(
+                invocation.LeaseId,
                 invocation.WorkspaceId,
                 workspacePath,
                 state,
                 cancellationToken).ConfigureAwait(false);
-            var registration = runtime.Registrations.FirstOrDefault(item =>
-                string.Equals(item.Definition.Name.ToString(), request.Params.Name, StringComparison.Ordinal));
+            var registration = invocation.PreparedBinding is not null
+                ? runtime.Plugins.Resolve(invocation)
+                : runtime.Registrations.FirstOrDefault(item =>
+                    string.Equals(item.Definition.Name.ToString(), request.Params.Name, StringComparison.Ordinal));
             if (registration is null)
                 throw new RemoteToolHostException(
                     RemoteToolErrorCodes.RemoteToolUnavailable,
@@ -124,7 +139,8 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
 
             var definitionId = registration.Definition.Id.ToString();
             var contractHash = RemoteToolContractHasher.Compute(registration.Definition);
-            if (!string.Equals(definitionId, invocation.DefinitionId, StringComparison.Ordinal)
+            if (!string.Equals(registration.Definition.Name.ToString(), request.Params.Name, StringComparison.Ordinal)
+                || !string.Equals(definitionId, invocation.DefinitionId, StringComparison.Ordinal)
                 || !string.Equals(contractHash, invocation.ContractHash, StringComparison.Ordinal))
             {
                 throw new RemoteToolHostException(
@@ -133,20 +149,12 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
                     invocation.InvocationId);
             }
 
-            var toolName = registration.Definition.Name.Name;
+            var toolName = registration.Definition.Name.ToString();
             using var activity = _activity?.Begin(peerId, toolName, ReadCommandPreview(request.Params.Arguments));
             RequireBoundTerminal(toolName, request.Params.Arguments, invocation);
             var approval = new HostInvocationApprovalService.Invocation(
                 peer, invocation.InvocationId, workspacePath, _approvalPresenter, cancellationToken);
             using var approvalScope = HostInvocationApprovalService.Begin(approval);
-            await AuthorizeAsync(toolName, request.Params.Arguments, state, approval, workspacePath, cancellationToken)
-                .ConfigureAwait(false);
-            var currentPeer = RequirePeer(RequireState(), peerId, invocation.WorkspaceId);
-            if (currentPeer.AuthorizationRevision != peer.AuthorizationRevision)
-                throw new RemoteToolHostException(RemoteToolErrorCodes.RemotePolicyDenied, "Authorization changed.");
-            if (toolName == "LSP")
-                await runtime.InitializeLspAsync(cancellationToken).ConfigureAwait(false);
-
             var arguments = new JsonObject();
             foreach (var (name, value) in request.Params.Arguments ?? new Dictionary<string, JsonElement>())
                 arguments[name] = JsonNode.Parse(value.GetRawText());
@@ -165,8 +173,13 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
             var terminalsBeforeExec = string.Equals(toolName, "Exec", StringComparison.Ordinal)
                 ? await SnapshotTerminalIdsAsync(runtime, cancellationToken).ConfigureAwait(false)
                 : null;
-            var result = await registration.Binding.Runtime.InvokeAsync(context, arguments, cancellationToken)
-                .ConfigureAwait(false);
+            var policy = new HostDispatchPolicy(this, state, peer, invocation, approval, runtime);
+            var dispatcher = new ToolDispatcher(policyEvaluator: policy, approvalEvaluator: policy,
+                resultNormalizer: new DefaultToolResultNormalizer(maxModelContentCharacters: 0));
+            var snapshot = new EffectiveToolSnapshotBuilder().Build([registration], invocation.SnapshotRevision ?? 0);
+            var result = await dispatcher.DispatchAsync(snapshot, registration.Definition.Name, arguments,
+                new(context.ThreadId, context.TurnId, context.CallId, context.Audience, context.Origin, workspacePath),
+                cancellationToken).ConfigureAwait(false);
             if (terminalsBeforeExec is not null)
             {
                 var current = await SnapshotTerminalIdsAsync(runtime, cancellationToken).ConfigureAwait(false);
@@ -232,6 +245,7 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _leases.ReleaseAll();
+        await _leases.WaitForAllDrainsAsync().ConfigureAwait(false);
         HostWorkspaceRuntime[] runtimes;
         lock (_gate)
         {
@@ -266,7 +280,7 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
             contracts,
             state.Workspaces.Where(pair => pair.Key == peer.WorkspaceId).OrderBy(pair => pair.Key, StringComparer.Ordinal)
                 .Select(pair => ToCatalogEntry(pair.Key, pair.Value, parameters.ClientInstanceId))
-                .ToArray(), ["files-v1"]);
+                .ToArray(), ["files-v1", RemotePluginProtocol.Capability]);
         return JsonSerializer.SerializeToNode(response, RemoteToolHostProtocol.JsonOptions);
     }
 
@@ -301,7 +315,7 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
             parameters.LeaseId,
             parameters.WorkspaceId);
         if (finalRelease)
-            await DisposeRuntimeAsync(parameters.WorkspaceId).ConfigureAwait(false);
+            await _leases.WaitForDrainAsync(parameters.WorkspaceId).ConfigureAwait(false);
         return new JsonObject();
     }
 
@@ -321,15 +335,17 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
     }
 
     private async Task<HostWorkspaceRuntime> GetRuntimeAsync(
+        string leaseId,
         string workspaceId,
         string workspacePath,
         RemoteToolHostState state,
         CancellationToken cancellationToken)
     {
+        _leases.Validate(leaseId, workspaceId);
         lock (_gate)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (_runtimes.TryGetValue(workspaceId, out var cached)
-                && cached.CatalogRevision == state.CatalogRevision
                 && PathsEqual(cached.WorkspacePath, workspacePath))
                 return cached;
         }
@@ -342,23 +358,35 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
             _storage.RootPath,
             cancellationToken).ConfigureAwait(false);
         HostWorkspaceRuntime? retired = null;
-        lock (_gate)
+        try
         {
-            if (_runtimes.TryGetValue(workspaceId, out var current)
-                && current.CatalogRevision == state.CatalogRevision
-                && PathsEqual(current.WorkspacePath, workspacePath))
+            _leases.CommitArtifact(leaseId, workspaceId, () =>
             {
-                retired = runtime;
-                runtime = current;
-            }
-            else
-            {
-                _runtimes.TryGetValue(workspaceId, out retired);
-                _runtimes[workspaceId] = runtime;
-            }
+                cancellationToken.ThrowIfCancellationRequested();
+                lock (_gate)
+                {
+                    if (_runtimes.TryGetValue(workspaceId, out var current)
+                        && PathsEqual(current.WorkspacePath, workspacePath))
+                    {
+                        retired = runtime;
+                        runtime = current;
+                    }
+                    else
+                    {
+                        _runtimes.TryGetValue(workspaceId, out retired);
+                        _runtimes[workspaceId] = runtime;
+                    }
+                }
+            });
+        }
+        catch
+        {
+            await runtime.DisposeAsync().ConfigureAwait(false);
+            throw;
         }
         if (retired is not null)
             await retired.DisposeAsync().ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
         return runtime;
     }
 
@@ -495,7 +523,7 @@ internal sealed partial class RemoteToolHostMcpHandlers : IAsyncDisposable
     private static IList<ContentBlock> ToMcpContent(ToolExecutionResult result)
     {
         if (result.ContentItems is not { Count: > 0 })
-            return [new TextContentBlock { Text = result.Content ?? string.Empty }];
+            return [new TextContentBlock { Text = result.Content ?? result.Error?.Message ?? string.Empty }];
 
         var content = new List<ContentBlock>();
         foreach (var item in result.ContentItems)

--- a/src/DotCraft.RemoteTools/RemoteToolHostOutboundHost.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostOutboundHost.cs
@@ -35,7 +35,6 @@ internal sealed class RemoteToolHostOutboundHost : IAsyncDisposable
             onReleased: released =>
             {
                 _leaseTerminals.ReleaseLease(released.LeaseId);
-                _handlers!.ReleaseFileTransfers(released.LeaseId);
                 RemoteToolArtifactStore.CleanupLeaseArtifacts(storage.ArtifactsRootPath, released.LeaseId);
             },
             onChanged: () => Changed?.Invoke());

--- a/src/DotCraft.RemoteTools/RemoteToolHostProtocol.cs
+++ b/src/DotCraft.RemoteTools/RemoteToolHostProtocol.cs
@@ -112,7 +112,7 @@ internal sealed record WorkspaceCatalogEntry(
     bool Busy,
     string? BusyOwner = null,
     DateTimeOffset? LeaseExpiresAt = null);
-internal sealed record RemoteCatalogScope(string LeaseId, string WorkspaceId);
+internal sealed record RemoteCatalogScope(string LeaseId, string WorkspaceId, string? ThreadId = null);
 internal sealed record WorkspaceAcquireRequest(
     string ProfileVersion,
     string ClientInstanceId,
@@ -142,7 +142,9 @@ internal sealed record RemoteInvocationMeta(
     string? ThreadId,
     string? TurnId,
     int MaxResultChars,
-    int SpillPreviewLines);
+    int SpillPreviewLines,
+    string? PreparedBinding = null,
+    long? SnapshotRevision = null);
 
 internal sealed record RemoteToolArtifactMeta(string Path, long CharacterCount);
 

--- a/src/DotCraft.RemoteTools/WorkspaceLeaseManager.cs
+++ b/src/DotCraft.RemoteTools/WorkspaceLeaseManager.cs
@@ -22,6 +22,7 @@ internal sealed class WorkspaceLeaseManager(
     private ITimer? _expiry;
     private bool _changed;
     private bool _disposed;
+    internal Func<WorkspaceLeaseReleased, Task, Task>? DrainResourcesAsync { get; set; }
 
     public WorkspaceAcquireResponse Acquire(
         string ownerId,
@@ -33,7 +34,7 @@ internal sealed class WorkspaceLeaseManager(
         ReapExpiredCore();
         if (_byWorkspace.TryGetValue(workspaceId, out var existing))
         {
-            if (!string.Equals(existing.OwnerId, ownerId, StringComparison.Ordinal))
+            if (existing.Releasing || !string.Equals(existing.OwnerId, ownerId, StringComparison.Ordinal))
                 throw new RemoteToolHostException(
                     Tools.RemoteToolErrorCodes.WorkspaceBusy,
                     $"Workspace '{workspaceId}' is leased by another Agent Host.");
@@ -78,6 +79,22 @@ internal sealed class WorkspaceLeaseManager(
     });
 
     public string Validate(string leaseId, string workspaceId) => Locked(() => Find(leaseId, workspaceId).WorkspacePath);
+
+    public LeaseCall EnterCall(string leaseId, string workspaceId) => Locked(() =>
+    {
+        var lease = Find(leaseId, workspaceId);
+        lease.Calls++;
+        return new LeaseCall(lease.Stopping.Token, () => Locked(() =>
+        {
+            if (--lease.Calls == 0 && lease.Releasing) lease.Drained.TrySetResult();
+        }));
+    });
+
+    public Task WaitForDrainAsync(string workspaceId) => Locked(() =>
+        _byWorkspace.TryGetValue(workspaceId, out var lease) ? lease.Cleanup ?? Task.CompletedTask : Task.CompletedTask);
+
+    public Task WaitForAllDrainsAsync() => Locked(() => Task.WhenAll(_byWorkspace.Values
+        .Select(lease => lease.Cleanup ?? Task.CompletedTask)));
 
     public void CommitArtifact(string leaseId, string workspaceId, Action commit) => Locked(() =>
     {
@@ -214,13 +231,36 @@ internal sealed class WorkspaceLeaseManager(
 
     private void RemoveCore(Lease lease)
     {
-        _byId.Remove(lease.LeaseId);
-        _byWorkspace.Remove(lease.WorkspaceId);
+        if (!_byId.Remove(lease.LeaseId)) return;
+        lease.Releasing = true;
+        if (lease.Calls == 0) lease.Drained.TrySetResult();
         _changed = true;
-        _onReleased?.Invoke(new WorkspaceLeaseReleased(
-            lease.LeaseId,
-            lease.WorkspaceId,
-            lease.WorkspacePath));
+        if (DrainResourcesAsync is null && lease.Calls == 0)
+        {
+            _byWorkspace.Remove(lease.WorkspaceId);
+            _onReleased?.Invoke(new(lease.LeaseId, lease.WorkspaceId, lease.WorkspacePath));
+            lease.Stopping.Dispose();
+        }
+        else lease.Cleanup = FinishReleaseAsync(lease);
+    }
+
+    private async Task FinishReleaseAsync(Lease lease)
+    {
+        await Task.Yield();
+        var cancellation = lease.Stopping.CancelAsync();
+        var released = new WorkspaceLeaseReleased(lease.LeaseId, lease.WorkspaceId, lease.WorkspacePath);
+        var resources = DrainResourcesAsync?.Invoke(released, lease.Drained.Task) ?? Task.CompletedTask;
+        await Task.WhenAll(cancellation, lease.Drained.Task, resources).ConfigureAwait(false);
+        _onReleased?.Invoke(released);
+        lease.Stopping.Dispose();
+        Locked(() => { _byWorkspace.Remove(lease.WorkspaceId); _changed = true; });
+    }
+
+    internal sealed class LeaseCall(CancellationToken token, Action release) : IDisposable
+    {
+        private Action? _release = release;
+        public CancellationToken Token => token;
+        public void Dispose() => Interlocked.Exchange(ref _release, null)?.Invoke();
     }
 
     private sealed class Lease
@@ -231,6 +271,11 @@ internal sealed class WorkspaceLeaseManager(
         public required string WorkspacePath { get; init; }
         public required DateTimeOffset ExpiresAt { get; set; }
         public int ReferenceCount { get; set; }
+        public bool Releasing { get; set; }
+        public int Calls { get; set; }
+        public CancellationTokenSource Stopping { get; } = new();
+        public TaskCompletionSource Drained { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task? Cleanup { get; set; }
 
         public WorkspaceAcquireResponse ToResponse(string hostInstanceId, long catalogRevision) =>
             new(LeaseId, WorkspaceId, WorkspacePath, ExpiresAt, hostInstanceId, catalogRevision);

--- a/src/DotCraft.Runtime/DotCraft.Runtime.csproj
+++ b/src/DotCraft.Runtime/DotCraft.Runtime.csproj
@@ -22,6 +22,9 @@
       <_Parameter1>DotCraft.Core.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DotCraft.App.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>DotCraft.Harness</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>

--- a/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeExport.cs
+++ b/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeExport.cs
@@ -1,0 +1,129 @@
+using DotCraft.Plugins;
+using DotCraft.Tools;
+
+namespace DotCraft.Runtime;
+
+internal sealed partial class DotNetPluginRuntimeManager
+{
+    private readonly object _exportGate = new();
+    private int _exportCount;
+    private TaskCompletionSource? _exportsDrained;
+
+    internal async ValueTask<RemoteToolSourceExport> ExportAsync(
+        string pluginId, string generationId, CancellationToken cancellationToken)
+    {
+        await _mutationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var files = new List<RemotePluginBundleFiles>();
+        var pinned = false;
+        try
+        {
+            ThrowIfDisposed();
+            if (!_nodes.TryGetValue(pluginId, out var selected) || selected.GenerationId != generationId)
+                throw new InvalidOperationException("The selected plugin generation is no longer active.");
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            Visit(selected);
+            lock (_exportGate)
+            {
+                if (_exportCount++ == 0) _exportsDrained = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                pinned = true;
+            }
+            return new RemoteToolSourceExport(files.ToArray(), Release);
+
+            void Visit(PluginRuntimeNode node)
+            {
+                if (!visited.Add(node.Snapshot.Manifest.Id)) return;
+                if (node.State != PluginDotnetRuntimeState.Active || node.Generation is null
+                    || !CallGates.IsCallable(node.Snapshot.Manifest.Id, node.GenerationId!))
+                    throw new InvalidOperationException("The selected plugin generation is no longer active.");
+                foreach (var dependency in node.Snapshot.Manifest.Dependencies.Keys)
+                    Visit(_nodes[dependency]);
+                var root = _bundleStore.CreateGenerationCopy(node.Snapshot, "export-" + Guid.NewGuid().ToString("N"));
+                files.Add(new(new(node.Snapshot.Manifest.Id, node.GenerationId!, node.GenerationRevision,
+                    node.Snapshot.ContentFingerprint, node.Snapshot.DotnetFingerprint, node.Settings!.Value.Clone()), root));
+            }
+        }
+        catch { Release(); throw; }
+        finally { _mutationLock.Release(); }
+
+        void Release()
+        {
+            foreach (var file in files) _bundleStore.DeleteGeneration(file.RootPath);
+            lock (_exportGate)
+                if (pinned && --_exportCount == 0) _exportsDrained!.TrySetResult();
+        }
+    }
+
+    private Task WaitForExportsAsync()
+    {
+        lock (_exportGate) return _exportCount == 0 ? Task.CompletedTask : _exportsDrained!.Task;
+    }
+
+    internal async Task PrepareExecutionAsync(
+        IReadOnlyList<RemotePluginBundleFiles> bundles, CancellationToken cancellationToken)
+    {
+        if (!_executionOnly) throw new InvalidOperationException("This runtime does not accept execution bundles.");
+        await _mutationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var accepted = new List<(RemotePluginBundle Bundle, PluginAcceptedSnapshot Snapshot)>();
+        try
+        {
+            ThrowIfDisposed();
+            foreach (var files in bundles)
+            {
+                var bundle = files.Bundle;
+                var parsed = PluginManifestParser.Load(files.RootPath);
+                if (parsed.Manifest?.Id != bundle.PluginId || parsed.Manifest.Dotnet is null)
+                    throw new InvalidOperationException("The prepared bundle identity is invalid.");
+                var snapshot = _bundleStore.Accept(new(parsed.Manifest, PluginDiscoverySourceKind.Explicit, files.RootPath, true));
+                accepted.Add((bundle, snapshot));
+                if (snapshot.ContentFingerprint != bundle.ContentFingerprint || snapshot.DotnetFingerprint != bundle.DotnetFingerprint
+                    || PreflightBlockers(snapshot).Length != 0)
+                    throw new InvalidOperationException("The prepared bundle failed fingerprint or ABI validation.");
+            }
+
+            foreach (var (bundle, snapshot) in accepted)
+            {
+                if (_nodes.TryGetValue(bundle.PluginId, out var previous))
+                {
+                    if (previous.Snapshot.ContentFingerprint == bundle.ContentFingerprint
+                        && previous.ExecutionSourceGeneration == bundle.SourceGeneration
+                        && previous.Settings?.GetRawText() == bundle.Settings.GetRawText()
+                        && previous.State == PluginDotnetRuntimeState.Active)
+                        continue;
+                    if (!await StopClosureAsync(bundle.PluginId, previous, cancellationToken).ConfigureAwait(false))
+                        throw new InvalidOperationException("The previous plugin generation is still draining.");
+                    _bundleStore.DeleteAccepted(previous.Snapshot.ContentRoot);
+                    _nodes.Remove(bundle.PluginId);
+                }
+                _executionQualifications[bundle.PluginId] = bundle.DotnetFingerprint;
+                _nodes.Add(bundle.PluginId, new(snapshot, true, _paths.WorkspacePath)
+                {
+                    Settings = bundle.Settings.Clone(),
+                    ExecutionSourceGeneration = bundle.SourceGeneration
+                });
+            }
+            await ReplanAllAsync(_nodes.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase), cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            PublishSnapshot();
+            foreach (var (bundle, _) in accepted)
+                if (_nodes[bundle.PluginId].State != PluginDotnetRuntimeState.Active)
+                    throw new InvalidOperationException($"Plugin '{bundle.PluginId}' could not activate in the execution host. "
+                        + string.Join(" ", _nodes[bundle.PluginId].Blockers.Select(blocker => $"{blocker.Code}: {blocker.Message}")));
+        }
+        catch (OperationCanceledException)
+        {
+            foreach (var (bundle, snapshot) in accepted)
+                if (_nodes.TryGetValue(bundle.PluginId, out var node) && ReferenceEquals(node.Snapshot, snapshot))
+                    await StopClosureAsync(bundle.PluginId, node, CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+        finally
+        {
+            foreach (var (_, snapshot) in accepted)
+                if (!_nodes.Values.Any(node => ReferenceEquals(node.Snapshot, snapshot)))
+                    _bundleStore.DeleteAccepted(snapshot.ContentRoot);
+            _mutationLock.Release();
+        }
+    }
+
+    private readonly Dictionary<string, string> _executionQualifications = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeGenerations.cs
+++ b/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeGenerations.cs
@@ -7,7 +7,7 @@ namespace DotCraft.Runtime;
 /// <summary>The generation half of the runtime manager: one activation transaction and one teardown.</summary>
 internal sealed partial class DotNetPluginRuntimeManager
 {
-    private async Task ActivateNodeAsync(PluginRuntimeNode node, CancellationToken _)
+    private async Task ActivateNodeAsync(PluginRuntimeNode node, CancellationToken cancellationToken)
     {
         if (node.Generation != null || node.PendingActivation != null || node.PendingTeardown != null)
             return;
@@ -32,7 +32,8 @@ internal sealed partial class DotNetPluginRuntimeManager
         node.PendingRemnant = null;
         node.State = PluginDotnetRuntimeState.Activating;
         node.Blockers = [];
-        var generationId = $"g{Interlocked.Increment(ref _generationSequence):x}-{Guid.NewGuid():N}";
+        node.GenerationRevision = Interlocked.Increment(ref _generationSequence);
+        var generationId = $"g{node.GenerationRevision:x}-{Guid.NewGuid():N}";
         node.GenerationId = generationId;
         PublishSnapshot();
 
@@ -61,16 +62,18 @@ internal sealed partial class DotNetPluginRuntimeManager
             return;
         }
 
-        using var activationCts = new CancellationTokenSource();
+        using var activationCts = _executionOnly
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken) : new CancellationTokenSource();
         var commitGate = new PluginActivationCommitGate();
         var dataRoot = PluginDataPaths.Resolve(_paths, node.Snapshot.Manifest.Id);
         Directory.CreateDirectory(dataRoot);
         JsonElement settings;
         try
         {
-            settings = node.Snapshot.Manifest.Settings == null
+            settings = (_executionOnly ? node.Settings : null) ?? (node.Snapshot.Manifest.Settings == null
                 ? JsonSerializer.Deserialize<JsonElement>("{}"u8)
-                : _pluginConfigStore.Get(node.Snapshot.Manifest).Value;
+                : _pluginConfigStore.Get(node.Snapshot.Manifest).Value);
+            node.Settings = settings.Clone();
         }
         catch (PluginConfigException exception)
         {
@@ -97,7 +100,7 @@ internal sealed partial class DotNetPluginRuntimeManager
             dataRoot,
             node.WorkspaceRoot,
             settings,
-            new PluginGenerationHost(_services, _contributions, CallGates),
+            new PluginGenerationHost(_services, _contributions, CallGates, _executionOnly),
             GetDirectProviderGenerations(node),
             commitGate,
             TrustCommitBlocker,
@@ -106,8 +109,19 @@ internal sealed partial class DotNetPluginRuntimeManager
         PluginActivationAttempt attempt;
         try
         {
-            attempt = await activation.WaitAsync(_options.ActivationTimeout)
+            attempt = await activation.WaitAsync(_options.ActivationTimeout,
+                    _executionOnly ? cancellationToken : CancellationToken.None)
                 .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (_executionOnly && cancellationToken.IsCancellationRequested)
+        {
+            commitGate.TryCancel();
+            await activationCts.CancelAsync().ConfigureAwait(false);
+            var teardown = AbandonedActivationAsync(activation, node.Snapshot.Manifest.Id, generationId, shadowRoot);
+            node.PendingTeardown = teardown;
+            node.PendingTeardownCompletedState = PluginDotnetRuntimeState.Stopped;
+            await AwaitPendingTeardownAsync(node, teardown).ConfigureAwait(false);
+            throw;
         }
         catch (TimeoutException)
         {

--- a/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeManager.cs
+++ b/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeManager.cs
@@ -35,6 +35,7 @@ internal sealed partial class DotNetPluginRuntimeManager :
     private bool _started;
     private volatile bool _stopping;
     private bool _disposed;
+    private readonly bool _executionOnly;
 
     /// <summary>Creates a runtime manager for one configured workspace.</summary>
     internal DotNetPluginRuntimeManager(
@@ -46,7 +47,8 @@ internal sealed partial class DotNetPluginRuntimeManager :
         DotNetPluginRuntimeOptions? options = null,
         ILogger<DotNetPluginRuntimeManager>? logger = null,
         IPluginDotnetTrustStore? trustStore = null,
-        PluginConfigStore? pluginConfigStore = null)
+        PluginConfigStore? pluginConfigStore = null,
+        bool executionOnly = false)
     {
         _discovery = discovery;
         _config = config;
@@ -55,6 +57,7 @@ internal sealed partial class DotNetPluginRuntimeManager :
         _services = services;
         _contributions = contributions;
         _options = options ?? new DotNetPluginRuntimeOptions();
+        _executionOnly = executionOnly;
         _logger = logger;
         _trust = new PluginDotnetTrust(config, trustStore);
         _bundleStore = new PluginBundleSnapshotStore(Path.Combine(
@@ -64,7 +67,7 @@ internal sealed partial class DotNetPluginRuntimeManager :
             $"{Environment.ProcessId}-{Guid.NewGuid():N}"));
         _reclaim = new PluginReclaimPoller(_options, ReclaimAsync, _bundleStore.DeleteGeneration, logger);
         CallGates = new PluginCallGateRegistry();
-        ToolSource = new DotNetPluginToolSource(contributions, CallGates);
+        ToolSource = new DotNetPluginToolSource(contributions, CallGates, ExportAsync);
         _trust.Changed += OnTrustChanged;
     }
 
@@ -189,6 +192,7 @@ internal sealed partial class DotNetPluginRuntimeManager :
         {
             await StopAsync(CancellationToken.None).ConfigureAwait(false);
             await WaitForTrustChangeWorkerAsync().ConfigureAwait(false);
+            await WaitForExportsAsync().ConfigureAwait(false);
 
             // Retained assemblies are mapped from the shadow copies, so the store only goes once nothing is outstanding.
             if (!_reclaim.HasOutstanding

--- a/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeTrust.cs
+++ b/src/DotCraft.Runtime/Plugins/DotNetPluginRuntimeTrust.cs
@@ -120,7 +120,8 @@ internal sealed partial class DotNetPluginRuntimeManager
     /// <summary>Re-reads the machine authority immediately before an activation is published.</summary>
     private PluginRuntimeBlocker? TrustCommitBlocker(string pluginId, string fingerprint)
     {
-        if (HasAuthoringExecutionQualification(pluginId, fingerprint))
+        if ((_executionOnly && _executionQualifications.TryGetValue(pluginId, out var qualified) && qualified == fingerprint)
+            || HasAuthoringExecutionQualification(pluginId, fingerprint))
             return null;
 
         var status = _trust.ResolveStatus(pluginId, fingerprint);

--- a/src/DotCraft.Runtime/Plugins/DotNetPluginToolProjection.cs
+++ b/src/DotCraft.Runtime/Plugins/DotNetPluginToolProjection.cs
@@ -18,7 +18,8 @@ internal static class DotNetPluginToolProjection
         string generationId,
         ToolPlanningContext planning,
         ToolRegistration contributed,
-        long revision)
+        long revision,
+        Func<string, string, CancellationToken, ValueTask<RemoteToolSourceExport>> export)
     {
         var toolId = contributed.Definition.Id.SourceToolId.Value;
         var definitionId = new ToolDefinitionId(
@@ -31,7 +32,8 @@ internal static class DotNetPluginToolProjection
             pluginId,
             generationId,
             toolId,
-            planning);
+            planning,
+            export);
         var binding = new ToolRuntimeBinding(
             new RuntimeBindingId($"{DotNetPluginToolSource.Id}:{pluginId}:{generationId}:{toolId}:{revision}"),
             definitionId,
@@ -123,8 +125,14 @@ internal sealed class DotNetPluginToolProxy(
     string pluginId,
     string generationId,
     string toolId,
-    ToolPlanningContext planning) : IToolRuntime, IToolBindingLease
+    ToolPlanningContext planning,
+    Func<string, string, CancellationToken, ValueTask<RemoteToolSourceExport>> export)
+    : IToolRuntime, IToolBindingLease, IRemoteToolSourceBinding
 {
+    public string SourceId => pluginId;
+    public ValueTask<RemoteToolSourceExport> ExportAsync(CancellationToken cancellationToken = default) =>
+        export(pluginId, generationId, cancellationToken);
+
     public ValueTask<ToolBindingLeaseResult> CheckAsync(
         ToolInvocationContext context,
         CancellationToken cancellationToken = default)

--- a/src/DotCraft.Runtime/Plugins/DotNetPluginToolSource.cs
+++ b/src/DotCraft.Runtime/Plugins/DotNetPluginToolSource.cs
@@ -16,15 +16,18 @@ internal sealed class DotNetPluginToolSource : IToolSource, IThreadScopedToolSou
 
     private readonly IContributionView _contributions;
     private readonly PluginCallGateRegistry _callGates;
+    private readonly Func<string, string, CancellationToken, ValueTask<RemoteToolSourceExport>> _export;
     private volatile IReadOnlyList<PluginDiagnostic> _diagnostics = [];
     private volatile IReadOnlyDictionary<string, IReadOnlyList<PluginRuntimeToolInfo>> _described =
         new Dictionary<string, IReadOnlyList<PluginRuntimeToolInfo>>(StringComparer.Ordinal);
 
     /// <summary>Creates the aggregate plugin Tool source.</summary>
-    internal DotNetPluginToolSource(IContributionView contributions, PluginCallGateRegistry callGates)
+    internal DotNetPluginToolSource(IContributionView contributions, PluginCallGateRegistry callGates,
+        Func<string, string, CancellationToken, ValueTask<RemoteToolSourceExport>> export)
     {
         _contributions = contributions ?? throw new ArgumentNullException(nameof(contributions));
         _callGates = callGates ?? throw new ArgumentNullException(nameof(callGates));
+        _export = export;
     }
 
     /// <inheritdoc />
@@ -85,7 +88,8 @@ internal sealed class DotNetPluginToolSource : IToolSource, IThreadScopedToolSou
                     generationId,
                     context,
                     registration,
-                    revision);
+                    revision,
+                    _export);
                 registrations.Add(wrapped);
                 Describe(described, pluginId, generationId, wrapped.Definition);
             }

--- a/src/DotCraft.Runtime/Plugins/PluginAcceptedSnapshot.cs
+++ b/src/DotCraft.Runtime/Plugins/PluginAcceptedSnapshot.cs
@@ -27,6 +27,11 @@ internal sealed class PluginRuntimeNode(
 
     public string? GenerationId { get; set; }
 
+    public long GenerationRevision { get; set; }
+    public string? ExecutionSourceGeneration { get; set; }
+
+    public System.Text.Json.JsonElement? Settings { get; set; }
+
     public IReadOnlyList<PluginRuntimeBlocker> Blockers { get; set; } = [];
 
     public PluginGeneration? Generation { get; set; }

--- a/src/DotCraft.Runtime/Plugins/PluginContributionRegistrar.cs
+++ b/src/DotCraft.Runtime/Plugins/PluginContributionRegistrar.cs
@@ -13,14 +13,17 @@ internal sealed class PluginContributionRegistrar : IContributionRegistrar
     private object? _generationOwnedEntry;
     private int _preparing;
     private RegistrarState _state;
+    private readonly bool _toolsOnly;
 
     public PluginContributionRegistrar(
         IContributionRegistry registry,
         ContributionOrigin origin,
         PluginCallGate callGate,
-        object generationOwnedEntry)
+        object generationOwnedEntry,
+        bool toolsOnly = false)
     {
         _registry = registry;
+        _toolsOnly = toolsOnly;
         _inner = registry.CreateRegistrar(origin);
         _invocation = new PluginInvocation(origin.Name!, origin.Generation!, callGate);
         _generationOwnedEntry = generationOwnedEntry ?? throw new ArgumentNullException(nameof(generationOwnedEntry));
@@ -34,6 +37,8 @@ internal sealed class PluginContributionRegistrar : IContributionRegistrar
         where TContract : class, IContributionContract
     {
         ArgumentNullException.ThrowIfNull(contribution);
+        if (_toolsOnly && typeof(TContract) != typeof(DotCraft.Tools.IToolSource))
+            throw new InvalidOperationException($"The execution host does not support contribution '{typeof(TContract).FullName}'.");
         Registration<TContract> registration;
         lock (_gate)
         {

--- a/src/DotCraft.Runtime/Plugins/PluginExecutionHost.cs
+++ b/src/DotCraft.Runtime/Plugins/PluginExecutionHost.cs
@@ -1,0 +1,39 @@
+using DotCraft.Configuration;
+using DotCraft.Contributions;
+using DotCraft.Plugins;
+using DotCraft.Tools;
+using DotCraft.Workspaces;
+
+namespace DotCraft.Runtime;
+
+/// <summary>Runs explicitly admitted plugin bundles without composing an Agent or Session runtime.</summary>
+public sealed class PluginExecutionHost : IAsyncDisposable
+{
+    private readonly ContributionRegistry _contributions = new();
+    private readonly DotNetPluginRuntimeManager _runtime;
+
+    public PluginExecutionHost(DotCraftPaths paths, IServiceProvider services)
+    {
+        _runtime = new DotNetPluginRuntimeManager(new PluginDiscoveryService(), new AppConfig(), paths,
+            services, _contributions, executionOnly: true);
+    }
+
+    public Task PrepareAsync(IReadOnlyList<RemotePluginBundleFiles> bundles, CancellationToken cancellationToken = default) =>
+        _runtime.PrepareExecutionAsync(bundles, cancellationToken);
+
+    public static bool MatchesBundle(string rootPath, RemotePluginBundle bundle) =>
+        PluginBundleFingerprint.Compute(rootPath) == bundle.ContentFingerprint
+        && PluginDotnetFingerprint.Compute(rootPath) == bundle.DotnetFingerprint;
+
+    public ValueTask<IReadOnlyList<ToolRegistration>> GetRegistrationsAsync(
+        ToolPlanningContext context, CancellationToken cancellationToken = default) =>
+        _runtime.ToolSource.GetRegistrationsAsync(context, cancellationToken);
+
+    public async ValueTask ReleaseThreadAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        await _runtime.ToolSource.ReleaseThreadAsync(threadId, cancellationToken).ConfigureAwait(false);
+        _contributions.ReleaseThread(threadId);
+    }
+
+    public ValueTask DisposeAsync() => _runtime.DisposeAsync();
+}

--- a/src/DotCraft.Runtime/Plugins/PluginGeneration.cs
+++ b/src/DotCraft.Runtime/Plugins/PluginGeneration.cs
@@ -10,7 +10,8 @@ namespace DotCraft.Runtime;
 internal sealed record PluginGenerationHost(
     IServiceProvider Services,
     IContributionRegistry Contributions,
-    PluginCallGateRegistry CallGates);
+    PluginCallGateRegistry CallGates,
+    bool ToolsOnly = false);
 
 /// <summary>What a torn-down generation leaves behind for the reclaim poller.</summary>
 /// <param name="LoadContext">Weak by construction: a poller able to keep the context alive could never observe its collection.</param>
@@ -155,7 +156,8 @@ internal sealed class PluginGeneration
                 host.Contributions,
                 ContributionOrigin.Plugin(snapshot.Manifest.Id, generationId),
                 calls,
-                entry);
+                entry,
+                host.ToolsOnly);
             exports = new PluginServiceExportRegistry(
                 snapshot.Manifest.Id,
                 new HashSet<Assembly>(exportedApis.Values, ReferenceEqualityComparer.Instance));

--- a/tests/DotCraft.App.Tests/DotCraft.App.Tests.csproj
+++ b/tests/DotCraft.App.Tests/DotCraft.App.Tests.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\DotCraft.Core.Tests\Tools\RemotePluginFixture.cs" Link="Hub\Support\RemotePluginFixture.cs" />
+    <Compile Include="..\DotCraft.Runtime.Tests\Plugins\DotNetPluginTestBundle.cs" Link="Hub\Support\DotNetPluginTestBundle.cs" />
+    <Compile Include="..\DotCraft.Runtime.Tests\Plugins\PluginRuntimeHarness.cs" Link="Hub\Support\PluginRuntimeHarness.cs" />
+    <Compile Include="..\DotCraft.Runtime.Tests\Plugins\PluginLogFile.cs" Link="Hub\Support\PluginLogFile.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DotCraft.App.Tests/Hub/SatelliteBridgeEndToEndTests.cs
+++ b/tests/DotCraft.App.Tests/Hub/SatelliteBridgeEndToEndTests.cs
@@ -21,7 +21,7 @@ public sealed class SatelliteBridgeEndToEndTests : IDisposable
         var approvals = new CountingApprovalService();
         await using var client = new RemoteToolHostClient(scenario.Directory, approvals);
         var registrations = await scenario.AgentRegistrationsAsync();
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
 
         var connected = await client.ConnectAsync("thread", scenario.PeerId, scenario.WorkspaceId);
         Assert.Contains("ReadFile", connected.MatchedTools);

--- a/tests/DotCraft.App.Tests/Hub/SatellitePluginEndToEndTests.cs
+++ b/tests/DotCraft.App.Tests/Hub/SatellitePluginEndToEndTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotCraft.Hub;
+using DotCraft.Plugins;
+using DotCraft.RemoteTools;
+using DotCraft.Tests.Runtime.Plugins;
+using DotCraft.Tests.Tools;
+using DotCraft.Tools;
+using Xunit;
+
+namespace DotCraft.Tests.Hub;
+
+public sealed class SatellitePluginEndToEndTests
+{
+    [Fact]
+    public async Task Bridge_SynchronizesAcceptedPluginAndEnforcesOwnerPolicy_ThenReleasesExecution()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        harness.CreatePluginConfigStore().Mutate(
+            PluginManifestParser.Load(harness.PluginRoot("probe")).Manifest!,
+            "personal", [new PluginConfigMutation("set", "label", JsonSerializer.SerializeToElement("agent-setting"))]);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        await File.WriteAllTextAsync(Path.Combine(harness.PluginRoot("probe"), "resource.txt"), "changed-after-acceptance");
+
+        await using var scenario = await SatelliteScenario.StartAsync(Path.Combine(harness.Root, "satellite"));
+        await using var client = new RemoteToolHostClient(scenario.Directory, new CountingApprovalService());
+        var planning = new ToolPlanningContext("plugin-thread", null, harness.Workspace,
+            Path.Combine(harness.Workspace, ".craft"), "agent", null, [], 1);
+        var registrations = await manager.ToolSource.GetRegistrationsAsync(planning);
+        var snapshot = new EffectiveToolSnapshotBuilder().Build(RemoteToolRegistrationRouter.Wrap(registrations, client), 1);
+        client.UpdateRemoteToolSnapshot("plugin-thread", snapshot, "agent");
+        var log = Path.Combine(scenario.WorkspacePath, "plugin-lifecycle.log");
+        Assert.False(File.Exists(log));
+
+        var connected = await client.ConnectAsync("plugin-thread", scenario.PeerId, scenario.WorkspaceId);
+
+        Assert.Contains("Probe.Run", connected.MatchedTools);
+        var result = await InvokeAsync(snapshot, "start");
+        Assert.True(result.Success, result.Error?.Message);
+        using var document = JsonDocument.Parse(result.Content!);
+        var data = document.RootElement;
+        Assert.Equal(scenario.WorkspacePath, data.GetProperty("workspace").GetString());
+        Assert.Equal("bundle-resource", data.GetProperty("resource").GetString());
+        Assert.Equal("agent-setting", data.GetProperty("settings").GetProperty("label").GetString());
+        Assert.Equal("plugin-thread", data.GetProperty("thread").GetString());
+        Assert.Equal("agent", data.GetProperty("mode").GetString());
+        Assert.True(data.GetProperty("running").GetBoolean());
+
+        scenario.DenyTool("Probe.Run");
+        var denied = await InvokeAsync(snapshot, "cancel");
+        Assert.False(denied.Success);
+        Assert.Equal(RemoteToolErrorCodes.RemotePolicyDenied, denied.Error?.Code);
+
+        Assert.True((await client.DisconnectAsync("plugin-thread")).Disconnected);
+        await PluginRuntimeHarness.WaitForLineAsync(log, "release:plugin-thread");
+        await PluginRuntimeHarness.WaitForLineAsync(log, "dispose:first");
+        await SatelliteBridgeEndToEndTests.WaitUntilAsync(async () =>
+        {
+            var peer = Assert.Single(await scenario.Hub.GetAsync<HubSatelliteResponse[]>("/v1/satellites"));
+            return peer.Online && peer.Workspaces.All(workspace => !workspace.Busy);
+        });
+        Assert.Equal(RemoteToolHostStatus.Standby, scenario.Runtime.Status);
+    }
+
+    private static ValueTask<ToolExecutionResult> InvokeAsync(EffectiveToolSnapshot snapshot, string operation) =>
+        new ToolDispatcher().DispatchAsync(snapshot, new("Probe", "Run"),
+            new JsonObject { ["operation"] = operation, ["target"] = "remote" },
+            new("plugin-thread", "turn", Guid.NewGuid().ToString("N"), ToolInvocationAudience.Model));
+}

--- a/tests/DotCraft.AppServer.Tests/Protocol/AppServer/AppServerRemoteToolHostTests.cs
+++ b/tests/DotCraft.AppServer.Tests/Protocol/AppServer/AppServerRemoteToolHostTests.cs
@@ -155,6 +155,7 @@ public sealed class AppServerRemoteToolHostTests
         Assert.Equal(["Exec"], result.GetProperty("matchedTools").EnumerateArray().Select(item => item.GetString()));
         Assert.Equal(["LSP"], result.GetProperty("unavailableTools").EnumerateArray().Select(item => item.GetString()));
         Assert.False(result.GetProperty("alreadyConnected").GetBoolean());
+        Assert.Equal(thread.Id, Assert.Single(client.PreparedThreads));
 
         var notification = Assert.Single(broadcasts);
         Assert.Equal(thread.Id, notification.ThreadId);
@@ -399,9 +400,15 @@ public sealed class AppServerRemoteToolHostTests
 
         public event Action<RemoteToolRouteChange>? RouteChanged;
 
-        public void UpdateRemoteToolDefinitions(IReadOnlyList<ToolDefinition> definitions)
+        public void UpdateRemoteToolSnapshot(string threadId, EffectiveToolSnapshot snapshot, string mode)
         {
+            PreparedThreads.Add(threadId);
         }
+
+        public List<string> PreparedThreads { get; } = [];
+
+        public ValueTask PrepareTurnAsync(string threadId, EffectiveToolSnapshot snapshot, string mode,
+            CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public ValueTask<RemoteToolHostCatalog> ListAsync(string threadId, CancellationToken cancellationToken = default)
         {

--- a/tests/DotCraft.Core.Tests/DotCraft.Core.Tests.csproj
+++ b/tests/DotCraft.Core.Tests/DotCraft.Core.Tests.csproj
@@ -35,4 +35,10 @@
                       LogicalName="DotCraft.Tests.DesktopPluginRevision.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\DotCraft.Runtime.Tests\Plugins\DotNetPluginTestBundle.cs" Link="TestSupport\DotNetPluginTestBundle.cs" />
+    <Compile Include="..\DotCraft.Runtime.Tests\Plugins\PluginRuntimeHarness.cs" Link="TestSupport\PluginRuntimeHarness.cs" />
+    <Compile Include="..\DotCraft.Runtime.Tests\Plugins\PluginLogFile.cs" Link="TestSupport\PluginLogFile.cs" />
+  </ItemGroup>
+
 </Project>

--- a/tests/DotCraft.Core.Tests/Tools/Architecture/RemoteToolHostCoreTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/Architecture/RemoteToolHostCoreTests.cs
@@ -199,7 +199,10 @@ public sealed partial class RemoteToolHostCoreTests
         public int RemoteCalls { get; private set; }
         public IReadOnlyList<ToolDefinition> Definitions { get; private set; } = [];
         public (ToolDefinition Definition, string ContractHash, JsonObject Arguments)? LastInvocation { get; private set; }
-        public void UpdateRemoteToolDefinitions(IReadOnlyList<ToolDefinition> definitions) => Definitions = definitions;
+        public void UpdateRemoteToolSnapshot(string threadId, EffectiveToolSnapshot snapshot, string mode) =>
+                    Definitions = snapshot.Registrations.Values.Where(RemoteToolMetadata.IsRpcEligible).Select(RemoteToolMetadata.NativeDefinition).ToArray();
+        public ValueTask PrepareTurnAsync(string threadId, EffectiveToolSnapshot snapshot, string mode,
+            CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public ValueTask<RemoteToolHostCatalog> ListAsync(string threadId, CancellationToken cancellationToken = default)
         {

--- a/tests/DotCraft.Core.Tests/Tools/Architecture/RemoteToolHostRouteNoticeTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/Architecture/RemoteToolHostRouteNoticeTests.cs
@@ -233,7 +233,9 @@ public sealed class RemoteToolHostRouteNoticeTests : IDisposable
 
         public event Action<RemoteToolRouteChange>? RouteChanged;
 
-        public void UpdateRemoteToolDefinitions(IReadOnlyList<ToolDefinition> definitions) { }
+        public void UpdateRemoteToolSnapshot(string threadId, EffectiveToolSnapshot snapshot, string mode) { }
+        public ValueTask PrepareTurnAsync(string threadId, EffectiveToolSnapshot snapshot, string mode,
+            CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
         public ValueTask<RemoteToolHostCatalog> ListAsync(
             string threadId,

--- a/tests/DotCraft.Core.Tests/Tools/Architecture/RemoteToolSchemaTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/Architecture/RemoteToolSchemaTests.cs
@@ -76,6 +76,7 @@ public sealed partial class RemoteToolHostCoreTests
         client.SetRoute("thread-1");
         var connected = RemoteToolRegistrationRouter.Wrap(wrapped, client);
         var snapshot = builder.Build(connected, 2);
+        client.UpdateRemoteToolSnapshot("thread-1", snapshot, "agent");
         Assert.Same(wrapped[0], connected[0]);
         Assert.Same(definition, Assert.Single(client.Definitions));
         Assert.Equal(fingerprint, PromptRequestFingerprints.ComputeToolFingerprint(AgentFactory.ProjectSnapshotTools(snapshot)));

--- a/tests/DotCraft.Core.Tests/Tools/RemotePluginExecutionTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemotePluginExecutionTests.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotCraft.RemoteTools;
+using DotCraft.Plugins;
+using DotCraft.Runtime;
+using DotCraft.Tests.Runtime.Plugins;
+using DotCraft.Tools;
+using Xunit;
+
+namespace DotCraft.Tests.Tools;
+
+public sealed class RemotePluginExecutionTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Connect_PreparesAcceptedBundleDependenciesAndResources_WithoutPreinstallation(bool deferred)
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness, deferred: deferred);
+        File.WriteAllText(Path.Combine(harness.Workspace, "executor-unavailable"), "");
+        harness.CreatePluginConfigStore().Mutate(PluginManifestParser.Load(harness.PluginRoot("probe")).Manifest!,
+            "personal", [new PluginConfigMutation("set", "label", JsonSerializer.SerializeToElement("agent-setting"))]);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        var storage = Setup(home.Path, workspace.Path);
+        await using var server = new RemoteToolHostTestServer(storage);
+        await using var client = server.CreateClient(new ApproveService());
+        var snapshot = await SnapshotAsync(manager, client, "thread", 1);
+        Assert.False(File.Exists(Path.Combine(workspace.Path, "plugin-lifecycle.log")));
+        var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
+        Assert.Contains("Probe.Run", connected.MatchedTools);
+        var result = await InvokeAsync(snapshot, "thread", "read");
+        Assert.True(result.Success, result.Error?.Message);
+        using var document = JsonDocument.Parse(result.Content!);
+        Assert.Equal("bundle-resource", document.RootElement.GetProperty("resource").GetString());
+        Assert.Equal(workspace.Path, document.RootElement.GetProperty("workspace").GetString());
+        Assert.Equal("agent-setting", document.RootElement.GetProperty("settings").GetProperty("label").GetString());
+        var local = await new ToolDispatcher().DispatchAsync(snapshot, new("Probe", "Run"),
+            new JsonObject { ["operation"] = "read", ["target"] = "local" },
+            new("thread", "turn", "local-call", ToolInvocationAudience.Model));
+        Assert.False(local.Success);
+        var installRoot = Path.Combine(storage.RootPath, "workspaces", "repo", "plugins");
+        Assert.True(File.Exists(Path.Combine(installRoot, "dependency", ".craft-plugin", "plugin.json")));
+        var stamp = File.GetLastWriteTimeUtc(Path.Combine(installRoot, "probe", "resource.txt"));
+        await client.ConnectAsync("thread", server.PeerId, "repo");
+        await client.PrepareTurnAsync("thread", snapshot, "agent");
+        Assert.Equal(stamp, File.GetLastWriteTimeUtc(Path.Combine(installRoot, "probe", "resource.txt")));
+        Assert.Single(PluginLogFile.ReadLines(Path.Combine(workspace.Path, "plugin-lifecycle.log")), line => line.StartsWith("activate:"));
+        await client.DisconnectAsync("thread");
+        Assert.Contains("dispose:first", PluginLogFile.ReadLines(Path.Combine(workspace.Path, "plugin-lifecycle.log")));
+        Assert.True(Directory.Exists(installRoot));
+    }
+
+    [Fact]
+    public async Task ThreadsKeepDistinctSnapshotsAndState_ReleaseDoesNotStopAnotherThread()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        await using var server = new RemoteToolHostTestServer(Setup(home.Path, workspace.Path));
+        await using var client = server.CreateClient(new ApproveService());
+        var first = await SnapshotAsync(manager, client, "first", 1, "agent");
+        var second = await SnapshotAsync(manager, client, "second", 1, "plan");
+        await client.ConnectAsync("first", server.PeerId, "repo");
+        await client.ConnectAsync("second", server.PeerId, "repo");
+        Assert.True((await InvokeAsync(first, "first", "start")).Success);
+        var other = await InvokeAsync(second, "second", "read");
+        Assert.Contains("\"mode\":\"plan\"", other.Content);
+        Assert.Contains("\"running\":false", other.Content);
+        await client.DisconnectAsync("first");
+        Assert.True((await InvokeAsync(second, "second", "start")).Success);
+        var cancelled = await InvokeAsync(second, "second", "cancel");
+        Assert.Contains("\"running\":false", cancelled.Content);
+        var log = PluginLogFile.ReadLines(Path.Combine(workspace.Path, "plugin-lifecycle.log"));
+        Assert.Contains("release:first", log);
+        Assert.DoesNotContain("dispose:first", log);
+    }
+
+    [Fact]
+    public async Task NewGenerationWithSameSchema_InvalidatesOldCalls_AndNextTurnPreparesNewCode()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        await using var server = new RemoteToolHostTestServer(Setup(home.Path, workspace.Path));
+        await using var client = server.CreateClient(new ApproveService());
+        var first = await SnapshotAsync(manager, client, "thread", 1);
+        await client.ConnectAsync("thread", server.PeerId, "repo");
+        await manager.QuiesceForMutationAsync("probe");
+        RemotePluginFixture.Write(harness, "second");
+        harness.TrustInstalled();
+        await manager.ReconcileAfterMutationAsync("probe");
+        Assert.False((await InvokeAsync(first, "thread", "read")).Success);
+        var second = await SnapshotAsync(manager, client, "thread", 2);
+        Assert.Equal(RemoteToolContractHasher.Compute(RemoteToolMetadata.NativeDefinition(first.Registrations.Values.Single())),
+            RemoteToolContractHasher.Compute(RemoteToolMetadata.NativeDefinition(second.Registrations.Values.Single())));
+        await client.PrepareTurnAsync("thread", second, "agent");
+        var result = await InvokeAsync(second, "thread", "read");
+        Assert.True(result.Success, result.Error?.Message);
+        Assert.Contains("\"implementation\":\"second\"", result.Content);
+        Assert.False((await InvokeAsync(first, "thread", "read")).Success);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OwnerApprovalPrecedesRemoteAssemblyLoad(bool approved)
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        var storage = Setup(home.Path, workspace.Path);
+        var owner = new Owner(approved);
+        await using var server = new RemoteToolHostTestServer(storage, ownerApprovals: owner);
+        storage.SaveHostState(storage.LoadHostState()! with
+        {
+            Peers = [storage.LoadHostState()!.Peers.Single() with { AuthorizationMode = RemoteToolAuthorization.WorkspacePreferred }]
+        });
+        await using var client = server.CreateClient(new ApproveService());
+        await SnapshotAsync(manager, client, "thread", 1);
+        if (approved) await client.ConnectAsync("thread", server.PeerId, "repo");
+        else
+        {
+            var failure = await Assert.ThrowsAsync<RemoteToolHostException>(async () => await client.ConnectAsync("thread", server.PeerId, "repo"));
+            Assert.Equal(RemoteToolErrorCodes.ApprovalDeclined, failure.Code);
+            Assert.False(client.TryGetRoute("thread", out _));
+        }
+        Assert.Equal(approved, File.Exists(Path.Combine(workspace.Path, "plugin-lifecycle.log")));
+        Assert.Single(owner.Requests, request => request.Kind == "plugin");
+    }
+
+    [Theory]
+    [InlineData("block")]
+    [InlineData("block-until-stop")]
+    public async Task LeaseRevocationCancelsAndDrainsAnExecutingPlugin(string operation)
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        await using var server = new RemoteToolHostTestServer(Setup(home.Path, workspace.Path));
+        await using var client = server.CreateClient(new ApproveService());
+        var snapshot = await SnapshotAsync(manager, client, "thread", 1);
+        await client.ConnectAsync("thread", server.PeerId, "repo");
+        var running = InvokeAsync(snapshot, "thread", operation).AsTask();
+        var log = Path.Combine(workspace.Path, "plugin-lifecycle.log");
+        await PluginRuntimeHarness.WaitForLineAsync(log, "entered:thread");
+        server.Leases.ReleaseWorkspace("repo");
+        await server.Leases.WaitForDrainAsync("repo").WaitAsync(TimeSpan.FromSeconds(10));
+        var result = await running.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(result.Success);
+        Assert.Contains("cancelled:thread", PluginLogFile.ReadLines(log));
+        Assert.Contains("dispose:first", PluginLogFile.ReadLines(log));
+    }
+
+    private static RemoteToolHostStorage Setup(string home, string workspace)
+    {
+        var storage = new RemoteToolHostStorage(home, new MemoryCredentialStore());
+        RemoteToolHostTestHost.Setup(storage, new Dictionary<string, string> { ["repo"] = workspace });
+        return storage;
+    }
+
+    private static async Task<EffectiveToolSnapshot> SnapshotAsync(DotNetPluginRuntimeManager manager,
+        RemoteToolHostClient client, string threadId, long revision, string mode = "agent")
+    {
+        var planning = new ToolPlanningContext(threadId, null, Path.GetTempPath(), Path.GetTempPath(), mode, null, [], revision);
+        var registrations = await manager.ToolSource.GetRegistrationsAsync(planning);
+        var snapshot = new EffectiveToolSnapshotBuilder().Build(RemoteToolRegistrationRouter.Wrap(registrations, client), revision);
+        client.UpdateRemoteToolSnapshot(threadId, snapshot, mode);
+        return snapshot;
+    }
+
+    private static ValueTask<ToolExecutionResult> InvokeAsync(EffectiveToolSnapshot snapshot, string threadId, string operation) =>
+        new ToolDispatcher().DispatchAsync(snapshot, new("Probe", "Run"), new JsonObject { ["operation"] = operation },
+            new(threadId, "turn", Guid.NewGuid().ToString("N"), ToolInvocationAudience.Model));
+
+    private sealed class Owner(bool accepted) : IRemoteToolApprovalPresenter
+    {
+        internal List<RemoteToolApprovalRequest> Requests { get; } = [];
+        public Task<bool> RequestAsync(RemoteToolApprovalRequest request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(accepted);
+        }
+    }
+}

--- a/tests/DotCraft.Core.Tests/Tools/RemotePluginFixture.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemotePluginFixture.cs
@@ -1,0 +1,137 @@
+using DotCraft.Tests.Runtime.Plugins;
+
+namespace DotCraft.Tests.Tools;
+
+internal static class RemotePluginFixture
+{
+    internal static void Write(PluginRuntimeHarness harness, string implementation = "first", bool deferred = true)
+    {
+        harness.WriteNoop("dependency");
+        var root = harness.PluginRoot("probe");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "settings.schema.json"),
+            """{"fields":[{"key":"label","type":"text","defaultValue":"default"}]}""");
+        DotNetPluginTestBundle.WritePluginBundle(root, "probe", "Probe.Plugin", Source
+            .Replace("IMPLEMENTATION", implementation, StringComparison.Ordinal)
+            .Replace("EXPOSURE", deferred ? "ToolExposure.Deferred" : "ToolExposure.Direct", StringComparison.Ordinal),
+            dependencies: new Dictionary<string, string> { ["dependency"] = "1.0.0" }, settings: "./settings.schema.json");
+        File.WriteAllText(Path.Combine(root, "resource.txt"), "bundle-resource");
+    }
+
+    private const string Source = """
+        using System;
+        using System.IO;
+        using System.Linq;
+        using System.Collections.Concurrent;
+        using System.Collections.Generic;
+        using System.Text.Json;
+        using System.Text.Json.Nodes;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using DotCraft.Contributions;
+        using DotCraft.Plugins;
+        using DotCraft.Tools;
+        namespace Probe;
+        public sealed class Plugin : IDotCraftPlugin
+        {
+            public async ValueTask ActivateAsync(IPluginActivationContext context, CancellationToken cancellationToken)
+            {
+                if (File.Exists(Path.Combine(context.WorkspaceRoot, "block-plugin-activation")))
+                {
+                    var log = Path.Combine(context.WorkspaceRoot, "activation.log");
+                    File.AppendAllText(log, "entered\n");
+                    try { await Task.Delay(Timeout.Infinite, cancellationToken); }
+                    finally { File.AppendAllText(log, "cancelled\n"); }
+                }
+                context.Contributions.Add<IToolSource>(new Source(context), new ContributionOptions { OwnsContribution = true });
+            }
+        }
+        internal sealed class Source : IToolSource, IThreadScopedToolSource, IAsyncDisposable
+        {
+            private readonly IPluginActivationContext _activation;
+            private readonly ConcurrentDictionary<string, Job> _jobs = new();
+            private readonly TaskCompletionSource _workerStopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private string Log => Path.Combine(_activation.WorkspaceRoot, "plugin-lifecycle.log");
+            public Source(IPluginActivationContext context)
+            {
+                _activation = context;
+                File.AppendAllText(Log, "activate:IMPLEMENTATION\n");
+                context.Lifetime.Run(async stopping =>
+                {
+                    try { await Task.Delay(Timeout.Infinite, stopping); }
+                    finally { _workerStopped.TrySetResult(); }
+                });
+            }
+            public string SourceId => "probe";
+            public ValueTask<IReadOnlyList<ToolRegistration>> GetRegistrationsAsync(ToolPlanningContext context,
+                CancellationToken cancellationToken = default)
+            {
+                var id = new ToolDefinitionId(ToolSourceKind.PluginNative, "probe", new SourceToolId("run"));
+                var definition = new ToolDefinition(id, new ToolName("Probe", "Run"), "Run a stateful probe.",
+                    JsonSerializer.SerializeToElement(new
+                    {
+                        type = "object", properties = new { operation = new { type = "string" } },
+                        required = new[] { "operation" }, additionalProperties = false
+                    }), annotations: new Dictionary<string, JsonElement>
+                    { [RemoteToolMetadata.RpcEligibleAnnotation] = JsonSerializer.SerializeToElement(true) });
+                var binding = new ToolRuntimeBinding(new("probe:" + context.Revision), id,
+                    new Runtime(this, context.Mode), ToolBindingLeases.AlwaysAvailable, "probe", context.Revision,
+                    File.Exists(Path.Combine(_activation.WorkspaceRoot, "executor-unavailable"))
+                        ? ToolBindingAvailability.Unavailable : ToolBindingAvailability.Available);
+                return ValueTask.FromResult<IReadOnlyList<ToolRegistration>>([new ToolRegistration(definition, binding,
+                    ToolProjectionShape.StandardPair, EXPOSURE, deferred: new DeferredToolDescriptor("Probe", "probe"))]);
+            }
+            private sealed class Runtime(Source source, string mode) : IToolRuntime
+            {
+                public async ValueTask<ToolExecutionResult> InvokeAsync(ToolInvocationContext context, JsonObject arguments,
+                    CancellationToken cancellationToken = default)
+                {
+                    var operation = arguments["operation"]!.GetValue<string>();
+                    if (operation == "start") source._jobs.GetOrAdd(context.ThreadId, _ => new Job());
+                    if (operation == "cancel" && source._jobs.TryGetValue(context.ThreadId, out var cancel))
+                        await cancel.StopAsync();
+                    if (operation == "block" || operation == "block-until-stop")
+                    {
+                        File.AppendAllText(source.Log, "entered:" + context.ThreadId + "\n");
+                        try { await Task.Delay(Timeout.Infinite, cancellationToken); }
+                        finally
+                        {
+                            if (operation == "block-until-stop") await source._workerStopped.Task;
+                            File.AppendAllText(source.Log, "cancelled:" + context.ThreadId + "\n");
+                        }
+                    }
+                    var data = new
+                    {
+                        implementation = "IMPLEMENTATION", mode, thread = context.ThreadId,
+                        workspace = source._activation.WorkspaceRoot,
+                        settings = source._activation.Settings,
+                        resource = File.ReadAllText(Path.Combine(source._activation.ContentRoot, "resource.txt")),
+                        running = source._jobs.TryGetValue(context.ThreadId, out var job) && !job.Work.IsCompleted
+                    };
+                    return ToolExecutionResult.Succeeded(JsonSerializer.Serialize(data), JsonSerializer.SerializeToElement(data));
+                }
+            }
+            public async ValueTask ReleaseThreadAsync(string threadId, CancellationToken cancellationToken = default)
+            {
+                if (_jobs.TryRemove(threadId, out var job)) await job.StopAsync();
+                File.AppendAllText(Log, "release:" + threadId + "\n");
+            }
+            public async ValueTask DisposeAsync()
+            {
+                foreach (var thread in _jobs.Keys) await ReleaseThreadAsync(thread);
+                File.AppendAllText(Log, "dispose:IMPLEMENTATION\n");
+            }
+            private sealed class Job
+            {
+                private readonly CancellationTokenSource _stop = new();
+                public Task Work { get; }
+                public Job() => Work = Task.Delay(Timeout.Infinite, _stop.Token);
+                public async Task StopAsync()
+                {
+                    await _stop.CancelAsync();
+                    try { await Work; } catch (OperationCanceledException) { }
+                }
+            }
+        }
+        """;
+}

--- a/tests/DotCraft.Core.Tests/Tools/RemotePluginPreparationTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemotePluginPreparationTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using DotCraft.RemoteTools;
+using DotCraft.Security;
+using DotCraft.Tests.Runtime.Plugins;
+using DotCraft.Tools;
+using ModelContextProtocol.Client;
+using Xunit;
+
+namespace DotCraft.Tests.Tools;
+
+public sealed class RemotePluginPreparationTests
+{
+    [Fact]
+    public async Task AcceptedExportPinsImmutableBytes_UntilTransferReleasesThem()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        var registration = Assert.Single(await manager.ToolSource.GetRegistrationsAsync(PluginRuntimeHarness.PlanningContext(1)));
+        var export = await RemoteToolMetadata.SourceBinding(registration)!.ExportAsync();
+        try
+        {
+            File.WriteAllText(Path.Combine(harness.PluginRoot("probe"), "resource.txt"), "changed-installed-file");
+            var stopping = manager.DisposeAsync().AsTask();
+            var root = export.Bundles.Single(file => file.Bundle.PluginId == "probe").RootPath;
+            Assert.Equal("bundle-resource", await File.ReadAllTextAsync(Path.Combine(root, "resource.txt")));
+            Assert.False(stopping.IsCompleted);
+            export.Dispose();
+            await stopping.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.False(Directory.Exists(root));
+        }
+        finally
+        {
+            export.Dispose();
+            await manager.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task NextTurnPreparationFailureRetainsOwnerError_WithoutDisconnectingCoreTools()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        var storage = Setup(home.Path, workspace.Path);
+        await using var server = new RemoteToolHostTestServer(storage, ownerApprovals: new DeclineOwner());
+        var state = storage.LoadHostState()!;
+        storage.SaveHostState(state with
+        {
+            Peers = [state.Peers.Single() with
+        { AuthorizationMode = RemoteToolAuthorization.WorkspacePreferred }]
+        });
+        await using var client = server.CreateClient(new ApproveService());
+        await client.ConnectAsync("thread", server.PeerId, "repo");
+        var registrations = await manager.ToolSource.GetRegistrationsAsync(PluginRuntimeHarness.PlanningContext(2, "thread"));
+        var snapshot = new EffectiveToolSnapshotBuilder().Build(RemoteToolRegistrationRouter.Wrap(registrations, client), 2);
+
+        await client.PrepareTurnAsync("thread", snapshot, "agent");
+
+        var result = await new ToolDispatcher().DispatchAsync(snapshot, new("Probe", "Run"),
+            new JsonObject { ["operation"] = "read" }, new("thread", "turn", "call", ToolInvocationAudience.Model));
+        Assert.Equal(RemoteToolErrorCodes.ApprovalDeclined, result.Error?.Code);
+        Assert.True(client.TryGetRoute("thread", out _));
+        Assert.NotEmpty((await client.ListAsync("thread")).Hosts);
+        Assert.False(File.Exists(Path.Combine(workspace.Path, "plugin-lifecycle.log")));
+    }
+
+    [Fact]
+    public async Task IncompleteUploadCannotActivate_AndReleasesStagingFiles()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        var registration = Assert.Single(await manager.ToolSource.GetRegistrationsAsync(PluginRuntimeHarness.PlanningContext(1)));
+        using var export = await RemoteToolMetadata.SourceBinding(registration)!.ExportAsync();
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        var storage = Setup(home.Path, workspace.Path);
+        await using var server = new RemoteToolHostTestServer(storage);
+        await using var client = server.CreateClient(new ApproveService());
+        var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
+        await using var raw = await server.ConnectRawAsync();
+        var bundles = new List<PluginBundleTransfer>();
+        foreach (var file in export.Bundles)
+            bundles.Add(new(file.Bundle, await TransferFileTree.DescribeAsync(file.RootPath,
+                new FileAccessGuard(file.RootPath), 10_000_000, default)));
+        var definition = registration.Definition;
+        var prepare = await raw.SendRequestAsync<PluginPrepareRequest, ExtensionResponse<PluginPrepareResponse>>(
+            RemotePluginProtocol.Prepare, new(connected.Route.LeaseId, "repo", "thread", 1, "agent", bundles,
+                [new(definition.Id.ToString(), definition.Name.ToString(), RemoteToolContractHasher.Compute(definition))]),
+            RemoteToolHostProtocol.JsonOptions, default, default);
+        Assert.True(prepare.Success, prepare.Error?.Message);
+        var pending = prepare.Result!;
+        var activate = await raw.SendRequestAsync<PluginActivateRequest, ExtensionResponse<PluginActivateResponse>>(
+            RemotePluginProtocol.Activate, new(pending.PreparationId), RemoteToolHostProtocol.JsonOptions, default, default);
+
+        Assert.False(activate.Success);
+        Assert.Contains("incomplete", activate.Error?.Message);
+        Assert.False(File.Exists(Path.Combine(workspace.Path, "plugin-lifecycle.log")));
+        var staging = Path.Combine(storage.RootPath, "workspaces", "repo", "plugin-staging", pending.PreparationId);
+        Assert.False(Directory.Exists(staging));
+    }
+
+    [Fact]
+    public async Task CancellingConnectStopsActivation_WithoutPublishingRouteOrLeakingLease()
+    {
+        using var harness = new PluginRuntimeHarness();
+        RemotePluginFixture.Write(harness);
+        await using var manager = harness.CreateManager();
+        await manager.StartAsync(default);
+        using var home = new TemporaryDirectory();
+        using var workspace = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(workspace.Path, "block-plugin-activation"), "");
+        await using var server = new RemoteToolHostTestServer(Setup(home.Path, workspace.Path));
+        await using var client = server.CreateClient(new ApproveService());
+        var registrations = await manager.ToolSource.GetRegistrationsAsync(PluginRuntimeHarness.PlanningContext(1, "thread"));
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
+        using var cancellation = new CancellationTokenSource();
+        var connecting = client.ConnectAsync("thread", server.PeerId, "repo", cancellation.Token).AsTask();
+        var log = Path.Combine(workspace.Path, "activation.log");
+        await PluginRuntimeHarness.WaitForLineAsync(log, "entered");
+
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => connecting.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Contains("cancelled", PluginLogFile.ReadLines(log));
+        Assert.False(client.TryGetRoute("thread", out _));
+        Assert.False(server.Leases.HasActiveLease);
+        Assert.False(File.Exists(Path.Combine(workspace.Path, "plugin-lifecycle.log")));
+    }
+
+    [Fact]
+    public async Task ExpiredLeaseStopsResourcesBeforeWaitingForCalls_AndBlocksNewOwnerUntilDrained()
+    {
+        var clock = new ManualTimeProvider(DateTimeOffset.UtcNow);
+        using var leases = new WorkspaceLeaseManager(clock);
+        var stopping = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var released = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        leases.DrainResourcesAsync = async (_, calls) =>
+        {
+            stopping.SetResult();
+            await calls;
+            await released.Task;
+        };
+        var lease = leases.Acquire("owner", "workspace", Path.GetTempPath(), "host", 1);
+        using var call = leases.EnterCall(lease.LeaseId, "workspace");
+        clock.Advance(TimeSpan.FromSeconds(61));
+        Assert.Throws<RemoteToolHostException>(() => leases.Validate(lease.LeaseId, "workspace"));
+        await stopping.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(call.Token.IsCancellationRequested);
+        Assert.Throws<RemoteToolHostException>(() => leases.Acquire("next", "workspace", Path.GetTempPath(), "host", 1));
+        call.Dispose();
+        Assert.Throws<RemoteToolHostException>(() => leases.Acquire("next", "workspace", Path.GetTempPath(), "host", 1));
+        released.SetResult();
+        await leases.WaitForDrainAsync("workspace").WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.NotEqual(lease.LeaseId, leases.Acquire("next", "workspace", Path.GetTempPath(), "host", 1).LeaseId);
+    }
+
+    private static RemoteToolHostStorage Setup(string home, string workspace)
+    {
+        var storage = new RemoteToolHostStorage(home, new MemoryCredentialStore());
+        RemoteToolHostTestHost.Setup(storage, new Dictionary<string, string> { ["repo"] = workspace });
+        return storage;
+    }
+
+    private sealed class DeclineOwner : IRemoteToolApprovalPresenter
+    {
+        public Task<bool> RequestAsync(RemoteToolApprovalRequest request, CancellationToken cancellationToken) => Task.FromResult(false);
+    }
+}

--- a/tests/DotCraft.Core.Tests/Tools/RemoteToolHostCatalogTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemoteToolHostCatalogTests.cs
@@ -22,16 +22,16 @@ public sealed class RemoteToolHostCatalogTests
         await using var client = server.CreateClient(new ApproveService());
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
         var read = registrations.Single(item => item.Definition.Name.Name == "ReadFile").Definition;
-        client.UpdateRemoteToolDefinitions(
-        [
-            new ToolDefinition(
+        var drifted = new ToolDefinition(
                 read.Id,
                 read.Name,
                 read.Description + " (drifted)",
                 read.InputSchema,
                 read.OutputSchema,
-                read.Annotations)
-        ]);
+                read.Annotations);
+        var binding = registrations.Single(item => item.Definition.Id == read.Id).Binding;
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(
+            [new ToolRegistration(drifted, binding, ToolProjectionShape.StandardPair)], 1), "agent");
 
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
 
@@ -58,15 +58,16 @@ public sealed class RemoteToolHostCatalogTests
         await using var client = server.CreateClient(new ApproveService());
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
         var read = registrations.Single(item => item.Definition.Name.Name == "ReadFile").Definition;
-        client.UpdateRemoteToolDefinitions(
-        [
-            read,
-            new ToolDefinition(
+        var missing = new ToolDefinition(
                 new ToolDefinitionId(ToolSourceKind.CoreNative, "core-native", new SourceToolId("HostOnlyTool")),
                 new ToolName(null, "HostOnlyTool"),
                 "A tool the Host does not export.",
-                read.InputSchema)
-        ]);
+                read.InputSchema, annotations: read.Annotations);
+        var missingBinding = new ToolRuntimeBinding(new("missing"), missing.Id,
+            registrations[0].Binding.Runtime, ToolBindingLeases.AlwaysAvailable, "test", 1);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(
+            [registrations.Single(item => item.Definition.Id == read.Id),
+                new ToolRegistration(missing, missingBinding, ToolProjectionShape.StandardPair)], 1), "agent");
 
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
 
@@ -172,7 +173,7 @@ public sealed class RemoteToolHostCatalogTests
         var approvals = new ApproveService();
         await using var client = server.CreateClient(approvals);
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
         var route = (await client.ConnectAsync("thread", server.PeerId, "repo")).Route;
         var read = registrations.Single(item => item.Definition.Name.Name == "ReadFile");
 

--- a/tests/DotCraft.Core.Tests/Tools/RemoteToolHostInfrastructureTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemoteToolHostInfrastructureTests.cs
@@ -282,7 +282,7 @@ public sealed class RemoteToolHostInfrastructureTests
         var registrations = await source.GetRegistrationsAsync(new ToolPlanningContext(
             "agent-thread", null, workspace.Path, hostDirectory.Path, "agent", null, [], 1,
             workspaceRoots: [workspace.Path]));
-        client.UpdateRemoteToolDefinitions(registrations.Select(item => item.Definition).ToArray());
+        client.UpdateRemoteToolSnapshot("agent-thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
 
         var connected = await client.ConnectAsync("agent-thread", server.PeerId, "repo");
         Assert.Contains("ReadFile", connected.MatchedTools);

--- a/tests/DotCraft.Core.Tests/Tools/RemoteToolHostServeTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemoteToolHostServeTests.cs
@@ -36,7 +36,7 @@ public sealed class RemoteToolHostServeTests
             shared.Path,
             home.Path,
             enableLsp: true);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread-shared", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
 
         var withLsp = await client.ConnectAsync("thread-shared", server.PeerId, "shared");
         await Assert.ThrowsAsync<RemoteToolHostException>(async () =>
@@ -59,7 +59,7 @@ public sealed class RemoteToolHostServeTests
         await using var server = new RemoteToolHostTestServer(storage);
         await using var client = server.CreateClient(new ApproveService());
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
 
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
 
@@ -89,7 +89,7 @@ public sealed class RemoteToolHostServeTests
         await using var server = new RemoteToolHostTestServer(storage);
         await using var client = server.CreateClient(new ApproveService());
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
         var read = registrations.Single(item => item.Definition.Name.Name == "ReadFile");
 
@@ -157,7 +157,7 @@ public sealed class RemoteToolHostServeTests
         await using var server = new RemoteToolHostTestServer(storage);
         await using var client = server.CreateClient(new ApproveService());
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
         var writeStdin = registrations.Single(item => item.Definition.Name.Name == "WriteStdin");
 
@@ -184,7 +184,7 @@ public sealed class RemoteToolHostServeTests
         await using var server = new RemoteToolHostTestServer(storage);
         await using var client = server.CreateClient(new ApproveService());
         var registrations = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
         var exec = registrations.Single(item => item.Definition.Name.Name == "Exec");
         var writeStdin = registrations.Single(item => item.Definition.Name.Name == "WriteStdin");
@@ -232,7 +232,7 @@ public sealed class RemoteToolHostServeTests
             withLsp.Path,
             home.Path,
             enableLsp: true);
-        client.UpdateRemoteToolDefinitions([.. registrations.Select(item => item.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(registrations, 1), "agent");
 
         var connected = await client.ConnectAsync("thread", server.PeerId, "a-plain");
 

--- a/tests/DotCraft.Core.Tests/Tools/RemoteToolHostTestSupport.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemoteToolHostTestSupport.cs
@@ -116,7 +116,6 @@ internal sealed class RemoteToolHostTestServer : IAsyncDisposable
             onReleased: released =>
             {
                 _terminals.ReleaseLease(released.LeaseId);
-                _handlers!.ReleaseFileTransfers(released.LeaseId);
                 RemoteToolArtifactStore.CleanupLeaseArtifacts(storage.ArtifactsRootPath, released.LeaseId);
             });
         _handlers = new RemoteToolHostMcpHandlers(storage, Leases, _terminals, approvalPresenter: ownerApprovals);

--- a/tests/DotCraft.Core.Tests/Tools/RemoteToolOwnerAuthorizationTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/RemoteToolOwnerAuthorizationTests.cs
@@ -22,7 +22,7 @@ public sealed class RemoteToolOwnerAuthorizationTests
         var inviter = new ApproveService();
         await using var client = server.CreateClient(inviter);
         var tools = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. tools.Select(tool => tool.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(tools, 1), "agent");
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
         var target = Path.Combine(outside.Path, "result.txt");
         var result = await Invoke(client, connected.Route, tools, "WriteFile",
@@ -43,7 +43,7 @@ public sealed class RemoteToolOwnerAuthorizationTests
         await using var server = new RemoteToolHostTestServer(storage);
         await using var client = server.CreateClient(new ApproveService());
         var tools = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. tools.Select(tool => tool.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(tools, 1), "agent");
         var connected = await client.ConnectAsync("thread", server.PeerId, "repo");
         var file = await Invoke(client, connected.Route, tools, "WriteFile",
             new JsonObject { ["path"] = "result.txt", ["content"] = "value" });
@@ -78,7 +78,7 @@ public sealed class RemoteToolOwnerAuthorizationTests
         var server = new RemoteToolHostTestServer(storage, ownerApprovals: owner);
         await using var client = server.CreateClient(new ApproveService());
         var tools = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. tools.Select(tool => tool.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(tools, 1), "agent");
         var route = (await client.ConnectAsync("thread", server.PeerId, "repo")).Route;
         using var cancellation = new CancellationTokenSource();
         var target = Path.Combine(outside.Path, "never.txt");
@@ -103,7 +103,7 @@ public sealed class RemoteToolOwnerAuthorizationTests
         await using var server = new RemoteToolHostTestServer(storage, ownerApprovals: owner);
         await using var client = server.CreateClient(new ApproveService());
         var tools = await RemoteToolHostTestHost.AgentRegistrationsAsync(workspace.Path, home.Path);
-        client.UpdateRemoteToolDefinitions([.. tools.Select(tool => tool.Definition)]);
+        client.UpdateRemoteToolSnapshot("thread", new EffectiveToolSnapshotBuilder().Build(tools, 1), "agent");
         var route = (await client.ConnectAsync("thread", server.PeerId, "repo")).Route;
         var result = await Invoke(client, route, tools, "WriteFile", new JsonObject { ["path"] = "no.txt", ["content"] = "no" });
         Assert.Equal(RemoteToolErrorCodes.RemotePolicyDenied, result.Error?.Code);

--- a/tests/DotCraft.Core.Tests/Tools/ToolFunctionGeneratorTests.cs
+++ b/tests/DotCraft.Core.Tests/Tools/ToolFunctionGeneratorTests.cs
@@ -53,6 +53,7 @@ public sealed class ToolFunctionGeneratorTests
             internal interface IFixtureDeclaration
             {
                 [ToolDeclaration(Name = "schema_test")]
+                [ToolRpc]
                 [Description("Schema-only declaration.")]
                 void Run(
                     [ToolParameter(Name = "mode_name")]
@@ -109,7 +110,7 @@ public sealed class ToolFunctionGeneratorTests
         Assert.Equal("schema_test", declaration.Name);
         Assert.Equal("Schema-only declaration.", declaration.Description);
         Assert.Null(declaration.OutputSchema);
-        Assert.False(declaration.RpcEligible);
+        Assert.True(declaration.RpcEligible);
         var schema = JsonNode.Parse(declaration.InputSchema.GetRawText())!.AsObject();
         Assert.False(schema["additionalProperties"]!.GetValue<bool>());
         Assert.Equal(["mode_name"], schema["required"]!.AsArray().Select(static value => value!.GetValue<string>()));

--- a/tests/DotCraft.Runtime.Tests/Plugins/DotNetPluginToolSourceTests.cs
+++ b/tests/DotCraft.Runtime.Tests/Plugins/DotNetPluginToolSourceTests.cs
@@ -25,7 +25,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var gate = PublishGate("acme.tools", "gen-1");
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         registrar.Add<IToolSource>(new StubToolSource("review", "review", "Reviews a diff."));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
 
         var registrations = await source.GetRegistrationsAsync(PlanningContext());
 
@@ -55,7 +55,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         var plugin = new StubToolSource("review", "review", "Reviews a diff.");
         registrar.Add<IToolSource>(plugin);
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var contributed = Assert.Single(await plugin.GetRegistrationsAsync(PlanningContext()));
 
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
@@ -78,7 +78,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
     public async Task Source_IgnoresContributionsThatDoNotComeFromAPlugin()
     {
         _registry.Add<IToolSource>(new StubToolSource("builtin", "builtin", "Not a plugin Tool."));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
 
         Assert.Empty(await source.GetRegistrationsAsync(PlanningContext()));
     }
@@ -90,7 +90,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         registrar.Add<IToolSource>(new StubToolSource("review", "review", "First."));
         registrar.Add<IToolSource>(new StubToolSource("review", "review_again", "Second."));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
 
         var registrations = await source.GetRegistrationsAsync(PlanningContext());
 
@@ -110,7 +110,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         registrar.Add<IToolSource>(new StubToolSource("bad", "bad", "Bad.") { ThrowsWhilePlanning = true });
         registrar.Add<IToolSource>(new StubToolSource("good", "good", "Good."));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
 
         var registrations = await source.GetRegistrationsAsync(PlanningContext());
 
@@ -133,7 +133,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
             registration,
             enumerationStarted,
             releaseEnumeration));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
 
         var planning = Task.Run(async () => await source.GetRegistrationsAsync(PlanningContext()));
         Assert.True(enumerationStarted.Wait(TimeSpan.FromSeconds(10)));
@@ -152,7 +152,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         PublishGate("acme.tools", "gen-1");
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         var handle = registrar.Add<IToolSource>(new StubToolSource("review", "review", "Reviews a diff."));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
         var context = InvocationContext(registration);
 
@@ -173,7 +173,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var gate = PublishGate("acme.tools", "gen-1");
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         registrar.Add<IToolSource>(new StubToolSource("review", "review", "Reviews a diff."));
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
         var context = InvocationContext(registration);
 
@@ -191,7 +191,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         var plugin = new StubToolSource("review", "review", "Reviews a diff.");
         registrar.Add<IToolSource>(plugin);
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
 
         plugin.LeaseAvailable = false;
@@ -214,7 +214,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
                 JsonDocument.Parse("{\"findings\":2}").RootElement)
         };
         registrar.Add<IToolSource>(plugin);
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
         var arguments = new JsonObject { ["path"] = "a.cs" };
 
@@ -240,7 +240,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
             Result = null
         });
         registrar.Add<IToolSource>(new StubToolSource("thrower", "thrower", "Throws.") { Throws = true });
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var registrations = await source.GetRegistrationsAsync(PlanningContext());
 
         var invalid = registrations.Single(r => r.Definition.Id.SourceToolId.Value == "empty");
@@ -270,7 +270,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
                     }),
                 "could not review")
         });
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
 
         var result = await registration.Binding.Runtime.InvokeAsync(
@@ -289,7 +289,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         var registrar = _registry.CreateRegistrar(ContributionOrigin.Plugin("acme.tools", "gen-1"));
         var plugin = new StubToolSource("review", "review", "Reviews a diff.");
         registrar.Add<IToolSource>(plugin);
-        var source = new DotNetPluginToolSource(_registry, _callGates);
+        var source = new DotNetPluginToolSource(_registry, _callGates, UnexpectedExport);
 
         await source.ReleaseThreadAsync("thread-1");
         var forked = source.TryForkThreadBinding("thread-1", "thread-2");
@@ -352,7 +352,7 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
             """);
         var attempt = await _harness.ActivateAsync("drain");
         var generation = Assert.IsType<PluginGeneration>(attempt.Generation);
-        var source = new DotNetPluginToolSource(_harness.Registry, _harness.CallGates);
+        var source = new DotNetPluginToolSource(_harness.Registry, _harness.CallGates, UnexpectedExport);
         var registration = Assert.Single(await source.GetRegistrationsAsync(PlanningContext()));
         var call = Task.Run(async () => await registration.Binding.Runtime.InvokeAsync(
             InvocationContext(registration),
@@ -374,6 +374,10 @@ public sealed class DotNetPluginToolSourceTests : IDisposable
         Assert.Equal("drained", (await call).Content);
         Assert.Empty(remnant.CleanupErrors);
     }
+
+    private static ValueTask<RemoteToolSourceExport> UnexpectedExport(
+        string pluginId, string generationId, CancellationToken cancellationToken) =>
+        throw new Xunit.Sdk.XunitException("This fixture must not export plugin bundles.");
 
     private PluginCallGate PublishGate(string pluginId, string generationId)
     {

--- a/tests/DotCraft.Session.TestSupport/Sessions/Protocol/AppServer/TestableSessionService.ToolSnapshots.cs
+++ b/tests/DotCraft.Session.TestSupport/Sessions/Protocol/AppServer/TestableSessionService.ToolSnapshots.cs
@@ -1,0 +1,13 @@
+using DotCraft.Sessions;
+using DotCraft.Tools;
+
+namespace DotCraft.Tests.Sessions.Protocol.AppServer;
+
+public partial class TestableSessionService : IThreadToolSnapshotService
+{
+    public Dictionary<string, EffectiveToolSnapshot> ToolSnapshots { get; } = new(StringComparer.Ordinal);
+
+    public Task<EffectiveToolSnapshot> GetEffectiveToolSnapshotAsync(string threadId,
+        CancellationToken cancellationToken = default) => Task.FromResult(
+            ToolSnapshots.GetValueOrDefault(threadId) ?? new EffectiveToolSnapshotBuilder().Build([], 1));
+}

--- a/tests/DotCraft.Session.TestSupport/Sessions/Protocol/AppServer/TestableSessionService.cs
+++ b/tests/DotCraft.Session.TestSupport/Sessions/Protocol/AppServer/TestableSessionService.cs
@@ -30,7 +30,7 @@ namespace DotCraft.Tests.Sessions.Protocol.AppServer;
 /// <c>SubmitInputAsync</c> yields canned <see cref="SessionEvent"/> sequences queued
 /// per thread via <see cref="EnqueueSubmitEvents"/>.
 /// </summary>
-public class TestableSessionService : ISessionService, IThreadAgentRefreshService, ISubAgentSyntheticTurnService, ISubAgentThreadLifecycleService
+public partial class TestableSessionService : ISessionService, IThreadAgentRefreshService, ISubAgentSyntheticTurnService, ISubAgentThreadLifecycleService
 {
     private readonly ThreadStore _store;
     private readonly Dictionary<string, SessionThread> _cache = new();


### PR DESCRIPTION
## Summary

- Extend Remote Tool Host routing to .NET plugin tools marked with `[ToolRpc]`, while keeping MCP and dynamic tools local.
- Automatically synchronize accepted plugin bundles, dependencies, and settings before connection or turn execution, without requiring manual installation on the remote host.
- Bind calls to prepared plugin generations and enforce Host-local authorization, revocation, cancellation, and lease-scoped cleanup without silently falling back to local execution.